### PR TITLE
Enabling authentication for all controllers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,7 +5,7 @@ class ApplicationController < ActionController::Base
 
   # breadcrumbs
   add_breadcrumb 'All Vendors', :root_path
-
+  before_action :authenticate_user!
   private
 
   # Overwriting the sign_out redirect path method

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   # breadcrumbs
   add_breadcrumb 'All Vendors', :root_path
   before_action :authenticate_user!
+
   private
 
   # Overwriting the sign_out redirect path method

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery :with => :exception
 
   # breadcrumbs
-  add_breadcrumb 'All Vendors', :root_path
+  add_breadcrumb 'All Vendors', :vendors_path
   before_action :authenticate_user!
 
   private

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,9 @@
+class HomeController < ActionController::Base
+  def index
+    if current_user
+      redirect_to :vendors
+    else
+      redirect_to :new_user_session
+    end
+  end
+end

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -4,7 +4,6 @@ class VendorsController < ApplicationController
   add_breadcrumb 'Add Vendor',  :new_vendor_path,  only: [:new, :create]
   add_breadcrumb 'Edit Vendor', :edit_vendor_path, only: [:edit, :update]
 
-  before_action :authenticate_user!
   def index
     @vendors = Vendor.all.order(:updated_at => :desc)
     respond_to do |f|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  root to: 'vendors#index'
+  root to: 'home#index'
 
   resources :vendors do
     resources :products, only: [:show, :index, :new, :create, :edit, :update, :destroy]

--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -51,8 +51,11 @@ Then(/^the user should see a sign out link$/) do
   page.assert_text 'Log Out'
 end
 
+Then(/^the user should not see a warning message$/) do
+  page.assert_no_text 'You need to sign in or sign up before continuing.'
+end
+
 Then(/^the user should be redirected to the sign in page$/) do
-  page.assert_text 'You need to sign in or sign up before continuing.'
   assert_equal new_user_session_path, page.current_path
 end
 

--- a/features/users/login.feature
+++ b/features/users/login.feature
@@ -15,3 +15,4 @@ Scenario: Successful login
 Scenario: Not Logged In
   When the user navigates to the home page
   Then the user should be redirected to the sign in page
+  And the user should not see a warning message


### PR DESCRIPTION
This adds authentication to all controller actions except those required for login and sign up. This also adds a home controller to server as the root_path.  This allows us to check and see if the user is current authenticated and redirect as needed.  This prevents the warning message about being required to sign in when first accessing the root path when not currently authenticated.   If a user bookmarks a path that is authenticated though they will still see the warning message as they are attempting to access a path that requires authentication. 