### PR TITLE
Updated format of error string in check_population

### DIFF
--- a/app/models/calculated_product_test.rb
+++ b/app/models/calculated_product_test.rb
@@ -187,7 +187,7 @@ class CalculatedProductTest < ProductTest
       message += " for Population #{pop_key}"
       logger.call(message, stratification)
     elsif (expected_result[pop_key] != reported_result[pop_key]) && !reported_result.empty?
-      err = "expected #{pop_key} #{_ids[pop_key]} value #{expected_result[pop_key]} does not match reported value #{reported_result[pop_key]}"
+      err = "expected #{pop_key} #{expected_result["population_ids"][pop_key]} value #{expected_result[pop_key]} does not match reported value #{reported_result[pop_key]}"
       logger.call(err, stratification)
     end
   end


### PR DESCRIPTION
The old format called an object _ids on ProductTest::Class, which didn't appear to exist, and so broke the method. This new format appears to work better.
