### PR TITLE
Added dependent: :destroy to test_execution artifact

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -4,7 +4,7 @@ class ProductTest
 
   belongs_to :product
   has_one :patient_population
-  has_many :test_executions, dependent: :delete
+  has_many :test_executions, dependent: :destroy
   belongs_to :user
   belongs_to :bundle
 

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -5,7 +5,7 @@ class TestExecution
   include Mongoid::Attributes::Dynamic
   include AASM
 
-  has_one :artifact, autosave: true
+  has_one :artifact, autosave: true, dependent: :destroy
 
   belongs_to :product_test
 
@@ -144,7 +144,5 @@ class TestExecution
   def measure_passed?(measure)
     passing_measures.find{|m| m.id == measure.id}
   end
-
-
 
 end


### PR DESCRIPTION
 That way it gets deleted when the test execution does (also deletes the file(s) on disk). Keeps the data/uploads/test_executions folder from growing to consume ridiculous amounts of disk space.