### PR TITLE
Fixed vendor caching by removing collection cache

### DIFF
--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -1,4 +1,3 @@
-<%cache @vendors do %>
 <%= javascript 'vendors' %>
 
 <div id="container" class="container">
@@ -74,4 +73,3 @@
     <%= render :partial=>"shared/legend" %>
   </div>
 </div>
-<% end #cache @vendors %>


### PR DESCRIPTION
This fixes the duplicated header/footer issue, without affecting performance, since the individual vendors are still cached.