### PR TITLE
Excluded measure evaluation code from code coverage

### DIFF
--- a/lib/cypress/measure_evaluation_validator.rb
+++ b/lib/cypress/measure_evaluation_validator.rb
@@ -1,3 +1,4 @@
+# :nocov:
 module Cypress
   class MeasureEvaluationValidator
 
@@ -263,3 +264,4 @@ module Cypress
 
   end
 end
+# :nocov:

--- a/lib/tasks/quality.rake
+++ b/lib/tasks/quality.rake
@@ -19,7 +19,7 @@ begin
     cane.no_doc = true
     cane.no_readme = true
     cane.no_style = true
-    cane.add_threshold 'coverage/covered_percent', :>=, 77.00
+    cane.add_threshold 'coverage/covered_percent', :>=, 81.00
   end
 
 rescue LoadError

--- a/script/cat_3_calculator.rb
+++ b/script/cat_3_calculator.rb
@@ -1,3 +1,4 @@
+# :nocov:
 require 'mongoid'
 require 'health-data-standards'
 require 'quality-measure-engine'
@@ -129,3 +130,4 @@ captured_output = capture_output do
 end
 
 print generate_cat3(measure_ids, bundle.effective_date)
+# :nocov:


### PR DESCRIPTION
Added `# :nocov:` statements to measure evaluation code, such that it will not be counted against us in code coverage, as it is testing code, not application code. As a result, also bumped the code coverage percentage upwards.
