### PR TITLE
Updated README.md to use 'what is Cypress' text from projectcypress.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Cypress
 =========
 
-Cypress is an open source software tool that verifies the implementation of the Stage 1 Meaningful Use Clinical Quality Measures.
+Cypress is the rigorous and repeatable testing tool of Electronic Health Records (EHRs) and EHR modules in calculating Meaningful Use (MU) Stage 2 Clinical Quality Measures (CQMs). The Cypress tool is open source and freely available for use or adoption by the health IT community including EHR vendors and testing labs. Cypress serves as the official testing tool for the 2014 EHR Certification program supported by the Office of the National Coordinator for Health IT (ONC).
 
 Quality Measures
 ----------------


### PR DESCRIPTION
Previously, we were using text that referenced MU1, so we took the text from projectcypress.org to use as the Cypress intro.
