### PR TITLE
One more Gemfile/Rakefile change to support the Knife script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,7 +79,7 @@ end
 group :test do
   gem 'rails-perftest'
   gem 'ruby-prof'
-  gem 'simplecov', :require => false
+  gem 'simplecov'
 end
 
 group :production do

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,6 @@ require 'rails'
 
 require File.expand_path('../config/application', __FILE__)
 require 'rake'
-require 'simplecov'
 require "quality-measure-engine"
 
 Cypress::Application.load_tasks


### PR DESCRIPTION
Moved the "require" back into the Gemfile, and out of the Rakefile. Doesn't break the test suite, and lets other non-test rake tasks run without requiring Simplecov.
