### PR TITLE
Updated patients controller so @measures_categories is generated for tests

### DIFF
--- a/app/controllers/patients_controller.rb
+++ b/app/controllers/patients_controller.rb
@@ -17,7 +17,7 @@ class PatientsController < ApplicationController
       @measures = @bundle.measures
     end
     #only get the measures_categories if we don't have a fragment for the view section
-    if !fragment_exist?("index-" + @bundle.version)
+    if !fragment_exist?("index-" + @bundle.version) || @test
       @measures_categories = @measures.group_by { |t| t.category }
     end
 


### PR DESCRIPTION
 Before, if there was a fragment matching `index-@bundle.version` (the MPL) we wouldn't generate it, but we don't store fragments for product tests, so the @measures_categories was needed to generate the view.