### PR TITLE
Removed the measures minimal set route, and some associated code

### DIFF
--- a/app/assets/javascripts/product_tests.js
+++ b/app/assets/javascripts/product_tests.js
@@ -20,32 +20,6 @@
         });
     };
 
-
-/*    commented out functionality related to the minimal patient set since
- *    that screen is no longer part of the wizard sequence
-     $.testWizard.updateMinimalPatientSet = function() {
-        $('#measure_coverage').empty().html('<div class="busy">Finding appropriate patients...</h3>');
-        var ids = [];
-        $('.measure_cb:checked').each(function(i,e) {
-            var id = $(e).attr('id');
-            ids.push(id.substr(id.lastIndexOf('_')+1));
-        });
-        // get the needed num/den/exc for each of the selected measures
-        $.ajax({
-            url: "/measures/minimal_set",
-            type: "POST",
-            data: {
-                measure_ids: ids,
-                product_id: $('#product_test_product_id').val(),
-                num_records: $('#total_records').val()
-            },
-            dataType: 'script',
-            error: function(xhr, err) {
-                alert("Sorry, we can't currently calculate large numbers of quality measures:\n" + err);
-            }
-        });
-    };
-*/
     $.testWizard.updateProgressBar = function(screen) {
         switch (screen) {
             case "first":

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -3,7 +3,7 @@ class MeasuresController < ApplicationController
   before_filter :authenticate_user!
   before_filter :find_test_and_execution, only: [:show, :patients]
   before_filter :find_measure, only: [:show,:patients]
-  before_filter :find_product, only: [:show,:patients,:minimal_set]
+  before_filter :find_product, only: [:show,:patients]
 
   def by_type
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -86,7 +86,6 @@ Cypress::Application.routes.draw do
   get '/services/validate_pqri'
   post '/services/validate_pqri'
 
-  match '/measures/minimal_set' => 'measures#minimal_set', via: [:post]
   match '/measures/by_type' => 'measures#by_type', via: [:post]
   match '/product_tests/period', :to=>'product_tests#period', :as => :period, :via=> :post
 


### PR DESCRIPTION
Since that action doesn't exist in `measures_controller.rb` any more, I removed the route that referenced it, and some legacy code such as a `before_filter` include and a section of commented-out Javascript.