### PR TITLE
Refactor test execution and test deck download

### DIFF
--- a/app/assets/stylesheets/cypress/_navbar.scss
+++ b/app/assets/stylesheets/cypress/_navbar.scss
@@ -36,7 +36,7 @@
     display: table;
     margin: 0;
     width: 100%;
-    
+
     > li {
       display: table-row;
       text-align: center;

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -1,0 +1,55 @@
+module TestExecutionsHelper
+  def get_certification_types(task)
+    if currently_viewing_c1?(task)
+      certification_types = 'C1'
+    else
+      certification_types = 'C2'
+    end
+    certification_types << ' and C3' if task.product_test.product.c3_test
+  end
+
+  def get_other_certification_types(task)
+    if currently_viewing_c1?(task)
+      other_certification_types = 'C2'
+    else
+      other_certification_types = 'C1'
+    end
+    other_certification_types << ' and C3' if task.product_test.product.c3_test
+  end
+
+  def get_upload_type(task)
+    if currently_viewing_c1?(task)
+      'CAT 1 zip'
+    else
+      'CAT 3 XML'
+    end
+  end
+
+  # returns:
+  #   c1 task if we are currently on the c2 task page
+  #   c2 task if we are currently on the c1 task page
+  #   false if the user did not select the other task when creating the product
+  def get_other_task(task)
+    if currently_viewing_c1?(task)
+      task.product_test.c2_task
+    else
+      task.product_test.c1_task
+    end
+  end
+
+  def get_select_history_message(execution, is_most_recent)
+    msg = ''
+    msg << 'Most Recent - ' if is_most_recent
+    msg << execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p (%A)')
+    msg << ' (passing)' if execution.passing?
+    msg << ' (in progress)' if execution.incomplete?
+    msg << " (#{execution.execution_errors.count} errors)" if execution.failing?
+    msg
+  end
+
+  private
+
+  def currently_viewing_c1?(task)
+    task._type == 'C1Task'
+  end
+end

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -6,6 +6,7 @@ module TestExecutionsHelper
       certification_types = 'C2'
     end
     certification_types << ' and C3' if task.product_test.product.c3_test
+    certification_types
   end
 
   def get_other_certification_types(task)
@@ -15,6 +16,7 @@ module TestExecutionsHelper
       other_certification_types = 'C1'
     end
     other_certification_types << ' and C3' if task.product_test.product.c3_test
+    other_certification_types
   end
 
   def get_upload_type(task)

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -33,10 +33,17 @@
       </div>
       <div class = 'panel-body'>
         <p>This download contains a folder for each measure selected for this product. Inside these folders are XML documents for each patient associated with that measure.</p>
-        <%= form_for @product, url: { controller: 'records', action: 'download_full_test_deck' }, :html => { :method => 'GET' } do |f| %>
-          <%= button_tag(type: 'submit', class: 'btn btn-primary') do %>
-            <i class = 'fa fa-fw fa-download'></i> Download All Patients (.zip)
+        <% num_measure_tests = @product.product_tests.measure_tests.count %>
+        <% num_measure_tests_ready = @product.product_tests.measure_tests.where(state: :ready).count %>
+        <% if num_measure_tests_ready == num_measure_tests %>
+          <%= form_for @product, url: { controller: 'records', action: 'download_full_test_deck' }, :html => { :method => 'GET' } do |f| %>
+            <%= button_tag(type: 'submit', class: 'btn btn-primary') do %>
+              <i class = 'fa fa-fw fa-download'></i> Download All Patients (.zip)
+            <% end %>
           <% end %>
+        <% else %>
+          <p>test deck is loading. refresh your browser periodically</p>
+          <p><%= "#{num_measure_tests_ready} of #{num_measure_tests} ready" %></p>
         <% end %>
       </div>
     </div>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -8,20 +8,17 @@
 
 
 <% if execution.incomplete? %>
-  <h4>
-    <%= "PENDING: #{execution.created_at.to_time.strftime('%b %d, %Y at %I:%M:%S %p (%A)')}" %>
-  </h4>
+  <h4><i class="fa fa-fw fa-circle-o-notch fa-spin text-info"></i> In Progress</h4>
+  <!-- <p>You do not need to reload your browser. Results will automatically display when the tests are done running. This should take about ___ seconds.</p> -->
+  <p>Wait 10 seconds, then reload your browser.</p>
+<% elsif execution.passing? %>
+  <h4><i class="fa fa-fw fa-check-circle text-success"></i> Passed</h4>
 <% else %>
   <% qrda_errors = execution.qrda_errors %>
   <% report_errors = execution.reporting_errors %>
   <% submit_errors = execution.submission_errors %>
   
-  <h4>
-    <%= "#{execution.created_at.to_time.strftime('%b %d, %Y at %I:%M:%S %p (%A)')}" %>
-    <span class = 'text-danger'>
-      <%= "[#{execution.execution_errors.count} errors]" %>
-    </span>
-  </h4>
+  <h4><i class="fa fa-fw fa-times-circle text-danger"></i><%= " Failed with #{execution.execution_errors.count} errors" %></h4>
   <ul class = 'nav nav-tabs'>
     <li class = 'active'>
       <a data-toggle = 'tab' href = <%= "#QRDA_tab_execution_#{execution.id}" %>>

--- a/app/views/test_executions/show.erb
+++ b/app/views/test_executions/show.erb
@@ -32,11 +32,15 @@
     <div class="well well-sm test-step">
       <h2>[1] Download Test Deck</h2>
       <p>Here is a description of whats going on.</p>
-      <%= form_tag("/product_tests/#{@product_test.id}/download", method: 'get') do |f| %>
-        <%= hidden_field_tag :id, :value => @product_test.id %>
-        <%= button_tag(type: 'submit', class: 'btn btn-info btn-block') do %>
-          <i class = 'fa fa-fw fa-download'></i> Download CAT 1 (.zip)
+      <% if @product_test.state == :ready %>
+        <%= form_tag("/product_tests/#{@product_test.id}/download", method: 'get') do |f| %>
+          <%= hidden_field_tag :id, :value => @product_test.id %>
+          <%= button_tag(type: 'submit', class: 'btn btn-info btn-block') do %>
+            <i class = 'fa fa-fw fa-download'></i> Download CAT 1 (.zip)
+          <% end %>
         <% end %>
+      <% else %>
+        <p>test deck is loading. refresh your browser periodically</p>
       <% end %>
     </div>
   </div>

--- a/app/views/test_executions/show.erb
+++ b/app/views/test_executions/show.erb
@@ -1,25 +1,8 @@
 
-<% on_c1 = @task._type == 'C1Task' %>
-<% if on_c1 %>
-  <% certification_types = 'C1' %>
-  <% other_certification_types = 'C2' %>
-  <% upload_type = 'CAT 1 zip' %>
-<% else %>
-  <% certification_types = 'C2' %>
-  <% other_certification_types = 'C1' %>
-  <% upload_type = 'CAT 3 XML' %>
-<% end %>
-<% if @product_test.product.c3_test %>
-  <% certification_types << ' and C3' %>
-  <% other_certification_types << ' and C3' %>
-<% end %>
-
-<% # other_task will contain: %>
-<% #   c1 task if we are currently on the c2 task page %>
-<% #   c2 task if we are currently on the c1 task page %>
-<% #   false if the user did not select the other task when creating the product %>
-<% other_task = @product_test.c2_task if on_c1 %>
-<% other_task = @product_test.c1_task unless on_c1 %>
+<% certification_types = get_certification_types(@task) %>
+<% other_certification_types = get_other_certification_types(@task) %>
+<% upload_type = get_upload_type(@task) %>
+<% other_task = get_other_task(@task) %>
 
 <h3 class = 'page-title'><%= "#{certification_types} certification for #{@product_test.cms_id} #{@product_test.name}" %></h3>
 
@@ -77,12 +60,7 @@
         <label class = 'pull-right'>
           <select onchange = "location = this.options[this.selectedIndex].value;">
             <% @task.test_executions.sort_by { |obj| obj.created_at }.reverse.each_with_index do |execution, i| %>
-              <% select_msg = '' %>
-              <% select_msg << 'Most Recent - ' if i == 0 %>
-              <% select_msg << execution.created_at.to_time.strftime('%b %d, %Y at %I:%M %p (%A)') %>
-              <% select_msg << " (passing)" if execution.passing? %>
-              <% select_msg << " (#{execution.execution_errors.count} errors)" %>
-              <option value = <%= "/tasks/#{@task.id}/test_executions/#{execution.id}" %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= select_msg %></option>
+              <option value = <%= "/tasks/#{@task.id}/test_executions/#{execution.id}" %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i == 0) %></option>
             <% end %>
           </select>
         </label>

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -34,10 +34,16 @@ Scenario: View C1 and C3 And C2 and C3 Execution Pages
 
 Scenario: Successful Download CAT 1 Zip
   When the user creates a product with tasks c1
