### PR TITLE
changed product status display

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,3 +15,6 @@ Style/Documentation:
   #   - 'app/helpers/application_helper.rb'
   #   - 'config/application.rb'
   #   - 'test/test_helper.rb'
+
+Rails/FindEach:
+  Enabled: false

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,4 +1,35 @@
 module ProductsHelper
+  # returns zero for all values if test is false
+  def checklist_status_values(test)
+    passing = failing = total = 0
+    return [passing, failing, total] unless test
+    passing = test.num_measures_complete
+    total = test.num_measures
+    failing = total - passing
+    [passing, failing, total]
+  end
+
+  def measure_test_status_values(tests, task_type)
+    passing = failing = not_started = total = 0
+    tasks = []
+    tests.each { |test| tasks << test.tasks.where(_type: task_type) }
+    unless tasks.empty?
+      passing = tasks.count { |task| task.first.status == 'passing' }
+      failing = tasks.count { |task| task.first.status == 'failing' }
+      not_started = tasks.count { |task| task.first.status == 'incomplete' }
+      total = tasks.count
+    end
+    [passing, failing, not_started, total]
+  end
+
+  def filtering_test_status_values(tests)
+    passing = failing = not_started = total = 0
+
+    # add content here when C4 tasks are finalized
+
+    [passing, failing, not_started, total]
+  end
+
   def status_from_tasks(tests_type, task_type)
     # tests_type can be a set of product tests
     # task_type is a string representing the task type e.g. "C1Task"

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -6,4 +6,17 @@ class ChecklistTest < ProductTest
     criterias = checked_criteria.select { |criteria| criteria.measure_id == measure_id.to_s }
     criterias.count(&:completed) == criterias.count
   end
+
+  def num_measures_complete
+    num_complete = 0
+    Measure.top_level.where(:hqmf_id.in => measure_ids).each do |measure|
+      criterias = checked_criteria.select { |criteria| criteria.measure_id == measure.id.to_s }
+      num_complete += 1 if criterias.count(&:completed) == criterias.count
+    end
+    num_complete
+  end
+
+  def num_measures
+    measure_ids.count
+  end
 end

--- a/app/views/products/_product_status_row.html.erb
+++ b/app/views/products/_product_status_row.html.erb
@@ -1,0 +1,41 @@
+<%
+
+# local variables:
+#
+#   product
+#   test_type  can be 'Checklist Test', 'Measure Tests', or 'Filtering Tests'
+#   task_type  can be 'C1', 'C2', or 'C4' (C3 will be included with C1 and/or C2)
+
+%>
+
+<% if test_type == 'Checklist Test' %>
+  <% passing, failing, total = checklist_status_values(product.product_tests.checklist_tests.first) %>
+<% elsif test_type == 'Measure Tests' %>
+  <% passing, failing, not_started, total = measure_test_status_values(product.product_tests.measure_tests, "#{task_type}Task") %>
+<% elsif test_type == 'Filtering Tests' %>
+  <% passing, failing, not_started, total = filtering_test_status_values(product.product_tests.checklist_tests) %>
+<% else %>
+  <% # no other test_type should be specified. please don't do this %>
+<% end %>
+
+<tr>
+  <td>
+    <% visibility = (passing == total) && (total != 0) ? '' : 'invisible' %>
+    <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
+    <% # include C3 if we are on C1 or C2 and product has C3 %>
+    <% task_type_display = @product.c3_test && ['C1', 'C2'].include?(task_type) ? "#{task_type}, C3" : task_type %>
+    <strong><%= task_type_display %></strong>
+  </td>
+  <td><%= test_type %></td>
+  <% passing_display = total == 0 ? '--' : "#{passing}/#{total}" %>
+  <td><strong class = 'text-success'><%= passing_display %></strong></td>
+  <% failing_display = failing == 0 ? '--' : "#{failing}/#{total}" %>
+  <td><strong class = 'text-danger'><%= failing_display %></strong></td>
+  <% if test_type == 'Checklist Test' %>
+    <td>--</td>
+  <% else %>
+    <% not_started_display = not_started == 0 ? '--' : "#{not_started}/#{total}" %>
+    <td><%= not_started_display %></td>
+  <% end %>
+  </td>
+</tr>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -3,24 +3,39 @@
   <h1><%= @product.name %></h1>
 
   <div class="row">
-    <div class = 'col-sm-6'>
-      <h2>Current Test Status</h2>
-      <table class="table table-hover table-condensed">
-        <% certifications(@product).each do |c, certification| %>
-          <% certification['tests'].each do |cert_test| %>
-          <tr>
-            <% unless cert_test != certification['tests'][0] %>
-            <th rowspan="<%= certification['tests'].length %>"><%= "#{c}" %></th>
-            <% end %>
-            <td><%= APP_CONFIG.tests[cert_test]['title'] %></td>
-            <td><%= status_by_test(@product)[cert_test][c] %></td>
-          </tr>
-          <% end %>
-        <% end %>
-      </table>
+
+    <div class = 'col-sm-8'>
+      <div class = 'panel panel-default'>
+        <div class = 'panel-heading'><h3>Product Status</h3></div>
+        <div class = 'panel-body'>
+          <table class = 'table table-hover table-condensed'>
+            <thead>
+              <tr>
+                <th class = 'col-sm-1'></th>
+                <th class = 'col-sm-2'></th>
+                <th class = 'col-sm-1'>Passing</th>
+                <th class = 'col-sm-1'>Failing</th>
+                <th class = 'col-sm-1'>Not Started</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if @product.c1_test %>
+                <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Checklist Test', task_type: 'C1' } %>
+                <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Measure Tests', task_type: 'C1' } %>
+              <% end %>
+              <% if @product.c2_test %>
+                <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Measure Tests', task_type: 'C2' } %>
+              <% end %>
+              <% if @product.c4_test %>
+                <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Filtering Tests', task_type: 'C4' } %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      </div>
     </div>
 
-    <div class = 'col-sm-6'>
+    <div class = 'col-sm-4'>
       <h2>Product Information</h2>
       <%= render partial: 'product_summary', locals: { product: @product } %>
     </div>

