### PR TITLE
Updated match statement in routes.rb that I was missing by always runnin...

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -91,7 +91,7 @@ Cypress::Application.routes.draw do
   match '/product_tests/period', :to=>'product_tests#period', :as => :period, :via=> :post
 
   unless Rails.application.config.consider_all_requests_local
-    match '*not_found', to: 'errors#error_404', :via => :get
+    match '*not_found', to: 'errors#error_404', via: [:get, :post]
   end
 
   # The priority is based upon order of creation:


### PR DESCRIPTION
...g in development

I updated the rest of the match statements in `config/routes.rb` to the Rails 4 format, but missed this one. Never noticed it until today because I've always run in development.
