### PR TITLE
fix for patientzipper errors

### DIFF
--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -88,8 +88,8 @@ module Cypress
       first = patients.first
       ptest = first.product_test
       measures = ptest ? ptest.measures.top_level : Measure.top_level
-      start_date = ptest ? ptest.start_date : Time.at.utc(patients.first.bundle.effective_date)
-      end_date = ptest ? ptest.end_date : end_date.years_ago(1)
+      start_date = ptest ? ptest.start_date : Time.at(patients.first.bundle.effective_date).utc
+      end_date = ptest ? ptest.end_date : start_date + 1.year
       [measures, start_date, end_date]
     end
 


### PR DESCRIPTION
PatientZipper has 2 syntax errors that the current tests do not catch. The new test case in PatientZipperTest will error out without the corresponding fixes in PatientZipper