### PR TITLE
Escaped some user-supplied inputs to avoid XSS attacks

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -97,9 +97,9 @@ class AdminController < ApplicationController
     if user
       user.update_attribute(:disabled, disabled)
       if (disabled)
-        render :text => "<a href=\"#\" class=\"disable\" data-username=\"#{user.email}\">disabled</span>"
+        render :text => "<a href=\"#\" class=\"disable\" data-username=\"#{h(user.email)}\">disabled</span>"
       else
-        render :text => "<a href=\"#\" class=\"enable\" data-username=\"#{user.email}\">enabled</span>"
+        render :text => "<a href=\"#\" class=\"enable\" data-username=\"#{h(user.email)}\">enabled</span>"
       end
     else
       render :text => "User not found"


### PR DESCRIPTION
One of the potential issues identified by Brakeman was an XSS attack because these params were not escaped, and were provided by the user. The `h()` method is an alias to `html_escape()` and safely escapes the params for use in html.