### PR TITLE
Add medical record assigner to duplicated records, if such an assigner i...

### DIFF
--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -43,6 +43,11 @@ class CalculatedProductTest < ProductTest
     # p_ids = Record.where(:test_id=>nil, :type=>"ep").collect{|p| p.medical_record_number}
     pcj = Cypress::PopulationCloneJob.new({'patient_ids' =>p_ids, 'test_id' => self.id, "randomize_names"=> true, "randomization_ids" => randomization_ids})
     pcj.perform
+
+    self.records.each do |r|
+      r.medical_record_assigner = "Cypress" if r.medical_record_assigner.nil?
+      r.save!
+    end
     #now calculate the expected results
     self.calculate
   end


### PR DESCRIPTION
...s not already set.

This causes HealthDataStandards to export patients with the correct medical record IDs, which it wouldn't before, even if the medical record ID was set. Prior to this change, HDS assigned all patients without a medical record assigner and medical record ID the ID of `12345`, which causes problems on patient import.
