### PR TITLE
Test fixes

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -49,7 +49,7 @@ class ProductTest
       pcv.value['medical_record_id']
     end
     ids.uniq!
-    random_ids = Record.all.pluck('medical_record_number').uniq
+    random_ids = Record.where(test_id: nil).pluck('medical_record_number').uniq
     Cypress::PopulationCloneJob.new('test_id' => id,  'patient_ids' => ids, 'randomization_ids' =>  random_ids,
                                     'randomize_demographics' => true).perform
   end

--- a/test/controllers/product_tests_controller_test.rb
+++ b/test/controllers/product_tests_controller_test.rb
@@ -7,9 +7,6 @@ class ProductTestsControllerTest < ActionController::TestCase
     sign_in User.first
   end
 
-  teardown do
-    drop_database
-  end
   test 'should get index' do
     get :index, product_id: Product.first.id
     assert_response :success

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -7,10 +7,6 @@ class ProductsControllerTest < ActionController::TestCase
     sign_in User.first
   end
 
-  teardown do
-    drop_database
-  end
-
   test 'should get index' do
     get :index, vendor_id: Vendor.first.id
     assert_response :redirect

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -7,10 +7,6 @@ class TasksControllerTest < ActionController::TestCase
     sign_in User.first
   end
 
-  teardown do
-    drop_database
-  end
-
   test 'should get index' do
     get :index, product_test_id: ProductTest.first.id
     assert_response :success

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -6,9 +6,6 @@ class TestExecutionsControllerTest < ActionController::TestCase
     collection_fixtures('vendors', 'products', 'product_tests', 'tasks', 'test_executions', 'users')
     sign_in User.first
   end
-  teardown do
-    drop_database
-  end
 
   test 'should get show' do
     mt = Product.first.product_tests.build({ name: 'mtest', measure_ids: ['0001'], bundle_id: '4fdb62e01d41c820f6000001' }, MeasureTest)

--- a/test/helpers/caching_test.rb
+++ b/test/helpers/caching_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
 
-class CachingTest < MiniTest::Test
+class CachingTest < ActiveSupport::TestCase
   def setup
-    drop_database
     collection_fixtures('measures', 'bundles')
 
     ActionController::Base.perform_caching = true

--- a/test/jobs/measure_evaluation_job_test.rb
+++ b/test/jobs/measure_evaluation_job_test.rb
@@ -8,10 +8,6 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
     @result = QME::QualityReportResult.new(DENOM: 48, NUMER: 44, antinumerator: 4, DENEX: 0)
   end
 
-  def after_teardown
-    drop_database
-  end
-
   def test_can_queue_product_test_job
     assert_enqueued_jobs 0
     MeasureEvaluationJob.perform_later(ProductTest.new(measure_ids: ['8A4D92B2-3887-5DF3-0139-0C4E41594C98']), {})

--- a/test/jobs/test_execution_job_test.rb
+++ b/test/jobs/test_execution_job_test.rb
@@ -6,10 +6,6 @@ class TestExecutionJobTest < ActiveJob::TestCase
                         'measures', 'records')
   end
 
-  def after_teardown
-    drop_database
-  end
-
   def test_can_queue_job
     assert_enqueued_jobs 0
 

--- a/test/models/artifact_test.rb
+++ b/test/models/artifact_test.rb
@@ -1,9 +1,5 @@
 require 'test_helper'
-class ArtifactTest < MiniTest::Test
-  def after_teardown
-    drop_database
-  end
-
+class ArtifactTest < ActiveSupport::TestCase
   def test_should_be_able_to_tell_if_a_file_is_an_archive
     filename = "#{Rails.root}/test/fixtures/artifacts/qrda.zip"
     artifact = Artifact.new(file: File.new(filename))

--- a/test/models/c1_task_test.rb
+++ b/test/models/c1_task_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-class C1TaskTest < MiniTest::Test
+class C1TaskTest < ActiveSupport::TestCase
   include ::Validators
   include ActiveJob::TestHelper
 
@@ -8,10 +8,6 @@ class C1TaskTest < MiniTest::Test
                         'measures', 'records', 'patient_cache',
                         'health_data_standards_svs_value_sets')
     @product_test = ProductTest.find('51703a883054cf84390000d3')
-  end
-
-  def after_teardown
-    drop_database
   end
 
   def test_create

--- a/test/models/c2_task_test.rb
+++ b/test/models/c2_task_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 # rubocop:disable Metrics/ClassLength
-class C2TaskTest < MiniTest::Test
+class C2TaskTest < ActiveSupport::TestCase
   include ::Validators
   include ActiveJob::TestHelper
 
@@ -8,11 +8,6 @@ class C2TaskTest < MiniTest::Test
     collection_fixtures('product_tests', 'products', 'bundles',
                         'measures', 'records', 'patient_cache')
     @product_test = ProductTest.find('51703a6a3054cf8439000044')
-  end
-
-  def after_teardown
-    clear_enqueued_jobs
-    drop_database
   end
 
   def test_create

--- a/test/models/c3_task_test.rb
+++ b/test/models/c3_task_test.rb
@@ -1,14 +1,10 @@
 require 'test_helper'
-class C3TaskTest < MiniTest::Test
+class C3TaskTest < ActiveSupport::TestCase
   include ::Validators
 
   def setup
     collection_fixtures('product_tests', 'products', 'bundles',
                         'measures', 'records', 'patient_cache')
-  end
-
-  def after_teardown
-    drop_database
   end
 
   def test_create

--- a/test/models/c4_task_test.rb
+++ b/test/models/c4_task_test.rb
@@ -1,18 +1,14 @@
 require 'test_helper'
