### PR TITLE
fix for bug in test executions job

### DIFF
--- a/lib/validators/validator.rb
+++ b/lib/validators/validator.rb
@@ -16,7 +16,7 @@ module Validators
       attributes = { message: msg, msg_type: msg_type,
                      validator_type: self.class.validator_type }.merge(options)
       @errors ||= []
-      @errors << ExecutionError.new(attributes)
+      @errors << ::ExecutionError.new(attributes)
     end
 
     def add_errors(errors)


### PR DESCRIPTION
explicitly referencing the ExecutionError class as top-level prevents a module loading error when the TestExecutionJob is run delayed