### PR TITLE
Disabled download patients button when no patients in test

### DIFF
--- a/app/assets/stylesheets/cypress/_buttons.scss
+++ b/app/assets/stylesheets/cypress/_buttons.scss
@@ -12,9 +12,16 @@ a.cmd, input.cmd {
   text-align: center;
   text-decoration: none;
   cursor: pointer;
-
-  
 }
+
+a.cmd[disabled], a.cmd[disabled]:hover {
+  @include bordered(grey);
+  pointer-events: none;
+  color: grey;
+  background-color: $btnBkgColor;
+  cursor: not-allowed;
+}
+
 a.cmd:hover, input.cmd:hover {
   background-color: $btnHoverBkg;
 }

--- a/app/assets/stylesheets/cypress/_markup.scss
+++ b/app/assets/stylesheets/cypress/_markup.scss
@@ -16,7 +16,7 @@
 }
 
 .start-tag { color: #00008b;}
-.end_tag { color: #00008b;}
+.end-tag { color: #00008b;}
 
 
 .pi { color: #9932CC; }

--- a/app/views/product_tests/_status.html.erb
+++ b/app/views/product_tests/_status.html.erb
@@ -32,11 +32,21 @@ $(document).ready(function(){
             <p>
             1. Download Test Data
             </p><p>
-            <%= link_to 'Test Data', '', {
+            <%= 
+            if test.records.empty?
+              link_to 'No Data Available', 'javascript:;', {
+                  :id => 'share_menu',
+                  :class => "cmd",
+                  :disabled => "disabled"
+                }
+            else
+              link_to 'Test Data', '', {
                   :id => 'share_menu',
                   :class => "cmd",
                   :onmouseover => "$.cypress.showMenu($('#share_menu'), $('#share_options'));"
-                } %></p>
+                }
+            end
+             %></p>
                  <ul id="share_options" style="display: none" role="listbox"
                         class="ui-menu ui-widget ui-widget-content ui-corner-all dialog-menu" aria-activedescendant="ui-active-menuitem">
                       <li class="ui-menu-item" role="menuitem">


### PR DESCRIPTION
If there are no patients in the test, don't let them hover/click on the link to download, and change the text. Doesn't solve the issues with the measure evaluator not liking the lack of zip file, but keeps users from seeing an error page.

Also edited _markup so the xml all colors correctly.