### PR TITLE
bump version to 2.6

### DIFF
--- a/app/views/product_tests/wizard_screens/_home.html.erb
+++ b/app/views/product_tests/wizard_screens/_home.html.erb
@@ -32,7 +32,7 @@ var start_dates = <%= Hash[*Bundle.active.collect{|b| [b.id,b['measure_period_st
     <dd>
       <span class="controls">
         <label for="bundle_id">
-          <%= select_tag(:bundle_id, options_for_select(Bundle.active.order_by({version: 1}).collect{|b| ["#{b.title} - #{b.version}",b.id]}), :style=>"width:300px") %>
+          <%= select_tag(:bundle_id, options_for_select(Bundle.active.order_by({version: -1}).collect{|b| ["#{b.title} - #{b.version}",b.id]}), :style=>"width:300px") %>
         </label>
       </span>
     </dd>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -18,8 +18,8 @@ effective_date:
   month: 12
   day: 31
 
-version: 2.5.1
-default_bundle: 2.5.0
+version: 2.6.0
+default_bundle: 2.6.0
 enable_logging: false
 
 #set to true for a "demo mode" server (large banners on header, among other things)


### PR DESCRIPTION
Bump Cypress version to 2.6. Also changes sort order in test wizard so most recent bundle is the default.