### PR TITLE
Fixed typo in measure_evaluation_validator, and rearranged rake task so username isn't required

### DIFF
--- a/lib/cypress/measure_evaluation_validator.rb
+++ b/lib/cypress/measure_evaluation_validator.rb
@@ -183,7 +183,7 @@ module Cypress
       product.users << user
       product.save
       product_test_class = test_type.camelize.constantize
-      product_test = product_test_clas.find_or_create_by({name: "measureEvaluationTest",
+      product_test = product_test_class.find_or_create_by({name: "measureEvaluationTest",
                                                           bundle: bundle.id,
                                                           effective_date: bundle.effective_date,
                                                           product: product,

--- a/lib/tasks/measure_evaluation_validator.rake
+++ b/lib/tasks/measure_evaluation_validator.rake
@@ -39,7 +39,7 @@ namespace :measure_evaluation_validator do
     mev.evaluate_all_cat1
   end
 
-  task :evaluate_all, [:cypress_user,:num_tests,:num_measures] => :setup do |t, args|
+  task :evaluate_all, [:num_tests,:num_measures,:cypress_user] => :setup do |t, args|
     mev = Cypress::MeasureEvaluationValidator.new(args.to_hash)
     mev.evaluate_all_singly
     mev.evaluate_multi_measures


### PR DESCRIPTION
The Rake task rearrangement allows it to not rely on a specified Cypress user, and just use the first user in the DB.
