### PR TITLE
Updated the measure evaluation validator code 

### DIFF
--- a/lib/cypress/measure_evaluation_validator.rb
+++ b/lib/cypress/measure_evaluation_validator.rb
@@ -232,7 +232,6 @@ module Cypress
           end
         end
 
-
       puts "done"
     end
 
@@ -241,7 +240,7 @@ module Cypress
       # Generate a temporary file that acts just like a normal file, but is given a unique name in the './tmp' directory
       tmp = Tempfile.new(['qrda_upload', '.xml'], './tmp')
       tmp.write(xml)
-      product_test.execute({results: tmp})
+      product_test.execute(tmp)
     end
 
   end


### PR DESCRIPTION
`MeasureEvaluationValidator#upload_cat3` now uses the new method signature for CalculatedProductTest#Execute, passing in the file directly, rather than a params hash with the file in it.
