### PR TITLE
Added a question mark to the failing? method on test execution

### DIFF
--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -102,15 +102,15 @@ class TestExecution
   end
 
   def passing?
-    @state == :passed
+    self.state == :passed
   end
 
   def failing?
-    @state == :failed
+    self.state == :failed
   end
 
   def incomplete?
-    (!passing? && !failing)
+    (!passing? && !failing?)
   end
 
   def files

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -105,7 +105,7 @@ class TestExecution
     @state == :passed
   end
 
-  def failing
+  def failing?
     @state == :failed
   end
 

--- a/test/unit/test_execution_test.rb
+++ b/test/unit/test_execution_test.rb
@@ -45,6 +45,18 @@ class TestExecutionTest < ActiveSupport::TestCase
 
   end
 
+  test "passed failed and incomplete methods should be accurate" do
+    te = TestExecution.new
+    te.save
+
+    assert te.incomplete?, "te.imcomplete? should return true when execution is neither passing or failing"
+
+    te.failed
+    assert te.failing?, "te.failing? not returning true when execution is failing"
+
+    te.force_pass
+    assert te.passing?, "te.passing? not returning true when execution is passing"
+  end
 
   
   


### PR DESCRIPTION
Because `passing?` and `incomplete?` had one, but `failing` didn't.