### PR TITLE
Updated Simplecov to 0.9.1, as there is a bug in 0.8.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,9 +193,9 @@ GEM
     simple_form (3.0.2)
       actionpack (~> 4.0)
       activemodel (~> 4.0)
-    simplecov (0.8.2)
+    simplecov (0.9.1)
       docile (~> 1.1.0)
-      multi_json
+      multi_json (~> 1.0)
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
     slop (3.5.0)


### PR DESCRIPTION
According to the Simplecov Github repo: 

> Important Notice: There is a bug that affects exit code handling on the 0.8 line of SimpleCov, see #281.  Please use versions ~> 0.7.1 or ~> 0.9.0 to avoid this.

https://github.com/colszowka/simplecov

So Simplecov is updated to 0.9.1.
