### PR TITLE
Updated Gemfile to point to QME master

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'jquery-ui-rails'
 gem 'rake'
 
 
-gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'cypress2_5'
+gem 'quality-measure-engine', :git => 'https://github.com/pophealth/quality-measure-engine.git', :branch => 'master'
 
 # gem 'quality-measure-engine', :path => '../quality-measure-engine'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 GIT
   remote: https://github.com/pophealth/quality-measure-engine.git
-  revision: 00a50f14e753580cc75c6e09c8043fbe0012e9da
-  branch: cypress2_5
+  revision: 6dd30a31215b03b6d8c55dd28aac93894616e6fc
+  branch: master
   specs:
-    quality-measure-engine (3.0.2)
+    quality-measure-engine (3.1.0)
       delayed_job_mongoid (~> 2.1.0)
       mongoid (~> 4.0.0)
-      moped (~> 2.0.0.beta6)
+      moped (~> 2.0.0)
       rubyzip (~> 0.9.9)
 
 GIT


### PR DESCRIPTION
All the changes we should need for QME to work properly with Cypress 2.5 are now in QME master branch, so we should point at that instead of cypress2_5.
