### PR TITLE
Removed pry statement from cat_3_calculator that was breaking roundtrip

### DIFF
--- a/script/cat_3_calculator.rb
+++ b/script/cat_3_calculator.rb
@@ -1,7 +1,6 @@
 require 'mongoid'
 require 'health-data-standards'
 require 'quality-measure-engine'
-require 'pry'
 require 'optparse'
 
 def generate_oid_dictionary(measure, bundle)


### PR DESCRIPTION
Pry doesn't get installed on production systems with the Chef/Puppet script, so including it in `cat3_calculator.rb` was breaking Cypress-stage's roundtrip testing.
