### PR TITLE
Updated Rake task and install script to install over SSL

### DIFF
--- a/contrib/install_cypress.sh
+++ b/contrib/install_cypress.sh
@@ -730,7 +730,7 @@ else
   echo
   # download the measure bundle
   echo -n "   Download latest measure bundle (${complete_bundle_ver}): "
-  su - -c "cd cypress; curl -s -u ${nlm_user}:${nlm_passwd} http://demo.projectcypress.org/bundles/bundle-${complete_bundle_ver}.zip -o ../bundle-${complete_bundle_ver}.zip" cypress
+  su - -c "cd cypress; curl -s -u ${nlm_user}:${nlm_passwd} https://demo.projectcypress.org/bundles/bundle-${complete_bundle_ver}.zip -o ../bundle-${complete_bundle_ver}.zip" cypress
   success_or_fail $? "done" "failed to download bundle" "Can't continue without measure bundle."
   # import the bundle
   echo -n "   Import measure bundle: "

--- a/contrib/install_cypress.sh
+++ b/contrib/install_cypress.sh
@@ -491,7 +491,15 @@ done
 # Install the RVM GPG keys
 echo -n "   Install RVM GPG Keys: "
 gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 &> /dev/null
-success_or_fail $? "done" "failed"
+
+if [ $? -eq 0 ]; then
+  success "done"
+else
+  fail "failed"
+  echo -n "   Trying alternate keyserver: "
+  gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D39DC0E3 &> /dev/null
+  success_or_fail $? "done" "failed" "RVM cannot install without the GPG key"
+fi
 
 # Install RVM itself
 echo -n "   Install RVM: "
@@ -565,7 +573,7 @@ apt-key list | grep -q "^pub[[:space:]]\+.*/${mongodb_key_id}"
 if [ $? -eq 0 ]; then
   success "already in keyring"
 else
-  apt-key adv --keyserver keyserver.ubuntu.com --recv "$mongodb_key_id" &> /dev/null
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv "$mongodb_key_id" &> /dev/null
   success_or_fail $? "added to keyring" "failed."
 fi
 # update package lists

--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -126,7 +126,7 @@ namespace :cypress do
 
     puts "Downloading and saving #{@bundle_name} to #{measures_dir}"
     # Pull down the list of bundles and download the version we're looking for
-    bundle_uri = "http://demo.projectcypress.org/bundles/#{@bundle_name}"
+    bundle_uri = "https://demo.projectcypress.org/bundles/#{@bundle_name}"
     bundle = nil
 
     tries = 0


### PR DESCRIPTION
Because we added an SSL certificate to the server, the "right" way to connect to it is now https://

Also added changes to the keyserver definitions for RVM and Mongodb: added a backup keyserver for RVM, and added the missing `hkp://` and `:80` protocol and port definitions for the mongo keyserver. 

Includes changes from #152 