### PR TITLE
Fixed a collection_fixtures call for PatientZipperTest

### DIFF
--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -7,6 +7,8 @@ class PatientZipperTest < ActiveSupport::TestCase
 
     collection_fixtures('records','_id','bundle_id')
     collection_fixtures('bundles', '_id')
+    collection_fixtures('vendors', '_id')
+    collection_fixtures('products', '_id')
     collection_fixtures('product_tests', '_id')
     collection_fixtures('test_executions', '_id')
     @patients = Record.where("gender" => "F")


### PR DESCRIPTION
Changed the model name in `collection_fixtures` from `tests` to the correct name, `product_tests`.

This PR should fix the failing test in #107. Once it's pulled in to master, I'll rebase that PR.
