### PR TITLE
Product show page UI changes to group cat3 and cat1 tests, and organize all tests better

### DIFF
--- a/app/assets/stylesheets/cypress/_tables.scss
+++ b/app/assets/stylesheets/cypress/_tables.scss
@@ -37,7 +37,7 @@ table-layout:fixed;
 width:20px;
 }
 .tog{
-width:10px;
+width:20px;
 }
 .name {
 width:200px;
@@ -45,9 +45,23 @@ width:200px;
 .info {
 width:300px;
 }
+.type {
+  width:105px;
+}
+.time {
+  width:94px;
+}
+
+.percentage {
+  width: 30px;
+  font-weight: bold;
+}
 
 tr.sub_rows {
   display:none;
+  td:not(.nobg) {
+    background: whitesmoke;
+  }
 }
 
 #patient_characteristics th{

--- a/app/assets/stylesheets/cypress/_tables.scss
+++ b/app/assets/stylesheets/cypress/_tables.scss
@@ -41,6 +41,7 @@ width:20px;
 }
 .name {
 width:200px;
+white-space: nowrap;
 }
 .info {
 width:300px;

--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -94,7 +94,7 @@ class CalculatedProductTest < ProductTest
       mrns = results.collect{|r| r["value"]["medical_record_id"]}
       results.uniq!
        qrda = QRDAProductTest.new(measure_ids: [mes.measure_id],
-                               name: "#{self.name} - Measure #{mes.nqf_id} QRDA Cat I Test",
+                               name: "Measure #{mes.cms_id}",
                                bundle_id: self.bundle_id,
                                effective_date: self.effective_date,
                                product_id: self.product_id,

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -12,6 +12,30 @@ class Product
 
   validates_presence_of :name
 
+  def tests_by_cat3
+    cat3_tests = {}
+    cat1_tests = []
+    self.product_tests.each do |p|
+      if p.is_a? CalculatedProductTest 
+        cat3_tests[p.id] = p
+      else
+        cat1_tests << p
+      end
+    end
+
+    if !cat1_tests.empty?
+      sorted_tests = cat1_tests.group_by do |p|
+        cat3_tests[p.calculated_test_id]
+      end
+      cat3_tests.each do |id, t|
+        sorted_tests[t] = [] if sorted_tests[t].nil?
+      end
+      return sorted_tests
+    else
+      return cat3_tests.values.each_with_object([]).to_h
+    end
+  end
+
  # a product is only passing if all of it's tests have passed
   def passing?
     return true if self.product_tests.empty?

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,8 +16,8 @@ class Product
     cat3_tests = {}
     cat1_tests = []
     self.product_tests.each do |p|
-      if p.is_a? CalculatedProductTest 
-        cat3_tests[p.id] = p
+      if p.is_a? CalculatedProductTest
+        cat3_tests[p.id.to_s] = p
       else
         cat1_tests << p
       end
@@ -25,7 +25,7 @@ class Product
 
     if !cat1_tests.empty?
       sorted_tests = cat1_tests.group_by do |p|
-        cat3_tests[p.calculated_test_id]
+        cat3_tests[p.calculated_test_id.to_s]
       end
       cat3_tests.each do |id, t|
         sorted_tests[t] = [] if sorted_tests[t].nil?

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -1,5 +1,6 @@
 class ProductTest
   include Mongoid::Document
+  include Mongoid::Timestamps::Created
   include AASM
 
   belongs_to :product

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -44,67 +44,122 @@
           <tbody>
             <tr><td colspan="3" style="padding-top:15px">There are no tests for this product. <%= link_to "Add Test", new_product_test_path(:product_id => @product), { :class => "cmd" } %></td></tr>
           </tbody>
-          <% end %>
+        <% end %>
         <!-- END NO TESTS -->
-        <% product_tests_by_status(@product).each do |result_status, result_tests| %>
-          <thead>
-            <tr>
-              <th colspan="3"><span class="<%= result_status %>"><%= format_status(result_status) %></span> Tests</th>
-              <th>Type</th>
-              <th>Description</th>
-              <th>Executions</th>
-              <th></th>
-              <th></th>
-            </tr>
-          </thead>
-          <% result_tests.each do |test|
-            if test.passing?
-              success_rate = 100
+        <thead>
+          <tr>
+            <th colspan="2">Pass</th>
+            <th class="name">Tests</th>
+            <th>Type</th>
+            <th>Description</th>
+            <th>Date</th>
+            <th>Executions</th>
+            <th></th>
+            <th></th>
+          </tr>
+        </thead>
+        <% @product.tests_by_cat3.each do |cat3_test, cat1_tests| %>
+          <tbody>
+            
+            <% if !cat1_tests.empty?
+              first_td_class = 'expander toggle'
+
+            if cat3_test['_type'] == 'CalculatedProductTest'
+              type = 'EP'
+            elsif cat3_test['_type'] == 'InpatientProductTest'
+                type = 'EH'
             else
-              success_rate = 0
-            end %>
-            <tbody>
-              <% if !test.test_executions.empty?
-                first_td_class = 'expander toggle'
-                dot_color = result_status
-              else
-                dot_color = 'incomplete'
-              end
-              if test['_type'] == 'CalculatedProductTest'
-                type = 'EP'
-              elsif test['_type'] == 'InpatientProductTest'
-                  type = 'EH'
-              else
                 type = 'QRDA Cat I'
-              end
+            end 
+
+            pass_count = cat3_test.passing? ? 1 : 0
+            cat1_tests.each do |t|
+              pass_count += t.passing? ? 1 : 0
+            end
+            pass_percentage = (pass_count / (cat1_tests.size + 1.0) * 100).to_i
             %>
               <tr>
-                <td class="<%=dot_color%>-icon dot"></td>
-                <td class="<%= first_td_class %> tog" data-code="<%= test.id %>"></td>
-                <td class="name"><a class="<%= result_status %>" href="<%= product_test_path(test) %>"><%= test.name %></a></td>
+                <td class="percentage"><%= pass_percentage %>%</td>
+                <td class="<%= first_td_class %> tog" data-code="<%= cat3_test.id %>"></td>
+                <td class="name"><%= cat3_test.name %></td>
                 <td class="type"><%= type %></td>
-                <td class="info"><%= test.description %></td>
-                <td><%= test.test_executions.size %></td>
+                <td class="info"><%= cat3_test.description %></td>
+                <td class="time"></td>
                 <td></td>
-                <td class="align-right"><%= link_to 'Delete', product_test_path(test), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
+                <td></td>
+                <td class="align-right"><%= link_to 'Delete', product_test_path(cat3_test), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
               </tr>
+              <%
+              if !cat3_test.test_executions.empty?
+                dot_color = cat3_test.passing? ? "pass" : "fail"
+              else
+                dot_color = 'incomplete'
+              end %>
 
-              <% if !test.test_executions.empty?
-                test.test_executions.ordered_by_date.each do |execution|
-                 %>
 
-                  <tr class="sub_rows <%= test.id %>">
-                    <td colspan="2" class="<%=execution.state%>-icon dot"></td>
+                <tr class="sub_rows <%=cat3_test.id%>">
+                  <td class="nobg"></td>
+                  <td class="<%=dot_color%>-icon dot nobg"></td>
+                  <td class="name"><a href="<%= product_test_path(cat3_test) %>"><%= cat3_test.name %></a></td>
+                  <td class="type">QRDA Cat III</td>
+                  <td class="info"><%= cat3_test.description %></td>
+                  <td class="time"><%= cat3_test.created_at ? cat3_test.created_at.strftime("%b %e, %l:%M %p") : "" %></td>
+                  <td><%= cat3_test.test_executions.size %></td>
+                  <td></td>
+                  <td class="align-right"><%= link_to 'Delete', product_test_path(cat3_test), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
+                </tr>
 
-                    <td colspan="2" class="<%= execution.state %>"><%= link_to execution.execution_date,product_test_path(test, {:test_execution_id=> execution.id}) %> </td>
-                    <td colspan="3"></td>
-                    <td class="align-right"><%= link_to 'Delete', test_execution_path(execution, {:product_id => execution.product_test.product}), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
-                  </tr>
-                <% end %>
+              <% else #if no cat1 tests 
+
+                  if !cat3_test.test_executions.empty?
+                    dot_color = cat3_test.passing? ? "pass" : "fail"
+                  else
+                    dot_color = 'incomplete'
+                  end
+
+                  if cat3_test['_type'] == 'CalculatedProductTest'
+                    type = 'EP'
+                  elsif cat3_test['_type'] == 'InpatientProductTest'
+                    type = 'EH'
+                  end 
+                  %> 
+                <tr>
+                  <td class="<%=dot_color%>-icon dot"></td>
+                  <td class="<%= first_td_class %> tog" data-code="<%= cat3_test.id %>"></td>
+                  <td class="name"><a href="<%= product_test_path(cat3_test) %>"><%= cat3_test.name %></a></td>
+                  <td class="type"><%= type %></td>
+                  <td class="info"><%= cat3_test.description %></td>
+                  <td class="time"><%= cat3_test.created_at ? cat3_test.created_at.strftime("%b %e, %l:%M %p") : "" %></td>
+                  <td><%= cat3_test.test_executions.size %></td>
+                  <td></td>
+                  <td class="align-right"><%= link_to 'Delete', product_test_path(cat3_test), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
+                </tr>
               <% end %>
-            </tbody>
-          <% end %>
-        <% end %>
+
+              <% 
+              cat1_tests.sort_by! {|t| t.name}
+              cat1_tests.each do |cat1_test|
+
+              if !cat1_test.test_executions.empty?
+                dot_color = cat1_test.passing? ? "pass" : "fail"
+              else
+                dot_color = 'incomplete'
+              end %>
+
+                <tr class="sub_rows <%=cat3_test.id%>">
+                  <td class="nobg"></td>
+                  <td class="<%=dot_color%>-icon dot nobg"></td>
+                  <td class="name"><a href="<%= product_test_path(cat1_test) %>"><%= cat1_test.name %></a></td>
+                  <td class="type">QRDA Cat I</td>
+                  <td class="info"><%= cat1_test.description %></td>
+                  <td class="time"><%= cat1_test.created_at ? cat3_test.created_at.strftime("%b %e, %l:%M %p") : "" %></td>
+                  <td><%= cat1_test.test_executions.size %></td>
+                  <td></td>
+                  <td class="align-right"><%= link_to 'Delete', product_test_path(cat1_test), data: { :method => :delete, :confirm => 'Are you sure?' }, :class => 'cmd del' %></td>
+                </tr>
+              <% end %>
+            <% end %>
+          </tbody>
       </table>
     </section>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -35,4 +35,6 @@ Cypress::Application.configure do
 
   config.action_mailer.default_url_options = { :host => 'localhost:3000' }
 
+  config.time_zone = "Eastern Time (US & Canada)"
+
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -65,4 +65,6 @@ Cypress::Application.configure do
   ActionMailer::Base.delivery_method = :smtp
 
   config.eager_load = true
+
+  config.time_zone = "Eastern Time (US & Canada)"
 end

--- a/test/fixtures/product_tests/product_test8.json
+++ b/test/fixtures/product_tests/product_test8.json
@@ -1,0 +1,11 @@
+{
+	"_type" : "CalculatedProductTest",
+	"bundle_id" :"4fdb62e01d41c820f6000001",
+	"state"  : "ready",
+	"_id" : "4f58f8de1d41c851eb000fff",
+	"description" : "its a test",
+	"name" : "vendor1 qrda_product test8",
+	"product_id" : "515eeac93054cf180e0000f0",
+	"notes" : []
+}
+

--- a/test/fixtures/product_tests/qrda_nested_product_test.json
+++ b/test/fixtures/product_tests/qrda_nested_product_test.json
@@ -1,0 +1,11 @@
+{
+  "_id" : "509144aa709357a90600002f",
+ 	"bundle_id" :"4fdb62e01d41c820f6000001",
+  "_type" : "QRDAProductTest",
+  "state" : "ready",
+  "product_id" : "515eeac93054cf180e0000f0",
+  "name" : "QRDA Nested Test",
+  "effective_date" : 1293858000,
+  "description" : "",
+  "calculated_test_id" : "4f58f8de1d41c851eb000fff"
+}

--- a/test/fixtures/products/qrda_product.json
+++ b/test/fixtures/products/qrda_product.json
@@ -1,0 +1,7 @@
+{
+
+  "_id" : "515eeac93054cf180e0000f0",
+  "name" : "QRDA Product",
+  "description" : "QRDA product"
+
+}

--- a/test/unit/product_test.rb
+++ b/test/unit/product_test.rb
@@ -14,6 +14,7 @@ class ProducTest < ActiveSupport::TestCase
     
     @product1 = Product.find("4f57a88a1d41c851eb000004")
     @product2 = Product.find("4f636ae01d41c851eb00048e")
+    @qrda_product = Product.find("515eeac93054cf180e0000f0")
   end
 
   test "Should know if its passing" do
@@ -51,5 +52,12 @@ class ProducTest < ActiveSupport::TestCase
     assert_equal 1, @product2.success_rate 
   end
 
- 
+  test "Should group by cat 3" do
+    @qrda_product.tests_by_cat3.each_pair do |cat3, cat1s|
+      cat1s.each do |cat1|
+        assert_equal cat1.calculated_test_id.to_s, cat3.id.to_s, "Calculated test ID for cat1 test #{cat1.id} (#{cat1.calculated_test_id}) did not match cat3 test #{cat3.id}"
+      end
+    end
+  end
+  
 end


### PR DESCRIPTION
More well-formed tables (moved tbody to the outside of the results loop)

Merged changes from master into test list UI changes

Added tests_by_cat3 to product.rb, timestamps to some models, and a default timezone to development.rb

Added default time zone to production.rb

Added fallback for if the test does not have a created_at attribute

Removed reference to StaticCVProductTest