### PR TITLE
Cypress install script updates

### DIFF
--- a/contrib/install_cypress.sh
+++ b/contrib/install_cypress.sh
@@ -36,17 +36,17 @@
 # Author: Tim Taylor <ttaylor@mitre.org>
 # Date:   10 Dec 2012
 # Updates: Michael O'Keefe <mokeefe@mitre.org>
-# Date:   23 Sept 2014
+# Date:   23 Sept 2014-12 Jan 2015
 ##############################################################################
 
 # Variables that determine the versions of components we will install
-cypress_tag="v2.5.1"
+cypress_tag="v2.6.0"
 install_ruby_ver="2.1.5"
 install_bundler_ver="1.6.3"
 install_libxml_ver="2.8.0"
 
 install_nokogiri_ver="1.6.0"
-cypress_bundle_ver="2.4.0"
+cypress_bundle_ver="2.6.0"
 
 install_apache_ver="2.4.*"
 install_passenger_ver="4.0.50"
@@ -478,9 +478,9 @@ install_pkg "git-core"
 echo
 
 ##########
-# Task 4: Install RVM and Ruby 1.9.3
+# Task 4: Install RVM and Ruby
 ##########
-echo "Install RVM and Ruby $install_ruby_ver:"
+echo "Install RVM and Ruby $install_ruby_ver: "
 # RVM dependencies
 echo "   Install dependant packages:"
 for p in build-essential openssl libssl-dev libreadline6 libreadline6-dev curl zlib1g zlib1g-dev libyaml-dev libsqlite3-dev sqlite3 libxml2-dev libxslt-dev autoconf libc6-dev ncurses-dev automake libtool bison subversion pkg-config; do
@@ -489,8 +489,8 @@ for p in build-essential openssl libssl-dev libreadline6 libreadline6-dev curl z
 done
 
 # Install the RVM GPG keys
-echo -n "   Install RVM GPG Keys"
-`gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3`
+echo -n "   Install RVM GPG Keys: "
+gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 &> /dev/null
 success_or_fail $? "done" "failed"
 
 # Install RVM itself


### PR DESCRIPTION
Updated to the 2.6.0 version of Cypress as the default installed version.

Also updated some of the text output to the terminal, to format it better/hide text that shouldn't be displayed.