+  And the product test state is set to ready
   And the user views a product test for that product
-  And the user downloads the CAT 1 zip file
-  Then the CAT 1 zip file should be downloaded
+  Then the user should be able to download a CAT 1 zip file
   And the user should see no execution results
+
+Scenario: Cannot View Download CAT 1 Zip
+  When the user creates a product with tasks c1
+  And the product test state is not set to ready
+  And the user views a product test for that product
+  Then the user should not be able to download a CAT 1 zip file
 
 Scenario: Successful Upload CAT 1 Zip
   When the user creates a product with tasks c2

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -4,6 +4,12 @@ Background:
   Given the user is signed in
   And the user has created a vendor with a product
 
-Scenario: Successful Download Total Test Deck
-  When the user downloads all patients
-  Then the total test deck should be downloaded
+Scenario: Successful Download All Patients
+  When all measure tests have a state of ready
+  And the user visits the product page
+  Then the user should be able to download all patients
+
+Scenario: Cannot View Download All Patients
+  When all measure tests do not have a state of ready
+  And the user visits the product page
+  Then the user should not be able to download all patients

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -41,8 +41,16 @@ And(/^the user switches to c2 and c3 certification$/) do
   page.click_button 'Switch to C2 and C3 certification'
 end
 
-And(/^the user downloads the CAT 1 zip file$/) do
-  page.click_button 'Download CAT 1 (.zip)'
+And(/^the product test state is set to ready$/) do
+  pt = ProductTest.first
+  pt.state = :ready
+  pt.save!
+end
+
+And(/^the product test state is not set to ready$/) do
+  pt = ProductTest.first
+  pt.state = :garbablargblarg
+  pt.save!
 end
 
 And(/^the user uploads a CAT 1 zip file$/) do
