### PR TITLE
Fixed deprecation warnings about passing format in the template name

### DIFF
--- a/app/views/test_executions/_node.html.erb
+++ b/app/views/test_executions/_node.html.erb
@@ -64,7 +64,7 @@ case node_type(doc.node_type)
          when :text
           %><div class="text"><%= child.content %></div><%
          when :element
-          %> <%= render :partial=>"test_executions/node.html" , :locals=>{:doc=>child, :error_map=>error_map, :error_attributes=>error_attributes, :execution_errors=>execution_errors}%><%
+          %> <%= render :partial=>"test_executions/node" , :locals=>{:doc=>child, :error_map=>error_map, :error_attributes=>error_attributes, :execution_errors=>execution_errors}%><%
          when :cdata
            %><%=  render :partial=>"cdata", :locals=>{:cdata=>child}%><%
          when :comment

--- a/app/views/test_executions/_show.html.erb
+++ b/app/views/test_executions/_show.html.erb
@@ -88,24 +88,24 @@
         <% if test_execution.passing_measures.count == 0 %>
           <p>There are no passing measures for this test</p>
         <% else %>
-          <%= render partial: "/test_executions/results.html" , locals: {test_execution: test_execution, measures:grouped_passing[:proportional]} %>
-          <%= render partial: "/test_executions/continuous_results.html" , locals: {test_execution: test_execution, measures:grouped_passing[:continuous]} %>
+          <%= render partial: "/test_executions/results" , locals: {test_execution: test_execution, measures:grouped_passing[:proportional]} %>
+          <%= render partial: "/test_executions/continuous_results" , locals: {test_execution: test_execution, measures:grouped_passing[:continuous]} %>
         <% end %>
         <h5><span class='fail'>FAILING</span> MEASURES</h5>
         <% if test_execution.failing_measures.count == 0 %>
           <p>There are no failing measures for this test</p>
         <% else %>
-          <%= render partial: "/test_executions/results.html" , locals: {test_execution: test_execution, measures: grouped_failing[:proportional]} %>
-          <%= render partial: "/test_executions/continuous_results.html" , locals: {test_execution: test_execution, measures:grouped_failing[:continuous]} %>
+          <%= render partial: "/test_executions/results" , locals: {test_execution: test_execution, measures: grouped_failing[:proportional]} %>
+          <%= render partial: "/test_executions/continuous_results" , locals: {test_execution: test_execution, measures:grouped_failing[:continuous]} %>
         <% end %>
       </section>
 
 
   
   <div id="xml_frame">
-    <%= render :partial=>"test_executions/subnav.html"%>  
+    <%= render :partial=>"test_executions/subnav"%>  
     <h3>Vendor Generated XML</h3>
-    <%= render :partial=>"test_executions/node.html" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes, :execution_errors=>execution_errors}%>
+    <%= render :partial=>"test_executions/node" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes, :execution_errors=>execution_errors}%>
   </div>
 </div>
 

--- a/app/views/test_executions/qrda_product_test/_show.html.erb
+++ b/app/views/test_executions/qrda_product_test/_show.html.erb
@@ -93,7 +93,7 @@
   </div><!-- end #test_result_tabs -->
 
     <div id="xml_frame"> 
-    <%= render :partial=>"test_executions/subnav.html"%>  
+    <%= render :partial=>"test_executions/subnav"%>  
 
     <h3>Vendor Generated XML</h3>
    
@@ -103,7 +103,7 @@
     <div>
       <div class="expando file_name "><h4> <%= File.basename(emap[:file]) %> </h4> <div class="open" ></div></div>
       <div>
-     <%= render :partial=>"test_executions/node.html" , :locals=>{:doc=>emap[:doc], :error_map=>emap[:error_map], :error_attributes=>emap[:error_attributes], :execution_errors=>emap[:file_errors]}%>
+     <%= render :partial=>"test_executions/node" , :locals=>{:doc=>emap[:doc], :error_map=>emap[:error_map], :error_attributes=>emap[:error_attributes], :execution_errors=>emap[:file_errors]}%>
       </div>
    </div>
    <% end %>

--- a/app/views/test_executions/static_cv_product_test/_show.html.erb
+++ b/app/views/test_executions/static_cv_product_test/_show.html.erb
@@ -56,21 +56,21 @@
           <p>There are no passing measures for this test</p>
         <% else %>
           
-          <%= render partial: "/test_executions/continuous_results.html" , locals: {test_execution: test_execution, measures:grouped_passing[:continuous]} %>
+          <%= render partial: "/test_executions/continuous_results" , locals: {test_execution: test_execution, measures:grouped_passing[:continuous]} %>
         <% end %>
         <h5><span class='fail'>FAILING</span> MEASURES</h5>
         <% if test_execution.failing_measures.count == 0 %>
           <p>There are no failing measures for this test</p>
         <% else %>
         
-          <%= render partial: "/test_executions/continuous_results.html" , locals: {test_execution: test_execution, measures:grouped_failing[:continuous]} %>
+          <%= render partial: "/test_executions/continuous_results" , locals: {test_execution: test_execution, measures:grouped_failing[:continuous]} %>
         <% end %>
       </section>
 
 
   <div id="xml_frame">
-    <%= render :partial=>"test_executions/subnav.html"%>  
+    <%= render :partial=>"test_executions/subnav"%>  
     <h3>Vendor Generated XML</h3>
-    <%= render :partial=>"test_executions/node.html" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes,:test_execution=>test_execution}%>
+    <%= render :partial=>"test_executions/node" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes,:test_execution=>test_execution}%>
   </div>
 </div>

--- a/lib/cypress/pdf_generator.rb
+++ b/lib/cypress/pdf_generator.rb
@@ -278,7 +278,7 @@ module Cypress
       #new_section_margin
       #@pdf.text "Vendor Generated XML"
 
-      #render :partial=>"test_executions/node.html" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes}
+      #render :partial=>"test_executions/node" , :locals=>{:doc=>doc, :error_map=>error_map, :error_attributes=>error_attributes}
     end
   end
 end


### PR DESCRIPTION
This commit fixes the following deprecation warnings that appear dozens of times in the log as the app is running:

```
DEPRECATION WARNING: Passing the format in the template name is deprecated.
```

When rendering partials, the format will match the parent template's format by default and doesn't need to be specified as part of the file name.