--- a/test/fixtures/measures/cypress3_measure_01.json
+++ b/test/fixtures/measures/cypress3_measure_01.json
@@ -1,0 +1,1437 @@
+{
+    "_id" : "5671b6df457b5f208d000026",
+    "id" : "40280381-43DB-D64C-0144-5571970A2685",
+    "nqf_id" : "1354",
+    "hqmf_id" : "40280381-43DB-D64C-0144-5571970A2685",
+    "hqmf_set_id" : "0924FBAE-3FDB-4D0A-AAB7-9F354E699FDE",
+    "hqmf_version_number" : 3,
+    "cms_id" : "CMS31v3",
+    "name" : "Hearing Screening Prior To Hospital Discharge",
+    "description" : "This measure assesses the proportion of births that have been screened for hearing loss before hospital discharge.",
+    "type" : "eh",
+    "category" : "Newborn",
+    "map_fn" : "function() {\n          var patient = this;\n          var effective_date = <%= effective_date %>;\n          var enable_logging = <%= enable_logging %>;\n          var enable_rationale = <%= enable_rationale %>;\n          var short_circuit = <%= short_circuit %>;\n\n        <% if (!test_id.nil? && test_id.class==Moped::BSON::ObjectId) %>\n          var test_id = new ObjectId(\"<%= test_id %>\");\n        <% else %>\n          var test_id = null;\n        <% end %>\n\n          hqmfjs = {}\n          <%= init_js_frameworks %>\n\n          hqmfjs.effective_date = effective_date;\n          hqmfjs.test_id = test_id;\n      \n          \n        var patient_api = new hQuery.Patient(patient);\n\n        \n        // #########################\n        // ##### DATA ELEMENTS #####\n        // #########################\n\n        hqmfjs.nqf_id = '1354';\n        hqmfjs.hqmf_id = '40280381-43DB-D64C-0144-5571970A2685';\n        hqmfjs.sub_id = null;\n        if (typeof(test_id) == 'undefined') hqmfjs.test_id = null;\n\n        OidDictionary = {'2.16.840.1.113883.3.117.1.7.1.309':{'SNOMED-CT':['371828006']},'2.16.840.1.114222.4.1.214079.1.1.3':{'LOINC':['54108-6']},'2.16.840.1.114222.4.1.214079.1.1.4':{'LOINC':['54109-4']},'2.16.840.1.113762.1.4.1046.6':{'ICD-9-CM':['V30.00','V30.01','V31.00','V31.01','V32.00','V32.01','V33.00','V33.01','V34.00','V34.01','V35.00','V35.01','V36.00','V36.01','V37.00','V37.01','V39.00','V39.01'],'ICD-10-CM':['Z38.00','Z38.01','Z38.30','Z38.31','Z38.61','Z38.68','Z38.69']},'2.16.840.1.114222.4.1.214079.1.1.1':{'SNOMED-CT':['15467003','169826009','169828005','169829002','169831006','169832004','169833009','22514005','25192009','281050002','30165006','34100008','38257001','390959009','39213008','87662006']},'2.16.840.1.114222.4.1.214079.1.1.6':{'SNOMED-CT':['164059009','183924009']},'2.16.840.1.114222.4.1.214079.1.1.7':{'SNOMED-CT':['397745006','397773008','410534003']},'2.16.840.1.113883.3.666.5.307':{'SNOMED-CT':['183452005','32485007','8715000']},'2.16.840.1.114222.4.11.837':{'CDC Race':['2135-2','2186-5']},'2.16.840.1.113762.1.4.1':{'AdministrativeSex':['F','M','U']},'2.16.840.1.114222.4.11.836':{'CDC Race':['1002-5','2028-9','2054-5','2076-8','2106-3','2131-1']},'2.16.840.1.114222.4.11.3591':{'Source of Payment Typology':['1','11','111','112','113','119','12','121','122','123','129','19','2','21','211','212','213','219','22','23','24','25','29','3','31','311','3111','3112','3113','3114','3115','3116','3119','312','3121','3122','3123','313','32','321','3211','3212','32121','32122','32123','32124','32125','32126','322','3221','3222','3223','3229','33','331','332','333','334','34','341','342','343','349','35','36','361','362','369','37','371','3711','3712','3713','372','379','38','381','3811','3812','3813','3819','382','389','39','4','41','42','43','44','5','51','511','512','513','514','515','519','52','521','522','523','529','53','54','55','59','6','61','611','612','613','619','62','63','64','69','7','71','72','73','79','8','81','82','821','822','823','83','84','85','89','9','91','92','93','94','95','951','953','954','959','96','98','99','9999']}};\n        \n        // Measure variables\nvar MeasurePeriod = {\n  \"low\": new TS(\"201201010000\", true),\n  \"high\": new TS(\"201212312359\", true)\n}\nhqmfjs.MeasurePeriod = function(patient) {\n  return [new hQuery.CodedEntry(\n    {\n      \"start_time\": MeasurePeriod.low.asDate().getTime()/1000,\n      \"end_time\": MeasurePeriod.high.asDate().getTime()/1000,\n      \"codes\": {}\n    }\n  )];\n}\nif (typeof effective_date === 'number') {\n  MeasurePeriod.high.date = new Date(1000*effective_date);\n  // add one minute before pulling off the year.  This turns 12-31-2012 23:59 into 1-1-2013 00:00 => 1-1-2012 00:00\n  MeasurePeriod.low.date = new Date(1000*(effective_date+60));\n  MeasurePeriod.low.date.setFullYear(MeasurePeriod.low.date.getFullYear()-1);\n}\n\n// Data critera\nhqmfjs.OccurrenceAEncounterInpatient1 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\", \"specificOccurrence\": \"OccurrenceAEncounterInpatient1\"};\n  var events = patient.getEvents(eventCriteria);\n  events.specificContext=new hqmf.SpecificOccurrence(Row.buildForDataCriteria(events.specific_occurrence, events))\n  return events;\n}\n\nhqmfjs.OccurrenceAEncounterInpatient1 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\", \"specificOccurrence\": \"OccurrenceAEncounterInpatient1\"};\n  var events = patient.getEvents(eventCriteria);\n  events.specificContext=new hqmf.SpecificOccurrence(Row.buildForDataCriteria(events.specific_occurrence, events))\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNotDoneMedicalReasons = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"negated\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.3\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  hqmf.SpecificsManager.setIfNull(events);\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNotDoneMedicalReasons2 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"negated\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.4\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  hqmf.SpecificsManager.setIfNull(events);\n  return events;\n}\n\nhqmfjs.EncounterPerformedEncounterInpatient = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\"};\n  var events = patient.getEvents(eventCriteria);\n  hqmf.SpecificsManager.setIfNull(events);\n  return events;\n}\n\nhqmfjs.PatientCharacteristicSexOncAdministrativeSex = function(patient, initialSpecificContext) {\n  var value = patient.gender() || null;\n  matching = matchingValue(value, new CD(\"F\", \"Administrative Sex\"));\n  matching.specificContext=hqmf.SpecificsManager.identity();\n  return matching;\n}\n\nhqmfjs.PatientCharacteristicRaceRace = function(patient, initialSpecificContext) {\n  var value = patient.race() || null;\n  matching = new Boolean(value.includedIn({\"CDC Race\":[\"1002-5\",\"2028-9\",\"2054-5\",\"2076-8\",\"2106-3\",\"2131-1\"]}));\n  matching.specificContext=hqmf.SpecificsManager.identity();\n  return matching;\n}\n\nhqmfjs.PatientCharacteristicEthnicityEthnicity = function(patient, initialSpecificContext) {\n  var value = patient.ethnicity() || null;\n  matching = matchingValue(value, null);\n  matching.specificContext=hqmf.SpecificsManager.identity();\n  return matching;\n}\n\nhqmfjs.PatientCharacteristicPayerPayer = function(patient, initialSpecificContext) {\n  var value = patient.payer() || null;\n  matching = matchingValue(value, null);\n  matching.specificContext=hqmf.SpecificsManager.identity();\n  return matching;\n}\n\nhqmfjs.OccurrenceAEncounterInpatient1_precondition_3 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\", \"specificOccurrence\": \"OccurrenceAEncounterInpatient1\"};\n  var events = patient.getEvents(eventCriteria);\n  if (events.length > 0 || !Logger.short_circuit) events = EDU(events, hqmfjs.MeasurePeriod(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosisActiveLivebornNewbornBornInHospital_precondition_5 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"allProblems\", \"statuses\": [\"active\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113762.1.4.1046.6\"};\n  var events = patient.getEvents(eventCriteria);\n  if (events.length > 0 || !Logger.short_circuit) events = SDU(events, hqmfjs.OccurrenceAEncounterInpatient1(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosisActiveLivebirth_precondition_7 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"allProblems\", \"statuses\": [\"active\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.1\"};\n  var events = patient.getEvents(eventCriteria);\n  if (events.length > 0 || !Logger.short_circuit) events = SDU(events, hqmfjs.OccurrenceAEncounterInpatient1(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.OccurrenceAEncounterInpatient1_precondition_22 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\", \"specificOccurrence\": \"OccurrenceAEncounterInpatient1\"};\n  var events = patient.getEvents(eventCriteria);\n  events.specificContext=new hqmf.SpecificOccurrence(Row.buildForDataCriteria(events.specific_occurrence, events))\n  return events;\n}\n\nhqmfjs.PatientCharacteristicExpiredPatientExpired_precondition_12 = function(patient, initialSpecificContext) {\n  var value = patient.expired() || null;\n  var events = value ? [patient.deathdate()] : [];\n  events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_22(patient));\n  events.specificContext=events.specificContext||hqmf.SpecificsManager.identity();\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_14 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.3\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_22(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_16 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.4\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_22(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.OccurrenceAEncounterInpatient1_precondition_38 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"encounters\", \"statuses\": [\"performed\"], \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.113883.3.666.5.307\", \"specificOccurrence\": \"OccurrenceAEncounterInpatient1\"};\n  var events = patient.getEvents(eventCriteria);\n  events.specificContext=new hqmf.SpecificOccurrence(Row.buildForDataCriteria(events.specific_occurrence, events))\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_25 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.3\"};\n  var events = patient.getEvents(eventCriteria);\n  events = filterEventsByValue(events, new CodeList(getCodes(\"2.16.840.1.114222.4.1.214079.1.1.6\")));\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_38(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_27 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"negated\": true, \"negationValueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.7\", \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.3\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_38(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_31 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.4\"};\n  var events = patient.getEvents(eventCriteria);\n  events = filterEventsByValue(events, new CodeList(getCodes(\"2.16.840.1.114222.4.1.214079.1.1.6\")));\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_38(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\nhqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_33 = function(patient, initialSpecificContext) {\n  var eventCriteria = {\"type\": \"procedureResults\", \"includeEventsWithoutStatus\": true, \"negated\": true, \"negationValueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.7\", \"valueSetId\": \"2.16.840.1.114222.4.1.214079.1.1.4\"};\n  var events = patient.getEvents(eventCriteria);\n  // force a check of results for result types so that performed does not bleed into results\n  events = filterEventsByValue(events, new ANYNonNull());\n  if (events.length > 0 || !Logger.short_circuit) events = DURING(events, hqmfjs.OccurrenceAEncounterInpatient1_precondition_38(patient));\n  if (events.length == 0) events.specificContext=hqmf.SpecificsManager.empty();\n  return events;\n}\n\n\n\n        // #########################\n        // ##### MEASURE LOGIC #####\n        // #########################\n        \n        hqmfjs.initializeSpecifics = function(patient_api, hqmfjs) { hqmf.SpecificsManager.initialize(patient_api,hqmfjs,{\"id\":\"OccurrenceAEncounterInpatient1\",\"type\":\"ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT\",\"function\":\"OccurrenceAEncounterInpatient1\"}) }\n\n        // INITIAL PATIENT POPULATION\n        hqmfjs.IPP = function(patient, initialSpecificContext) {\n  population_criteria_fn = allTrue('IPP', patient, initialSpecificContext,\n    allTrue('11', patient, initialSpecificContext, hqmfjs.OccurrenceAEncounterInpatient1_precondition_3,\n      atLeastOneTrue('9', patient, initialSpecificContext, hqmfjs.DiagnosisActiveLivebornNewbornBornInHospital_precondition_5, hqmfjs.DiagnosisActiveLivebirth_precondition_7\n      )\n    )\n  );\n  if (typeof(population_criteria_fn) == 'function') {\n  \treturn population_criteria_fn();\n  } else {\n  \treturn population_criteria_fn;\n  }\n};\n\n\n        // STRATIFICATION\n        hqmfjs.STRAT=null;\n        // DENOMINATOR\n        hqmfjs.DENOM = function(patient) { return new Boolean(true); }\n        // NUMERATOR\n        hqmfjs.NUMER = function(patient, initialSpecificContext) {\n  population_criteria_fn = allTrue('NUMER', patient, initialSpecificContext,\n    allTrue('40', patient, initialSpecificContext,\n      allTrue('37', patient, initialSpecificContext,\n        atLeastOneTrue('29', patient, initialSpecificContext, hqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_25, hqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_27\n        ),\n        atLeastOneTrue('35', patient, initialSpecificContext, hqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_31, hqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_33\n        )\n      )\n    )\n  );\n  if (typeof(population_criteria_fn) == 'function') {\n  \treturn population_criteria_fn();\n  } else {\n  \treturn population_criteria_fn;\n  }\n};\n\n\n        hqmfjs.DENEX = function(patient, initialSpecificContext) {\n  population_criteria_fn = atLeastOneTrue('DENEX', patient, initialSpecificContext,\n    allTrue('24', patient, initialSpecificContext,\n      allTrue('21', patient, initialSpecificContext, hqmfjs.PatientCharacteristicExpiredPatientExpired_precondition_12,\n        allFalse('20', patient, initialSpecificContext,\n          atLeastOneTrue('18', patient, initialSpecificContext, hqmfjs.DiagnosticStudyResultNewbornHearingScreenLeft_precondition_14, hqmfjs.DiagnosticStudyResultNewbornHearingScreenRight_precondition_16\n          )\n        )\n      )\n    )\n  );\n  if (typeof(population_criteria_fn) == 'function') {\n  \treturn population_criteria_fn();\n  } else {\n  \treturn population_criteria_fn;\n  }\n};\n\n\n        hqmfjs.DENEXCEP = function(patient) { return new Boolean(false); }\n        // CV\n        hqmfjs.MSRPOPL = function(patient) { return new Boolean(false); }\n        hqmfjs.OBSERV = function(patient) { return new Boolean(false); }\n        \n        \n        var occurrenceId = [\"OccurrenceAEncounterInpatient1\"];\n\n        hqmfjs.initializeSpecifics(patient_api, hqmfjs)\n        \n        var population = function() {\n          return executeIfAvailable(hqmfjs.IPP, patient_api);\n        }\n        var stratification = null;\n        if (hqmfjs.STRAT) {\n          stratification = function() {\n            return hqmf.SpecificsManager.setIfNull(executeIfAvailable(hqmfjs.STRAT, patient_api));\n          }\n        }\n        var denominator = function() {\n          return executeIfAvailable(hqmfjs.DENOM, patient_api);\n        }\n        var numerator = function() {\n          return executeIfAvailable(hqmfjs.NUMER, patient_api);\n        }\n        var exclusion = function() {\n          return executeIfAvailable(hqmfjs.DENEX, patient_api);\n        }\n        var denexcep = function() {\n          return executeIfAvailable(hqmfjs.DENEXCEP, patient_api);\n        }\n        var msrpopl = function() {\n          return executeIfAvailable(hqmfjs.MSRPOPL, patient_api);\n        }\n        var observ = function(specific_context) {\n          \n          var observFunc = hqmfjs.OBSERV\n          if (typeof(observFunc)==='function')\n            return observFunc(patient_api, specific_context);\n          else\n            return [];\n        }\n        \n        var executeIfAvailable = function(optionalFunction, patient_api) {\n          if (typeof(optionalFunction)==='function') {\n            result = optionalFunction(patient_api);\n            \n            return result;\n          } else {\n            return false;\n          }\n        }\n\n        \n        if (typeof Logger != 'undefined') {\n          // clear out logger\n          Logger.logger = [];\n          Logger.rationale={};\n          if (typeof short_circuit == 'undefined') short_circuit = true;\n        \n          // turn on logging if it is enabled\n          if (enable_logging || enable_rationale) {\n            injectLogger(hqmfjs, enable_logging, enable_rationale, short_circuit);\n          } else {\n            Logger.enable_rationale = false;\n          }\n        }\n\n        try {\n          map(patient, population, denominator, numerator, exclusion, denexcep, msrpopl, observ, occurrenceId,false,stratification);\n        } catch(err) {\n          print(err.stack);\n          throw err;\n        }\n\n        \n        };\n        ",
+    "continuous_variable" : false,
+    "episode_of_care" : true,
+    "hqmf_document" : {
+        "id" : "1354",
+        "hqmf_id" : "40280381-43DB-D64C-0144-5571970A2685",
+        "hqmf_set_id" : "0924FBAE-3FDB-4D0A-AAB7-9F354E699FDE",
+        "hqmf_version_number" : 3,
+        "title" : "Hearing Screening Prior To Hospital Discharge",
+        "description" : "This measure assesses the proportion of births that have been screened for hearing loss before hospital discharge.",
+        "cms_id" : "CMS31v3",
+        "population_criteria" : {
+            "IPP" : {
+                "conjunction?" : true,
+                "type" : "IPP",
+                "title" : "Initial Patient Population",
+                "hqmf_id" : "615C7A1C-6611-49BF-B1E1-DA7090E996F1",
+                "preconditions" : [ 
+                    {
+                        "id" : 11,
+                        "preconditions" : [ 
+                            {
+                                "id" : 3,
+                                "reference" : "OccurrenceAEncounterInpatient1_precondition_3"
+                            }, 
+                            {
+                                "id" : 9,
+                                "preconditions" : [ 
+                                    {
+                                        "id" : 5,
+                                        "reference" : "DiagnosisActiveLivebornNewbornBornInHospital_precondition_5"
+                                    }, 
+                                    {
+                                        "id" : 7,
+                                        "reference" : "DiagnosisActiveLivebirth_precondition_7"
+                                    }
+                                ],
+                                "conjunction_code" : "atLeastOneTrue"
+                            }
+                        ],
+                        "conjunction_code" : "allTrue"
+                    }
+                ]
+            },
+            "DENOM" : {
+                "conjunction?" : true,
+                "type" : "DENOM",
+                "title" : "Denominator",
+                "hqmf_id" : "E2CD7340-6780-4783-872E-8E96D23DEEC2"
+            },
+            "DENEX" : {
+                "conjunction?" : true,
+                "type" : "DENEX",
+                "title" : "Denominator",
+                "hqmf_id" : "857DE65C-41BE-4736-A765-6EEADED9FB8C",
+                "preconditions" : [ 
+                    {
+                        "id" : 24,
+                        "preconditions" : [ 
+                            {
+                                "id" : 21,
+                                "preconditions" : [ 
+                                    {
+                                        "id" : 12,
+                                        "reference" : "PatientCharacteristicExpiredPatientExpired_precondition_12"
+                                    }, 
+                                    {
+                                        "id" : 20,
+                                        "preconditions" : [ 
+                                            {
+                                                "id" : 18,
+                                                "preconditions" : [ 
+                                                    {
+                                                        "id" : 14,
+                                                        "reference" : "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_14"
+                                                    }, 
+                                                    {
+                                                        "id" : 16,
+                                                        "reference" : "DiagnosticStudyResultNewbornHearingScreenRight_precondition_16"
+                                                    }
+                                                ],
+                                                "conjunction_code" : "atLeastOneTrue"
+                                            }
+                                        ],
+                                        "conjunction_code" : "atLeastOneTrue",
+                                        "negation" : true
+                                    }
+                                ],
+                                "conjunction_code" : "allTrue"
+                            }
+                        ],
+                        "conjunction_code" : "allTrue"
+                    }
+                ]
+            },
+            "NUMER" : {
+                "conjunction?" : true,
+                "type" : "NUMER",
+                "title" : "Numerator",
+                "hqmf_id" : "4432C10C-8CDA-40E0-8A4B-2EC7CB70C404",
+                "preconditions" : [ 
+                    {
+                        "id" : 40,
+                        "preconditions" : [ 
+                            {
+                                "id" : 37,
+                                "preconditions" : [ 
+                                    {
+                                        "id" : 29,
+                                        "preconditions" : [ 
+                                            {
+                                                "id" : 25,
+                                                "reference" : "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_25"
+                                            }, 
+                                            {
+                                                "id" : 27,
+                                                "reference" : "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_27"
+                                            }
+                                        ],
+                                        "conjunction_code" : "atLeastOneTrue"
+                                    }, 
+                                    {
+                                        "id" : 35,
+                                        "preconditions" : [ 
+                                            {
+                                                "id" : 31,
+                                                "reference" : "DiagnosticStudyResultNewbornHearingScreenRight_precondition_31"
+                                            }, 
+                                            {
+                                                "id" : 33,
+                                                "reference" : "DiagnosticStudyResultNewbornHearingScreenRight_precondition_33"
+                                            }
+                                        ],
+                                        "conjunction_code" : "atLeastOneTrue"
+                                    }
+                                ],
+                                "conjunction_code" : "allTrue"
+                            }
+                        ],
+                        "conjunction_code" : "allTrue"
+                    }
+                ]
+            }
+        },
+        "data_criteria" : {
+            "OccurrenceAEncounterInpatient1" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "specific_occurrence" : "A",
+                "specific_occurrence_const" : "ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT",
+                "source_data_criteria" : "OccurrenceAEncounterInpatient1",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNotDoneMedicalReasons" : {
+                "title" : "Medical Reasons",
+                "description" : "Diagnostic Study, Result not done: Medical Reasons",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "source_data_criteria" : "DiagnosticStudyResultNotDoneMedicalReasons",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNotDoneMedicalReasons2" : {
+                "title" : "Medical Reasons",
+                "description" : "Diagnostic Study, Result not done: Medical Reasons",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "source_data_criteria" : "DiagnosticStudyResultNotDoneMedicalReasons2",
+                "variable" : false
+            },
+            "EncounterPerformedEncounterInpatient" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "EncounterPerformedEncounterInpatient",
+                "variable" : false
+            },
+            "PatientCharacteristicSexOncAdministrativeSex" : {
+                "title" : "ONC Administrative Sex",
+                "description" : "Patient Characteristic Sex: ONC Administrative Sex",
+                "code_list_id" : "2.16.840.1.113762.1.4.1",
+                "property" : "gender",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_gender",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicSexOncAdministrativeSex",
+                "variable" : false,
+                "value" : {
+                    "type" : "CD",
+                    "system" : "Administrative Sex",
+                    "code" : "F"
+                }
+            },
+            "PatientCharacteristicRaceRace" : {
+                "title" : "Race",
+                "description" : "Patient Characteristic Race: Race",
+                "code_list_id" : "2.16.840.1.114222.4.11.836",
+                "property" : "race",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_race",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicRaceRace",
+                "variable" : false,
+                "inline_code_list" : {
+                    "CDC Race" : [ 
+                        "1002-5", 
+                        "2028-9", 
+                        "2054-5", 
+                        "2076-8", 
+                        "2106-3", 
+                        "2131-1"
+                    ]
+                }
+            },
+            "PatientCharacteristicEthnicityEthnicity" : {
+                "title" : "Ethnicity",
+                "description" : "Patient Characteristic Ethnicity: Ethnicity",
+                "code_list_id" : "2.16.840.1.114222.4.11.837",
+                "property" : "ethnicity",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_ethnicity",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicEthnicityEthnicity",
+                "variable" : false,
+                "inline_code_list" : {
+                    "CDC Race" : [ 
+                        "2135-2", 
+                        "2186-5"
+                    ]
+                }
+            },
+            "PatientCharacteristicPayerPayer" : {
+                "title" : "Payer",
+                "description" : "Patient Characteristic Payer: Payer",
+                "code_list_id" : "2.16.840.1.114222.4.11.3591",
+                "property" : "payer",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_payer",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicPayerPayer",
+                "variable" : false,
+                "inline_code_list" : {
+                    "Source of Payment Typology" : [ 
+                        "1", 
+                        "11", 
+                        "111", 
+                        "112", 
+                        "113", 
+                        "119", 
+                        "12", 
+                        "121", 
+                        "122", 
+                        "123", 
+                        "129", 
+                        "19", 
+                        "2", 
+                        "21", 
+                        "211", 
+                        "212", 
+                        "213", 
+                        "219", 
+                        "22", 
+                        "23", 
+                        "24", 
+                        "25", 
+                        "29", 
+                        "3", 
+                        "31", 
+                        "311", 
+                        "3111", 
+                        "3112", 
+                        "3113", 
+                        "3114", 
+                        "3115", 
+                        "3116", 
+                        "3119", 
+                        "312", 
+                        "3121", 
+                        "3122", 
+                        "3123", 
+                        "313", 
+                        "32", 
+                        "321", 
+                        "3211", 
+                        "3212", 
+                        "32121", 
+                        "32122", 
+                        "32123", 
+                        "32124", 
+                        "32125", 
+                        "32126", 
+                        "322", 
+                        "3221", 
+                        "3222", 
+                        "3223", 
+                        "3229", 
+                        "33", 
+                        "331", 
+                        "332", 
+                        "333", 
+                        "334", 
+                        "34", 
+                        "341", 
+                        "342", 
+                        "343", 
+                        "349", 
+                        "35", 
+                        "36", 
+                        "361", 
+                        "362", 
+                        "369", 
+                        "37", 
+                        "371", 
+                        "3711", 
+                        "3712", 
+                        "3713", 
+                        "372", 
+                        "379", 
+                        "38", 
+                        "381", 
+                        "3811", 
+                        "3812", 
+                        "3813", 
+                        "3819", 
+                        "382", 
+                        "389", 
+                        "39", 
+                        "4", 
+                        "41", 
+                        "42", 
+                        "43", 
+                        "44", 
+                        "5", 
+                        "51", 
+                        "511", 
+                        "512", 
+                        "513", 
+                        "514", 
+                        "515", 
+                        "519", 
+                        "52", 
+                        "521", 
+                        "522", 
+                        "523", 
+                        "529", 
+                        "53", 
+                        "54", 
+                        "55", 
+                        "59", 
+                        "6", 
+                        "61", 
+                        "611", 
+                        "612", 
+                        "613", 
+                        "619", 
+                        "62", 
+                        "63", 
+                        "64", 
+                        "69", 
+                        "7", 
+                        "71", 
+                        "72", 
+                        "73", 
+                        "79", 
+                        "8", 
+                        "81", 
+                        "82", 
+                        "821", 
+                        "822", 
+                        "823", 
+                        "83", 
+                        "84", 
+                        "85", 
+                        "89", 
+                        "9", 
+                        "91", 
+                        "92", 
+                        "93", 
+                        "94", 
+                        "95", 
+                        "951", 
+                        "953", 
+                        "954", 
+                        "959", 
+                        "96", 
+                        "98", 
+                        "99", 
+                        "9999"
+                    ]
+                }
+            },
+            "OccurrenceAEncounterInpatient1_precondition_3" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "specific_occurrence" : "A",
+                "specific_occurrence_const" : "ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT",
+                "source_data_criteria" : "OccurrenceAEncounterInpatient1",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "EDU",
+                        "reference" : "MeasurePeriod"
+                    }
+                ]
+            },
+            "DiagnosisActiveLivebornNewbornBornInHospital_precondition_5" : {
+                "title" : "Liveborn Newborn Born in Hospital",
+                "description" : "Diagnosis, Active: Liveborn Newborn Born in Hospital",
+                "code_list_id" : "2.16.840.1.113762.1.4.1046.6",
+                "type" : "conditions",
+                "definition" : "diagnosis",
+                "status" : "active",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosisActiveLivebornNewbornBornInHospital",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "SDU",
+                        "reference" : "OccurrenceAEncounterInpatient1"
+                    }
+                ]
+            },
+            "DiagnosisActiveLivebirth_precondition_7" : {
+                "title" : "Livebirth",
+                "description" : "Diagnosis, Active: Livebirth",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.1",
+                "type" : "conditions",
+                "definition" : "diagnosis",
+                "status" : "active",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosisActiveLivebirth",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "SDU",
+                        "reference" : "OccurrenceAEncounterInpatient1"
+                    }
+                ]
+            },
+            "OccurrenceAEncounterInpatient1_precondition_22" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "specific_occurrence" : "A",
+                "specific_occurrence_const" : "ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT",
+                "source_data_criteria" : "OccurrenceAEncounterInpatient1",
+                "variable" : false
+            },
+            "PatientCharacteristicExpiredPatientExpired_precondition_12" : {
+                "title" : "Patient Expired",
+                "description" : "Patient Characteristic Expired: Patient Expired",
+                "code_list_id" : "2.16.840.1.113883.3.117.1.7.1.309",
+                "property" : "expired",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_expired",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicExpiredPatientExpired",
+                "variable" : false,
+                "inline_code_list" : {
+                    "SNOMED-CT" : [ 
+                        "371828006"
+                    ]
+                },
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_22"
+                    }
+                ]
+            },
+            "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_14" : {
+                "title" : "Newborn Hearing Screen Left",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Left",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenLeft",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_22"
+                    }
+                ]
+            },
+            "DiagnosticStudyResultNewbornHearingScreenRight_precondition_16" : {
+                "title" : "Newborn Hearing Screen Right",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Right",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenRight",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_22"
+                    }
+                ]
+            },
+            "OccurrenceAEncounterInpatient1_precondition_38" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "specific_occurrence" : "A",
+                "specific_occurrence_const" : "ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT",
+                "source_data_criteria" : "OccurrenceAEncounterInpatient1",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_25" : {
+                "title" : "Newborn Hearing Screen Left",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Left",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenLeft",
+                "variable" : false,
+                "value" : {
+                    "type" : "CD",
+                    "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.6",
+                    "title" : "result"
+                },
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_38"
+                    }
+                ]
+            },
+            "DiagnosticStudyResultNewbornHearingScreenLeft_precondition_27" : {
+                "title" : "Newborn Hearing Screen Left",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Left",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "negation_code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.7",
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenLeft",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_38"
+                    }
+                ]
+            },
+            "DiagnosticStudyResultNewbornHearingScreenRight_precondition_31" : {
+                "title" : "Newborn Hearing Screen Right",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Right",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenRight",
+                "variable" : false,
+                "value" : {
+                    "type" : "CD",
+                    "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.6",
+                    "title" : "result"
+                },
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_38"
+                    }
+                ]
+            },
+            "DiagnosticStudyResultNewbornHearingScreenRight_precondition_33" : {
+                "title" : "Newborn Hearing Screen Right",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Right",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "negation_code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.7",
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenRight",
+                "variable" : false,
+                "temporal_references" : [ 
+                    {
+                        "type" : "DURING",
+                        "reference" : "OccurrenceAEncounterInpatient1_precondition_38"
+                    }
+                ]
+            }
+        },
+        "source_data_criteria" : {
+            "OccurrenceAEncounterInpatient1" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "specific_occurrence" : "A",
+                "specific_occurrence_const" : "ENCOUNTER_PERFORMED_ENCOUNTER_INPATIENT",
+                "source_data_criteria" : "OccurrenceAEncounterInpatient1",
+                "variable" : false
+            },
+            "DiagnosisActiveLivebirth" : {
+                "title" : "Livebirth",
+                "description" : "Diagnosis, Active: Livebirth",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.1",
+                "type" : "conditions",
+                "definition" : "diagnosis",
+                "status" : "active",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosisActiveLivebirth",
+                "variable" : false
+            },
+            "DiagnosisActiveLivebornNewbornBornInHospital" : {
+                "title" : "Liveborn Newborn Born in Hospital",
+                "description" : "Diagnosis, Active: Liveborn Newborn Born in Hospital",
+                "code_list_id" : "2.16.840.1.113762.1.4.1046.6",
+                "type" : "conditions",
+                "definition" : "diagnosis",
+                "status" : "active",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosisActiveLivebornNewbornBornInHospital",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNewbornHearingScreenLeft" : {
+                "title" : "Newborn Hearing Screen Left",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Left",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenLeft",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNotDoneMedicalReasons" : {
+                "title" : "Medical Reasons",
+                "description" : "Diagnostic Study, Result not done: Medical Reasons",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.3",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "source_data_criteria" : "DiagnosticStudyResultNotDoneMedicalReasons",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNewbornHearingScreenRight" : {
+                "title" : "Newborn Hearing Screen Right",
+                "description" : "Diagnostic Study, Result: Newborn Hearing Screen Right",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "DiagnosticStudyResultNewbornHearingScreenRight",
+                "variable" : false
+            },
+            "DiagnosticStudyResultNotDoneMedicalReasons2" : {
+                "title" : "Medical Reasons",
+                "description" : "Diagnostic Study, Result not done: Medical Reasons",
+                "code_list_id" : "2.16.840.1.114222.4.1.214079.1.1.4",
+                "type" : "diagnostic_studies",
+                "definition" : "diagnostic_study_result",
+                "hard_status" : false,
+                "negation" : true,
+                "source_data_criteria" : "DiagnosticStudyResultNotDoneMedicalReasons2",
+                "variable" : false
+            },
+            "PatientCharacteristicExpiredPatientExpired" : {
+                "title" : "Patient Expired",
+                "description" : "Patient Characteristic Expired: Patient Expired",
+                "code_list_id" : "2.16.840.1.113883.3.117.1.7.1.309",
+                "property" : "expired",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_expired",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicExpiredPatientExpired",
+                "variable" : false,
+                "inline_code_list" : {
+                    "SNOMED-CT" : [ 
+                        "371828006"
+                    ]
+                }
+            },
+            "EncounterPerformedEncounterInpatient" : {
+                "title" : "Encounter Inpatient",
+                "description" : "Encounter, Performed: Encounter Inpatient",
+                "code_list_id" : "2.16.840.1.113883.3.666.5.307",
+                "type" : "encounters",
+                "definition" : "encounter",
+                "status" : "performed",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "EncounterPerformedEncounterInpatient",
+                "variable" : false
+            },
+            "PatientCharacteristicSexOncAdministrativeSex" : {
+                "title" : "ONC Administrative Sex",
+                "description" : "Patient Characteristic Sex: ONC Administrative Sex",
+                "code_list_id" : "2.16.840.1.113762.1.4.1",
+                "property" : "gender",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_gender",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicSexOncAdministrativeSex",
+                "variable" : false,
+                "value" : {
+                    "type" : "CD",
+                    "system" : "Administrative Sex",
+                    "code" : "F"
+                }
+            },
+            "PatientCharacteristicRaceRace" : {
+                "title" : "Race",
+                "description" : "Patient Characteristic Race: Race",
+                "code_list_id" : "2.16.840.1.114222.4.11.836",
+                "property" : "race",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_race",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicRaceRace",
+                "variable" : false,
+                "inline_code_list" : {
+                    "CDC Race" : [ 
+                        "1002-5", 
+                        "2028-9", 
+                        "2054-5", 
+                        "2076-8", 
+                        "2106-3", 
+                        "2131-1"
+                    ]
+                }
+            },
+            "PatientCharacteristicEthnicityEthnicity" : {
+                "title" : "Ethnicity",
+                "description" : "Patient Characteristic Ethnicity: Ethnicity",
+                "code_list_id" : "2.16.840.1.114222.4.11.837",
+                "property" : "ethnicity",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_ethnicity",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicEthnicityEthnicity",
+                "variable" : false,
+                "inline_code_list" : {
+                    "CDC Race" : [ 
+                        "2135-2", 
+                        "2186-5"
+                    ]
+                }
+            },
+            "PatientCharacteristicPayerPayer" : {
+                "title" : "Payer",
+                "description" : "Patient Characteristic Payer: Payer",
+                "code_list_id" : "2.16.840.1.114222.4.11.3591",
+                "property" : "payer",
+                "type" : "characteristic",
+                "definition" : "patient_characteristic_payer",
+                "hard_status" : false,
+                "negation" : false,
+                "source_data_criteria" : "PatientCharacteristicPayerPayer",
+                "variable" : false,
+                "inline_code_list" : {
+                    "Source of Payment Typology" : [ 
+                        "1", 
+                        "11", 
+                        "111", 
+                        "112", 
+                        "113", 
+                        "119", 
+                        "12", 
+                        "121", 
+                        "122", 
+                        "123", 
+                        "129", 
+                        "19", 
+                        "2", 
+                        "21", 
+                        "211", 
+                        "212", 
+                        "213", 
+                        "219", 
+                        "22", 
+                        "23", 
+                        "24", 
+                        "25", 
+                        "29", 
+                        "3", 
+                        "31", 
+                        "311", 
+                        "3111", 
+                        "3112", 
+                        "3113", 
+                        "3114", 
+                        "3115", 
+                        "3116", 
+                        "3119", 
+                        "312", 
+                        "3121", 
+                        "3122", 
+                        "3123", 
+                        "313", 
+                        "32", 
+                        "321", 
+                        "3211", 
+                        "3212", 
+                        "32121", 
+                        "32122", 
+                        "32123", 
+                        "32124", 
+                        "32125", 
+                        "32126", 
+                        "322", 
+                        "3221", 
+                        "3222", 
+                        "3223", 
+                        "3229", 
+                        "33", 
+                        "331", 
+                        "332", 
+                        "333", 
+                        "334", 
+                        "34", 
+                        "341", 
+                        "342", 
+                        "343", 
+                        "349", 
+                        "35", 
+                        "36", 
+                        "361", 
+                        "362", 
+                        "369", 
+                        "37", 
+                        "371", 
+                        "3711", 
+                        "3712", 
+                        "3713", 
+                        "372", 
+                        "379", 
+                        "38", 
+                        "381", 
+                        "3811", 
+                        "3812", 
+                        "3813", 
+                        "3819", 
+                        "382", 
+                        "389", 
+                        "39", 
+                        "4", 
+                        "41", 
+                        "42", 
+                        "43", 
+                        "44", 
+                        "5", 
+                        "51", 
+                        "511", 
+                        "512", 
+                        "513", 
+                        "514", 
+                        "515", 
+                        "519", 
+                        "52", 
+                        "521", 
+                        "522", 
+                        "523", 
+                        "529", 
+                        "53", 
+                        "54", 
+                        "55", 
+                        "59", 
+                        "6", 
+                        "61", 
+                        "611", 
+                        "612", 
+                        "613", 
+                        "619", 
+                        "62", 
+                        "63", 
+                        "64", 
+                        "69", 
+                        "7", 
+                        "71", 
+                        "72", 
+                        "73", 
+                        "79", 
+                        "8", 
+                        "81", 
+                        "82", 
+                        "821", 
+                        "822", 
+                        "823", 
+                        "83", 
+                        "84", 
+                        "85", 
+                        "89", 
+                        "9", 
+                        "91", 
+                        "92", 
+                        "93", 
+                        "94", 
+                        "95", 
+                        "951", 
+                        "953", 
+                        "954", 
+                        "959", 
+                        "96", 
+                        "98", 
+                        "99", 
+                        "9999"
+                    ]
+                }
+            }
+        },
+        "attributes" : [ 
+            {
+                "code" : "OTH",
+                "name" : "Finalized Date/Time",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Finalized Date/Time"
+                },
+                "value_obj" : {
+                    "type" : "TS"
+                }
+            }, 
+            {
+                "code" : "COPY",
+                "value" : "None",
+                "name" : "Copyright",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "COPY",
+                    "title" : "Copyright"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "MSRSCORE",
+                "name" : "Measure Scoring",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "MSRSCORE",
+                    "title" : "Measure Scoring"
+                },
+                "value_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.1.11.20367",
+                    "code" : "PROPOR",
+                    "title" : "Proportion"
+                }
+            }, 
+            {
+                "code" : "MSRTYPE",
+                "name" : "Measure Type",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "MSRTYPE",
+                    "title" : "Measure Type"
+                },
+                "value_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.1.11.20368",
+                    "code" : "PROCESS",
+                    "title" : "Process"
+                }
+            }, 
+            {
+                "code" : "STRAT",
+                "value" : "None",
+                "name" : "Stratification",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "STRAT",
+                    "title" : "Stratification"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "MSRADJ",
+                "value" : "None",
+                "name" : "Risk Adjustment",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "MSRADJ",
+                    "title" : "Risk Adjustment"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "MSRAGG",
+                "value" : "None",
+                "name" : "Rate Aggregation",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "MSRAGG",
+                    "title" : "Rate Aggregation"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "RAT",
+                "value" : "Birthing facility staff should review the effectiveness and timeliness of screening relative to nursery discharge. Benchmarks set within the EHCP may trigger hospital or jurisdictional compliance activities, such as re-writing of procedural guidelines or re-training of screening staff.",
+                "name" : "Rationale",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "RAT",
+                    "title" : "Rationale"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "Birthing facility staff should review the effectiveness and timeliness of screening relative to nursery discharge. Benchmarks set within the EHCP may trigger hospital or jurisdictional compliance activities, such as re-writing of procedural guidelines or re-training of screening staff.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "CRS",
+                "value" : "None",
+                "name" : "Clinical Recommendation Statement",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.3.560",
+                    "code" : "CRS",
+                    "title" : "Clinical Recommendation Statement"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "IDUR",
+                "value" : "An increase in the rate.",
+                "name" : "Improvement Notation",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.3.560",
+                    "code" : "IDUR",
+                    "title" : "Improvement Notation"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "An increase in the rate.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "1354",
+                "name" : "NQF ID Number",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "NQF ID Number"
+                },
+                "value_obj" : {
+                    "type" : "II",
+                    "root" : "2.16.840.1.113883.3.560.1",
+                    "extension" : "1354"
+                }
+            }, 
+            {
+                "code" : "DISC",
+                "value" : "None",
+                "name" : "Disclaimer",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "DISC",
+                    "title" : "Disclaimer",
+                    "original_text" : "Disclaimer"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "31",
+                "name" : "eMeasure Identifier",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "eMeasure Identifier"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "31",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "REF",
+                "value" : "HRSA Title V Block Grant MCHB Performance Measure: Percentage of newborns who have been screened for hearing before hospital discharge.",
+                "name" : "Reference",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "REF",
+                    "title" : "Reference"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "HRSA Title V Block Grant MCHB Performance Measure: Percentage of newborns who have been screened for hearing before hospital discharge.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "DEF",
+                "value" : "None",
+                "name" : "Definition",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.3.560",
+                    "code" : "DEF",
+                    "title" : "Definition"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "GUIDE",
+                "value" : "The measurement period is one calendar year but the reporting period is jurisdictionally defined.",
+                "name" : "Guidance",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.4",
+                    "code" : "GUIDE",
+                    "title" : "Guidance"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "The measurement period is one calendar year but the reporting period is jurisdictionally defined.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "None",
+                "name" : "Transmission Format",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Transmission Format"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "IPP",
+                "value" : "All live births discharged during the measurement time period born at a facility",
+                "name" : "Initial Patient Population",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.1063",
+                    "code" : "IPP",
+                    "original_text" : "Initial Patient Population"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "All live births discharged during the measurement time period born at a facility",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "DENOM",
+                "value" : "All live births discharged during the measurement time period born at a facility",
+                "name" : "Denominator",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.1063",
+                    "code" : "DENOM",
+                    "original_text" : "Denominator"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "All live births discharged during the measurement time period born at a facility",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "Patient deceased prior to discharge and has not received hearing screening.",
+                "name" : "Denominator Exclusions",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Denominator Exclusions"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "Patient deceased prior to discharge and has not received hearing screening.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "NUMER",
+                "value" : "All live births during the measurement time period born at a facility and screened for\nhearing loss prior to discharge, or not being screened due to medical reasons or medical exclusions.",
+                "name" : "Numerator",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.1063",
+                    "code" : "NUMER",
+                    "original_text" : "Numerator"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "All live births during the measurement time period born at a facility and screened for\nhearing loss prior to discharge, or not being screened due to medical reasons or medical exclusions.",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "Not applicable",
+                "name" : "Numerator Exclusions",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Numerator Exclusions"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "Not applicable",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "DENEXCEP",
+                "value" : "None",
+                "name" : "Denominator Exceptions",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.1063",
+                    "code" : "DENEXCEP",
+                    "original_text" : "Denominator Exceptions"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "None",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "MSRPOPL",
+                "value" : "Not applicable",
+                "name" : "Measure Population",
+                "code_obj" : {
+                    "type" : "CD",
+                    "system" : "2.16.840.1.113883.5.1063",
+                    "code" : "MSRPOPL",
+                    "original_text" : "Measure Population"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "Not applicable",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "Not applicable",
+                "name" : "Measure Observations",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Measure Observations"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "Not applicable",
+                    "media_type" : "text/plain"
+                }
+            }, 
+            {
+                "code" : "OTH",
+                "value" : "For every patient evaluated by this measure also identify payer, race, ethnicity and sex.",
+                "name" : "Supplemental Data Elements",
+                "code_obj" : {
+                    "type" : "CD",
+                    "null_flavor" : "OTH",
+                    "original_text" : "Supplemental Data Elements"
+                },
+                "value_obj" : {
+                    "type" : "ED",
+                    "value" : "For every patient evaluated by this measure also identify payer, race, ethnicity and sex.",
+                    "media_type" : "text/plain"
+                }
+            }
+        ],
+        "populations" : [ 
+            {
+                "IPP" : "IPP",
+                "DENOM" : "DENOM",
+                "NUMER" : "NUMER",
+                "DENEX" : "DENEX"
+            }
+        ],
+        "measure_period" : {
+            "type" : "IVL_TS",
+            "low" : {
+                "type" : "TS",
+                "value" : "201201010000",
+                "inclusive?" : true,
+                "derived?" : false
+            },
+            "high" : {
+                "type" : "TS",
+                "value" : "201212312359",
+                "inclusive?" : true,
+                "derived?" : false
+            },
+            "width" : {
+                "type" : "PQ",
+                "unit" : "a",
+                "value" : "1",
+                "inclusive?" : true,
+                "derived?" : false
+            }
+        }
+    },
+    "oids" : [ 
+        "2.16.840.1.113883.3.117.1.7.1.309", 
+        "2.16.840.1.114222.4.1.214079.1.1.3", 
+        "2.16.840.1.114222.4.1.214079.1.1.4", 
+        "2.16.840.1.113762.1.4.1046.6", 
+        "2.16.840.1.114222.4.1.214079.1.1.1", 
+        "2.16.840.1.114222.4.1.214079.1.1.6", 
+        "2.16.840.1.114222.4.1.214079.1.1.7", 
+        "2.16.840.1.113883.3.666.5.307", 
+        "2.16.840.1.114222.4.11.837", 
+        "2.16.840.1.113762.1.4.1", 
+        "2.16.840.1.114222.4.11.836", 
+        "2.16.840.1.114222.4.11.3591"
+    ],
+    "population_ids" : {
+        "IPP" : "615C7A1C-6611-49BF-B1E1-DA7090E996F1",
+        "DENOM" : "E2CD7340-6780-4783-872E-8E96D23DEEC2",
+        "DENEX" : "857DE65C-41BE-4736-A765-6EEADED9FB8C",
+        "NUMER" : "4432C10C-8CDA-40E0-8A4B-2EC7CB70C404"
+    },
+    "bundle_id" : {"$oid" : "4fdb62e01d41c820f6000001"}
+}


### PR DESCRIPTION
. now split into 'C1 Checklist', 'C1/C3 Measure Tests', 'C2/C3 Measure Tests', and 'C4 Filtering Tests'. each show the number of passing, failing, not started, and total tests. disabled Rails/FindEach for rubocop