### PR TITLE
Fix CAT 1, CAT 3 upload for Measure Tests

### DIFF
--- a/app/assets/javascripts/test_executions.js
+++ b/app/assets/javascripts/test_executions.js
@@ -1,0 +1,11 @@
+
+var ready;
+ready = function() {
+  $("#submit-upload").click(function(event) {
+    event.preventDefault();
+    $("#new_test_execution").submit();
+  });
+}
+
+$(document).ready(ready);
+$(document).on('page:load', ready);

--- a/app/assets/stylesheets/cypress/_test_executions.scss
+++ b/app/assets/stylesheets/cypress/_test_executions.scss
@@ -19,3 +19,15 @@
 .inline {
   display: inline;
 }
+
+.btn-info {
+  background: $btn-info-bg;
+  color: $btn-info-color;
+  border-color: $btn-info-border;
+}
+
+.btn-success {
+  background: $btn-success-bg;
+  color: $btn-success-color;
+  border-color: $btn-success-border;
+}

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -7,6 +7,9 @@ class TestExecutionsController < ApplicationController
   def create
     @test_execution = @task.execute(params[:results])
     redirect_to "/tasks/#{@task.id}/test_executions/#{@test_execution.id}"
+  rescue Mongoid::Errors::Validations
+    alert = 'Invalid file upload. Please make sure you upload an XML or zip file.'
+    redirect_to "/tasks/#{@task.id}/test_executions/new", flash: { alert: alert.html_safe }
   end
 
   def new

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -20,8 +20,8 @@ class C1Task < Task
   end
 
   def execute(file)
-    te = test_executions.create(expected_results: expected_results)
-    te.artifact = Artifact.new(file: file)
+    te = test_executions.new(expected_results: expected_results, artifact: Artifact.new(file: file))
+    te.save!
     TestExecutionJob.perform_later(te, self)
     if product_test.contains_c3_task?
       product_test.tasks.each do |task|

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -16,8 +16,8 @@ class C2Task < Task
   end
 
   def execute(file)
-    te = test_executions.create(expected_results: expected_results)
-    te.artifact = Artifact.new(file: file)
+    te = test_executions.create(expected_results: expected_results, artifact: Artifact.new(file: file))
+    te.save!
     TestExecutionJob.perform_later(te, self, validate_reporting: product_test.contains_c3_task?)
     if product_test.contains_c3_task?
       product_test.tasks.each do |task|

--- a/app/views/test_executions/_execution_upload.html.erb
+++ b/app/views/test_executions/_execution_upload.html.erb
@@ -6,18 +6,19 @@
 
 %>
 
-<%= form_for(TestExecution.new, :html => {method: :post, :multipart => true}) do |f| %>
+<%= form_for(TestExecution.new, :html => { method: :post, :multipart => true }) do |f| %>
   <%= hidden_field_tag :task_id, task.id %>
   <div class="fileinput fileinput-new input-group" data-provides="fileinput">
-    <div class="form-control" data-trigger="fileinput"><i class="fa fa-fw fa-file fileinput-exists"></i> <span class="fileinput-filename"></span></div>
-    <span class="input-group-btn">
-      <span class="btn-file">
-        <span class="fileinput-new"><button class="btn btn-info" type="button"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</button></span>
-        <span class="fileinput-exists"><button class="btn btn-warning" type="button"><i class="fa fa-fw fa-refresh"></i> Change</button></span>
-        <label class = "hidden" for = "results"></label>
-        <%= file_field_tag :results, class: 'upload-results' %>
-      </span>
-      <span class="fileinput-exists"><button class="btn btn-info" type="submit"><i class="fa fa-fw fa-upload"></i> Upload and run test</button></span>
+    <div class="form-control" data-trigger="fileinput">
+      <i class="fa fa-fw fa-file fileinput-exists"></i>
+      <span class="fileinput-filename"></span>
+    </div>
+    <span class="input-group-addon btn btn-info btn-file">
+      <span class="fileinput-new"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</span>
+      <span class="fileinput-exists"><i class="fa fa-fw fa-refresh"></i> Change</span>
+      <label class = "hidden" for = "results"></label>
+      <%= file_field_tag :results, class: 'upload-results' %>
     </span>
+    <a id = 'submit-upload' class="input-group-addon fileinput-exists btn btn-success"><i class="fa fa-fw fa-upload"></i> Upload and run test</a>
   </div>
 <% end %>

--- a/app/views/test_executions/_execution_upload.html.erb
+++ b/app/views/test_executions/_execution_upload.html.erb
@@ -17,7 +17,7 @@
       <span class="fileinput-new"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</span>
       <span class="fileinput-exists"><i class="fa fa-fw fa-refresh"></i> Change</span>
       <label class = "hidden" for = "results"></label>