-class C4TaskTest < MiniTest::Test
+# rubocop:disable Metrics/ClassLength
+class C4TaskTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
   def setup
-    drop_database
-    collection_fixtures('product_tests', 'products', 'bundles',
-                        'measures', 'records', 'patient_cache',
-                        'health_data_standards_svs_value_sets')
+    collection_fixtures('product_tests', 'bundles',
+                        'records', 'health_data_standards_svs_value_sets')
 
     @product_test = ProductTest.find('51703a883054cf84390000d3')
 
     @all_records = @product_test.records.to_a
-  end
-
-  def after_teardown
-    # drop_database
   end
 
   def test_create

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -1,13 +1,9 @@
 require 'test_helper'
-class MeasureTestTest < MiniTest::Test
+class MeasureTestTest < ActiveSupport::TestCase
   def setup
     collection_fixtures('patient_cache', 'records', 'bundles', 'measures')
     vendor = Vendor.create!(name: 'test_vendor_name')
     @product = vendor.products.create(name: 'test_product')
-  end
-
-  def teardown
-    drop_database
   end
 
   def test_more_than_one_measure

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 require 'helpers/caching_test'
 
-class ProducTest < MiniTest::Test
+class ProducTest < ActiveSupport::TestCase
   def setup
-    drop_database
     collection_fixtures('measures', 'bundles')
     @vendor = Vendor.new(name: 'test_vendor_name')
     @vendor.save
@@ -17,9 +16,6 @@ class ProducTest < MiniTest::Test
   def teardown
     ActionController::Base.perform_caching = false
     ActionController::Base.cache_store = @old_cache_store
-  end
-
-  def after_teardown
     drop_database
   end
 

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -7,10 +7,6 @@ class ProductTestTest < ActiveJob::TestCase
     @product = vendor.products.create(name: 'test_product', c2_test: true)
   end
 
-  def after_teardown
-    drop_database
-  end
-
   def test_create
     assert_enqueued_jobs 0
     pt = @product.product_tests.build(name: 'test_for_measure_1a',

--- a/test/models/record_test.rb
+++ b/test/models/record_test.rb
@@ -1,12 +1,8 @@
 require 'test_helper'
 
-class RecordTest < MiniTest::Test
+class RecordTest < ActiveSupport::TestCase
   def setup
     @bundle = HealthDataStandards::CQM::Bundle.create(version: '1', name: 'test-bundle')
-  end
-
-  def after_teardown
-    drop_database
   end
 
   def test_record_knows_bundle

--- a/test/models/test_execution_test.rb
+++ b/test/models/test_execution_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-class TestExecutionTest < MiniTest::Test
+class TestExecutionTest < ActiveSupport::TestCase
   def setup
     drop_database
     vendor = Vendor.create(name: 'test_vendor_name')
@@ -7,10 +7,6 @@ class TestExecutionTest < MiniTest::Test
     ptest = product.product_tests.build(name: 'ptest', measure_ids: ['1a'])
     @task = ptest.tasks.build
   end
-
-  # def after_teardown
-  #   drop_database
-  # end
 
   def test_create
     te = @task.test_executions.build

--- a/test/models/vendor_test.rb
+++ b/test/models/vendor_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class VendorTest < MiniTest::Test
+class VendorTest < ActiveSupport::TestCase
   def setup
     Vendor.all.destroy
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ Warden.test_mode!
 
 Mongoid.logger.level = Logger::INFO
 Mongo::Logger.logger.level = Logger::WARN
-class MiniTest::Test
+class ActiveSupport::TestCase
   def teardown
     drop_database
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,8 @@ require 'minitest/reporters'
 require 'mocha/setup'
 
 Minitest::Reporters.use!
+# comment the previous line and uncomment the next one for test-by-test details
+# Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 
 include Warden::Test::Helpers
 Warden.test_mode!
@@ -29,7 +31,10 @@ class ActiveSupport::TestCase
   end
 
   def drop_database
-    Mongoid.default_client.database.drop
+    Mongoid::Config.purge!
+    # purge the database instead of dropping it
+    # because dropping it literally deletes the file
+    # which then has to be recreated (which is slow)
   end
 
   def drop_collection(collection)

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -6,9 +6,7 @@ class PatientZipperTest < ActiveSupport::TestCase
     collection_fixtures('records', 'bundles', 'vendors', 'products', 'product_tests', 'tasks', 'test_executions')
     @patients = Record.where('gender' => 'F')
   end
-  teardown do
-    drop_database
-  end
+
   test 'Should create valid html file' do
     format = :html
     filename = "pTest-#{Time.now.to_i}.html.zip"

--- a/test/unit/lib/record_filter_test.rb
+++ b/test/unit/lib/record_filter_test.rb
@@ -5,16 +5,9 @@ require 'fileutils'
 
 class RecordFilterTest < ActiveSupport::TestCase
   def setup
-    drop_database
-    collection_fixtures('product_tests', 'products', 'bundles',
-                        'measures', 'records', 'patient_cache',
-                        'health_data_standards_svs_value_sets')
+    collection_fixtures('records', 'health_data_standards_svs_value_sets')
 
     @all_records = Record.all
-  end
-
-  def after_teardown
-    # drop_database
   end
 
   def test_filter_gender


### PR DESCRIPTION
- fix for random failure in ProductTestTest
- fix for random failures caused by test order (the global teardown runs after every test, so individual test classes don't need to define a teardown unless they do something special)
- switch test classes from minitest to activesupport
- performance improvement by not dropping the whole db (which deletes the file on disk) but instead purging which drops all collections