### PR TITLE
Fixes intermittent test suite failures, mainly on Travis CI

### DIFF
--- a/test/unit/helpers/product_test_helper_test.rb
+++ b/test/unit/helpers/product_test_helper_test.rb
@@ -7,6 +7,7 @@ class ProductTestHelperTest < ActionView::TestCase
     collection_fixtures('test_executions', '_id', "product_test_id")
     collection_fixtures('products', '_id','vendor_id')
     collection_fixtures('product_tests', '_id','product_id')
+    collection_fixtures('measures','bundle')
   end
 
 	test "Should report result class" do
@@ -14,13 +15,13 @@ class ProductTestHelperTest < ActionView::TestCase
     assert result_class(nil,0) == 'na'
     assert result_class(1,0) == 'fail'
     assert result_class(1,1) == 'pass'
-  end  
+  end
 
 
   test "Group measures by type" do
   	groups = group_measures_by_type(Measure.all)
     assert_equal 5, groups[:continuous].length,  "Should contain 5 CV measure"
     assert_equal 17, groups[:proportional].length, "Should contain 17 non CV measures"
-  end  
+  end
 
 end


### PR DESCRIPTION
The test suite will intermittently fail on Travis, but this can be
replicated locally. The ProductTestHelperTest depends on the measures
collection being populated. Depending on test execution order or
previous state of a developer's database, the collection may or may
not be populated.

To ensure this test fails, drop the cypress_test database and run:
bundle exec rake test TEST=test/unit/helpers/product_test_helper_test.rb

Since Travis always starts with a clean database, it is much more
likely to see the test fail there.

This change ensures that the measure collection will be populated
before the test is run.