@@ -88,9 +96,13 @@ Then(/^the user should see the c2 and c3 execution page$/) do
   page.assert_no_text 'C1 and C3 certification for'
 end
 
-Then(/^the CAT 1 zip file should be downloaded$/) do
-  file_name = "Test_#{@product_test.id}._qrda.zip"
-  assert page.driver.response_headers['Content-Disposition'].include?("filename=\"#{file_name}\"")
+Then(/^the user should be able to download a CAT 1 zip file$/) do
+  page.assert_text 'Download CAT 1 (.zip)'
+end
+
+Then(/^the user should not be able to download a CAT 1 zip file$/) do
+  page.assert_text 'test deck is loading'
+  page.assert_no_text 'Download CAT 1 (.zip)'
 end
 
 Then(/^the user should see test results$/) do

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -218,9 +218,22 @@ When(/^the user views the product$/) do
   page.click_link @product.name
 end
 
-When(/^the user downloads all patients$/) do
-  steps %( When the user views the product )
-  page.click_button 'Download All Patients (.zip)'
+When(/^all measure tests have a state of ready$/) do
+  pt = ProductTest.first
+  pt.state = :ready
+  pt.save!
+end
+
+When(/^all measure tests do not have a state of ready$/) do
+  pt = ProductTest.first
+  pt.state = :nah_man_im_like_lightyears_away_from_bein_ready
+  pt.save!
+end
+
+#   A N D   #
+
+And(/^the user visits the product page$/) do
+  visit "/vendors/#{Vendor.first.id}/products/#{Product.first.id}"
 end
 
 # # # # # # # #
@@ -281,7 +294,11 @@ Then(/^the user should see the product information$/) do
   page.assert_text @vendor.name
 end
 
-Then(/^the total test deck should be downloaded$/) do
-  file_name = "Full_Test_Deck_#{Product.all.first.id}.zip"
-  assert page.driver.response_headers['Content-Disposition'].include?("filename=\"#{file_name}\"")
+Then(/^the user should be able to download all patients$/) do
+  page.assert_text 'Download All Patients'
+end
+
+Then(/^the user should not be able to download all patients$/) do
+  page.assert_no_text 'Download All Patients'
+  page.assert_text 'test deck is loading'
 end


### PR DESCRIPTION
refactored parts of test_execution show page into helper methods. added icons for passing / failing / in progress test_executions. ensured that users could not download or bulk download test deck until the measure_test(s) are ready. added integration tests for this