### PR TITLE
bump hds for cat3 export fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: f57b239d75d5627d4a356f0eb50f391bb1c9c222
+  revision: d54336e01be4c11bcdc6688daf735c32f0eb8800
   branch: master
   specs:
     health-data-standards (3.5.2)
@@ -91,7 +91,7 @@ GEM
     execjs (2.2.1)
     highline (1.6.21)
     hike (1.2.3)
-    i18n (0.6.11)
+    i18n (0.7.0)
     jquery-rails (3.1.1)
       railties (>= 3.0, < 5.0)
       thor (>= 0.14, < 2.0)
@@ -109,7 +109,7 @@ GEM
     method_source (0.8.2)
     mime-types (1.25.1)
     mini_portile (0.5.3)
-    minitest (5.4.3)
+    minitest (5.5.0)
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     mongoid (4.0.0)


### PR DESCRIPTION
Bump HDS to fix HDS Cat 3 exporter to be compatible with errata release
