### PR TITLE
Fixes issue when test machine is in different day than UTC

### DIFF
--- a/test/unit/helpers/application_helper_test.rb
+++ b/test/unit/helpers/application_helper_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class ApplicationHelperTest < ActionView::TestCase
 	test "Should return formatted time" do
-		now = Time.now
+		now = Time.now.utc
 		formatted_time = now.strftime('%m/%d/%Y')
 
-		assert display_time(now) == formatted_time
-		assert display_time('fail') == '?'
+		assert_equal display_time(now), formatted_time
+		assert_equal display_time('fail'), '?'
 	end
 
 


### PR DESCRIPTION
The test calls Time.now, but the underlying method converts the Time
object to UTC. Since the method strips the information down to just
the date, the test fails is the testing machine is in a different day
than UTC, for example 10PM Eastern Standard Time.