### PR TITLE
Removed unnecessary binding.pry requires from rakefiles for pophealth_ro...

### DIFF
--- a/lib/tasks/measure_evaluation_validator.rake
+++ b/lib/tasks/measure_evaluation_validator.rake
@@ -1,6 +1,4 @@
 namespace :measure_evaluation_validator do
-  require 'pry'
-  require 'pry-nav'
 
   task :setup => :environment
 

--- a/lib/tasks/pophealth_roundtrip.rake
+++ b/lib/tasks/pophealth_roundtrip.rake
@@ -1,6 +1,4 @@
 namespace :pophealth_roundtrip do
-  require 'pry'
-  require 'pry-nav'
 
   task :setup => :environment
 


### PR DESCRIPTION
...undtrip and measure_evaluation_validator

These break things in the Knife script, and are a good idea to remove for code cleanup.
