### PR TITLE
fix error messages for cat1 schematron errors

### DIFF
--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -11,7 +11,7 @@ class ExecutionError
   field :validator, type: String
   field :stratification, type: String
   field :location
-  field :file_name
+  field :file_name, type: String
   validates_presence_of :msg_type
   validates_presence_of :message
 

--- a/app/views/test_executions/qrda_product_test/_show.html.erb
+++ b/app/views/test_executions/qrda_product_test/_show.html.erb
@@ -70,7 +70,6 @@
        <% end %>
      </ol>
     </div>
-
      <div class="tab-pane" id="xml_validation_cheat_sheet">
        <table>
         <thead>

--- a/lib/validators/qrda_cat1_validator.rb
+++ b/lib/validators/qrda_cat1_validator.rb
@@ -18,16 +18,16 @@ module Validators
     # Validates a QRDA Cat I file.  This routine will validate the file against the CDA schema as well as the
     # Generic QRDA Cat I schematron rules and the measure specific rules for each of the measures passed in.
     # THe result will be an Array of execution errors or an empty array if there were no errors.
-    def validate(file, name)
+    def validate(file, options={})
       doc = get_document(file)
       # validate that each file in the zip contains a valid QRDA Cat I document.
       # We may in the future have to support looking in the contents of the test
       # patient records to match agaist QRDA Cat I documents
-      # First validate the schema correctness
-      add_errors QRDA_SCHEMA_VALIDATOR.validate(doc, {msg_type: :error})
-      add_errors SCHEMATRON_ERROR_VALIDATOR.validate(doc, {phase: :errors, msg_type: :error, file_name: name})
-
       @measures.each do |measure|
+      # First validate the schema correctness
+        add_errors QRDA_SCHEMA_VALIDATOR.validate(doc, options)
+        add_errors SCHEMATRON_ERROR_VALIDATOR.validate(doc, {file_name: options[:file_name]})
+
         # Look in the document to see if there is an entry stating that it is reporting on the given measure
         # we will be a bit lenient and look for both the version specific id and the non version specific ids
         measure_xpath = %Q(//cda:organizer[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.98']]/cda:reference[@typeCode='REFR']/

--- a/lib/validators/qrda_cat3_validator.rb
+++ b/lib/validators/qrda_cat3_validator.rb
@@ -16,9 +16,9 @@ module Validators
     # Nothing to see here - Move along
     def validate()
       file_errors = []
-      file_errors.concat QRDA_SCHEMA_VALIDATOR.validate(@document, {msg_type: :error})
+      file_errors.concat QRDA_SCHEMA_VALIDATOR.validate(@document)
       # Valdiate aginst the generic schematron rules
-      file_errors.concat SCHEMATRON_ERROR_VALIDATOR.validate(@document, {phase: :errors, msg_type: :error})
+      file_errors.concat SCHEMATRON_ERROR_VALIDATOR.validate(@document)
       file_errors
     end
 

--- a/lib/validators/schematron_validator.rb
+++ b/lib/validators/schematron_validator.rb
@@ -26,6 +26,7 @@ module Validators
                :validator_type => :xml_validation,
                :msg_type=>(data[:msg_type] || :error),
                :file_name => data[:file_name],
+               :phase => (data[:phase] || :error),
                :measure_id => data[:measure_id]
              )
 

--- a/lib/validators/validator.rb
+++ b/lib/validators/validator.rb
@@ -2,26 +2,26 @@ module Validators
   module Validator
 
       def errors
-  @errors ||= []
+        @errors ||= []
       end
 
       def add_error(msg, options={})
-  add_issue(msg, :error, options)
+        add_issue(msg, :error, options)
       end
 
       def add_warning(msg, options={})
-  add_issue(msg, :warning, options)
+        add_issue(msg, :warning, options)
       end
 
       def add_issue(msg, msg_type, options={})
-  attributes = {message: msg, msg_type: msg_type,
-          validator_type: self.class.validator_type}.merge(options)
-  @errors ||= []
-  @errors << ExecutionError.new(attributes)
+        attributes = {message: msg, msg_type: msg_type,
+                      validator_type: self.class.validator_type}.merge(options)
+        @errors ||= []
+        @errors << ExecutionError.new(attributes)
       end
 
       def add_errors(errors)
-  self.errors.concat errors
+        self.errors.concat errors
       end
 
     def self.included(receiver)

--- a/test/unit/lib/qrda_file_test.rb
+++ b/test/unit/lib/qrda_file_test.rb
@@ -112,7 +112,7 @@ class QRDATest < ActiveSupport::TestCase
      xml_file = File.new(File.join(Rails.root, 'test/fixtures/qrda/cat_1/good.xml'))
      doc = Nokogiri::XML(xml_file)
      qrda_file = Validators::QrdaCat1Validator.new([@m0004])
-     qrda_file.validate(doc, "filename.xml")
+     qrda_file.validate(doc, {file_name: "filename.xml"})
      assert qrda_file.errors.empty? , "Should be 0 errors for good cat 1 file"
   end
 
@@ -121,7 +121,8 @@ class QRDATest < ActiveSupport::TestCase
      doc = Nokogiri::XML(xml_file)
      qrda_file = Validators::QrdaCat1Validator.new([@m0004])
 
-     qrda_file.validate(doc, "filename.xml")
+     qrda_file.validate(doc, {file_name: "filename.xml"})
+
      assert_equal 2, qrda_file.errors.length, "Should report 2 errors, one for the schema issue and one for the schematron issue related to the schema issue"
   end
 
@@ -129,7 +130,8 @@ class QRDATest < ActiveSupport::TestCase
      xml_file = File.new(File.join(Rails.root, 'test/fixtures/qrda/cat_1/bad_schematron.xml'))
      doc = Nokogiri::XML(xml_file)
      qrda_file = Validators::QrdaCat1Validator.new([@m0004])
-     qrda_file.validate(doc, "filename.xml")
+     qrda_file.validate(doc, {file_name: "filename.xml"})
+
      assert_equal 1, qrda_file.errors.length, "Should report 1 error"
   end
 
@@ -137,7 +139,7 @@ class QRDATest < ActiveSupport::TestCase
      xml_file = File.new(File.join(Rails.root, 'test/fixtures/qrda/cat_1/bad_measure_id.xml'))
      doc = Nokogiri::XML(xml_file)
      qrda_file = Validators::QrdaCat1Validator.new([@m0004])
-     qrda_file.validate(doc, "filename.xml")
+     qrda_file.validate(doc, {file_name: "filename.xml"})
      # New schematron checks for the ID element, and @root and @extension attributes, this adds 2 errors
      # in addition to what's reported by Cypress
      assert_equal 3, qrda_file.errors.length, "Should report 3 errors"


### PR DESCRIPTION
Fix method signature for cat1 schematron validator to match other validators. Error caused file_name to be a hash which prevent file errors from showing up on the test page. Also set type for file_name field in ExecutionError to always be a String.
