### PR TITLE
Hide empty results tables on test execution page

### DIFF
--- a/app/views/test_executions/_continuous_results.html.erb
+++ b/app/views/test_executions/_continuous_results.html.erb
@@ -1,3 +1,4 @@
+<% unless measures.empty? %>
  <table class="table">
          <thead>
            <tr>
@@ -28,3 +29,4 @@
            <% end %>
          </tbody>
      </table>
+<% end %>

--- a/app/views/test_executions/_results.html.erb
+++ b/app/views/test_executions/_results.html.erb
@@ -1,4 +1,4 @@
- 
+ <% unless measures.empty? %>
  <table class="table">
          <thead>
            <tr>
@@ -40,3 +40,4 @@
            <% end %>
          </tbody>
      </table>
+<% end %>


### PR DESCRIPTION
If we're not testing proportion or CV measures, don't show the (empty) results table