-      <%= file_field_tag :results, class: 'upload-results' %>
+      <%= file_field_tag :results, class: 'upload-results', accept: 'application/zip, text/xml' %>
     </span>
     <a id = 'submit-upload' class="input-group-addon fileinput-exists btn btn-success"><i class="fa fa-fw fa-upload"></i> Upload and run test</a>
   </div>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -4,3 +4,4 @@
 # Mime::Type.register "text/richtext", :rtf
 
 Mime::Type.register 'application/zip', :zip
+Mime::Type.register 'text/xml', :xml

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -46,7 +46,7 @@ Scenario: Cannot View Download CAT 1 Zip
   Then the user should not be able to download a CAT 1 zip file
 
 Scenario: Successful Upload CAT 1 Zip
-  When the user creates a product with tasks c2
+  When the user creates a product with tasks c1
   And the user views a product test for that product
   And the user uploads a CAT 1 zip file
   Then the user should see test results
@@ -56,3 +56,17 @@ Scenario: Successful Upload CAT 3 XML
   And the user views a product test for that product
   And the user uploads a CAT 3 XML file
   Then the user should see test results
+
+Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
+  When the user creates a product with tasks c1
+  And the user views a product test for that product
+  And the user uploads an invalid file
+  Then the user should see an error message saying the upload was invalid
+  And the user should see no execution results
+
+Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type
+  When the user creates a product with tasks c2
+  And the user views a product test for that product
+  And the user uploads an invalid file
+  Then the user should see an error message saying the upload was invalid
+  And the user should see no execution results

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -67,6 +67,13 @@ And(/^the user uploads a CAT 3 XML file$/) do
   page.find('#submit-upload').click
 end
 
+And(/^the user uploads an invalid file$/) do
+  invalid_file_path = File.join(Rails.root, 'app/assets/images/checkmark.svg')
+  page.find('.fileinput > .form-control').click
+  page.attach_file(page.find('.upload-results').value, invalid_file_path)
+  page.find('#submit-upload').click
+end
+
 # # # # # # # #
 #   T H E N   #
 # # # # # # # #
@@ -107,6 +114,10 @@ end
 
 Then(/^the user should see test results$/) do
   assert_text 'Results'
+end
+
+Then(/^the user should see an error message saying the upload was invalid$/) do
+  assert_text 'Invalid file upload'
 end
 
 #   A N D   #

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -57,14 +57,14 @@ And(/^the user uploads a CAT 1 zip file$/) do
   zip_path = File.join(Rails.root, 'test/fixtures/product_tests/ep_qrda_test_good.zip')
   page.find('.fileinput > .form-control').click
   page.attach_file(page.find('.upload-results').value, zip_path)
-  page.click_button('Upload and run test')
+  page.find('#submit-upload').click
 end
 
 And(/^the user uploads a CAT 3 XML file$/) do
   xml_path = File.join(Rails.root, 'test/fixtures/product_tests/cms111v3_catiii.xml')
   page.find('.fileinput > .form-control').click
   page.attach_file(page.find('.upload-results').value, xml_path)
-  page.click_button('Upload and run test')
+  page.find('#submit-upload').click
 end
 
 # # # # # # # #

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -44,4 +44,28 @@ class TestExecutionsControllerTest < ActionController::TestCase
     assert_response 302
     assert_equal task.test_executions.count, orig_count + 1, 'Should have added 1 new TestExecution'
   end
+
+  test 'invalid upload type for c1 task should not create new test execution' do
+    task = C1Task.first
+    old_count = task.test_executions.count
+    file = File.new(File.join(Rails.root, 'app/assets/images/checkmark.svg'))
+    upload = Rack::Test::UploadedFile.new(file, 'image/svg')
+
+    post :create, task_id: task.id, results: upload
+
+    assert_equal old_count, task.test_executions.count
+  end
+
+  test 'invalid upload type for c2 task should not create new test execution' do
+    task = C1Task.first
+    task._type = 'C2Task'
+    task.save!
+    old_count = task.test_executions.count
+    file = File.new(File.join(Rails.root, 'app/assets/images/checkmark.svg'))
+    upload = Rack::Test::UploadedFile.new(file, 'image/svg')
+
+    post :create, task_id: task.id, results: upload
+
+    assert_equal old_count, task.test_executions.count
+  end
 end


### PR DESCRIPTION
Fixed clickable area for file upload so "Select file" and "Change" buttons are now clickable. Added validation error message when a file with invalid file type is uploaded (only XML and zip are allowed)