### PR TITLE
Added fragment caching for patient index and show actions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,8 @@ gem 'cancan', '~> 1.6.7'
 
 gem 'mongoid-grid_fs', '~> 1.7.0' #:git=>'https://github.com/ahoward/mongoid-grid_fs.git'
 
+gem 'cache_digests'
+
 
 group :assets do
   gem 'sass-rails'
@@ -70,5 +72,3 @@ group :production do
   gem 'therubyracer', :platforms => [:ruby]
   gem 'therubyrhino', :platforms => [:jruby]
 end
-
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
     arel (3.0.3)
     bcrypt-ruby (3.1.2)
     builder (3.0.4)
+    cache_digests (0.3.1)
+      actionpack (>= 3.2)
+      thread_safe
     cancan (1.6.10)
     carrierwave (0.9.0)
       activemodel (>= 3.2.0)
@@ -207,6 +210,7 @@ GEM
       eventmachine (>= 1.0.0)
       rack (>= 1.0.0)
     thor (0.18.1)
+    thread_safe (0.3.4)
     tilt (1.4.1)
     tins (0.13.1)
     treetop (1.4.15)
@@ -231,6 +235,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  cache_digests
   cancan (~> 1.6.7)
   carrierwave
   carrierwave-mongoid

--- a/app/views/patients/index.html.erb
+++ b/app/views/patients/index.html.erb
@@ -33,7 +33,7 @@
       <% if @test  %>
         <% if @result && @result['numerator']=='?' %>
           $.cypress.addPoll("<%= patients_path(:measure_id => @selected.id, :product_test_id => @test.id ) %>",
-                            "<%= table_patients_path(:measure_id => @selected.id, :product_test_id => @test.id,:execution=> params[:execution], :showAll => @showAll) %>")             
+                            "<%= table_patients_path(:measure_id => @selected.id, :product_test_id => @test.id,:execution=> params[:execution], :showAll => @showAll) %>")
         <% elsif @showAll%>
           $.cypress.updatePatientTable("<%= table_all_patients_path(:product_test_id => @test.id,:execution=> params[:execution]) %>")
         <% else %>
@@ -51,7 +51,7 @@
 
       var hidden  = true;
       $('#measureEditContainer').slideUp();
-  	  
+
   	  $('.measure_definition').click(function(){
     	  if(hidden){
           $('#measureEditContainer').slideDown(500);
@@ -63,10 +63,10 @@
     		}
   		  hidden = !hidden;
   	  });
-	  
+
     });
   </script>
-  
+
   <script type="text/html" id="ph_tmpl_paramItem">
     <div>
       <!-- ${percentage=Math.round(Math.random()*100,2)} -->
@@ -107,7 +107,7 @@
         zip_qrda_path = download_patients_path(:format => 'qrda', :bundle_id=>@bundle.id)
         zip_html_path = download_patients_path(:format => 'html', :bundle_id=>@bundle.id)
       end %>
-      
+
       <%= link_to 'Download', '', {
         :id => 'download_menu',
         :class => "cmd",
@@ -122,7 +122,7 @@
           <%= link_to "Patients as HTML", zip_html_path, { :class => "ui-corner-all", :tabindex => "-1" } %>
         </li>
       </ul>
-    
+
       <nav class="breadcrumb">
         <%= link_to "Certification Dashboard", root_path %>
         <% if @test %>
@@ -135,7 +135,7 @@
         <% end %>
       </nav>
     </section>
-    
+
     <section class="nqf bordered buffered">
       <h2>
         <% if @test %>
@@ -148,7 +148,8 @@
         <%= select_tag(:bundle_id, options_for_select(Bundle.active.order_by({version: 1}).collect{|b| ["#{b.title} - #{b.version}",b.id]},@bundle.id), :style=>"width: 300px;") %>
       <% end %>
     </section>
-    
+
+    <% cache("index-" + @bundle.version, skip_digest: true ) do %>
     <div class="tabs">
       NQF #
       <% @measures_categories.sort.each do |category, measures| %>
@@ -158,10 +159,10 @@
             <li>
               <a href="<%= patients_path(:product_test_id => @test, :measure_id=>measure_def.id,:execution=> params[:execution], :bundle_id=>@bundle.id) %>"
                 title="<%= "#{measure_def.name}" %><%= " - #{measure_def.subtitle}" if measure_def.sub_id %><%= ": #{measure_def.description}" %>"
-                class="<%= 'selected' if !@showAll and @selected.id==measure_def.id %>"><%= "#{measure_def['cms_id']}" %>  NQF:<%= "#{measure_def.nqf_id}" %> <br><%= truncate("#{measure_def.subtitle}") %> 
+                class="<%= 'selected' if !@showAll and @selected.id==measure_def.id %>"><%= "#{measure_def['cms_id']}" %>  NQF:<%= "#{measure_def.nqf_id}" %> <br><%= truncate("#{measure_def.subtitle}") %>
               </a>
             </li>
-          <% end %>        
+          <% end %>
         </ul>
       <% end %>
     </div>
@@ -221,7 +222,7 @@
                  </thead>
 
 
-                <% if @result %> 
+                <% if @result %>
                 <tr id='<%= "#{@selected.id}" %>'>
                   <td>&nbsp;</td>
                   <td> <span class="den"><%= @result['IPP'] %></span></td>
@@ -236,7 +237,7 @@
                   </tr>
 
                   <% end %>
-                 <% end %> 
+                 <% end %>
                 <% else %>
                   <tr id='all_measures'>
                  </tr>
@@ -246,9 +247,10 @@
             </dd>
           </dl>
         </section>
-     <% end %>
+      <% end %>
       <section id="product_test_patients">
       </section>
     </section>
+    <% end %>
   </div>
-</div><!-- end #container -->     
+</div><!-- end #container -->

--- a/app/views/patients/show.html.erb
+++ b/app/views/patients/show.html.erb
@@ -3,6 +3,7 @@
 <div id="container">
   <%= render :partial=>"shared/header" %>
 
+  <% cache @patient do %>
   <div class="buffered">
     <section class="tb">
       <div class="stacked">
@@ -61,7 +62,7 @@
             <% if result.value['IPP'] %>
               <tr>
 				<td title="<%= "#{(result.value['sub_id'].nil? ? "" : result.value['sub_id']) if @product}" %>">
-          <% measure = Measure.where(:hqmf_id => result.value.measure_id).first %> 
+          <% measure = Measure.where(:hqmf_id => result.value.measure_id).first %>
                  <%= link_to "#{measure['cms_id']} #{measure.nqf_id} #{result.value['sub_id']}" %>
                 </td>
                 <%= population_marker(result.value[QME::QualityReport::POPULATION])%>
@@ -78,7 +79,7 @@
     </section>
     <div id="effectiveDate">effective date: <%= display_time(@effective_date) %></div>
     <section class="patient bordered buffered">
-	
+
       <div class="offset2">
         <span class="patientname" ><strong><%= @patient.last %></strong>, <%= @patient.first %> <% if @patient.original_record %> <strong>Original Record</strong> <%= @patient.original_record.last %></strong>, <%= @patient.original_record.first %> <% end %></span>  <br>
         <dl class="dl-horizontal patient">
@@ -119,4 +120,5 @@
     <footer id="ccattribution">
     </footer>
   </div>
+  <% end %>
 </div><!-- end #container -->


### PR DESCRIPTION
Because the old action caching for the patient show and index actions was incorrectly caching user-specific things (like "Welcome, <user>"), switch to fragment caching for those pages. Note: added the "cache_digests" gem, to enable cache digests. This gem will be unnecessary after Cypress is updated to Rails 4.
