### PR TITLE
Re-enable evaluation of tests with the Childhood Immunization measure 

### DIFF
--- a/lib/cypress/measure_evaluation_validator.rb
+++ b/lib/cypress/measure_evaluation_validator.rb
@@ -243,14 +243,14 @@ module Cypress
 
     def upload_cat3s(tests)
       tests.each do |t|
-        if !t.measure_ids.include?("40280381-4555-E1C1-0145-D7C003364261")
+        # if !t.measure_ids.include?("40280381-4555-E1C1-0145-D7C003364261")
           begin
             xml = script_generate_cat3(t.measure_ids, t)
             upload_cat3(t, xml)
           rescue Exception => e
             $stderr.puts "Cat 3 test #{t.id} failed: #{e}"
           end
-        end
+        # end
       end
     end
 


### PR DESCRIPTION
Previously, we would simply not test any tests that were testing the Childhood Immunization measure as a Cat 3, because our `cat_3_calculator.rb` file would freeze up and never return. This situation has (for the most part) been rectified, so tests with those measures are being re-enabled. Be aware that you need to have uploaded a modified version of `map_reduce_utils.js` to your measure evaluator before attempting to evaluate this code (we're still working on a good way to do this automatically).