### PR TITLE
Execution status display

### DIFF
--- a/app/assets/stylesheets/cypress/_test_executions.scss
+++ b/app/assets/stylesheets/cypress/_test_executions.scss
@@ -37,3 +37,14 @@
 .tab-content {
   margin-top: 1em;
 }
+
+.execution-status-table {
+
+  th, td {
+    text-align: center;
+  }
+
+  .highlight-row {
+    background-color: $gray-lighter;
+  }
+}

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -39,6 +39,18 @@ module TestExecutionsHelper
     end
   end
 
+  # returns the number of each type of error
+  def get_error_counts(task)
+    qrda = reporting = submit = total = 0
+    execution = task.most_recent_execution
+    return [qrda, reporting, submit, total] unless execution && execution.failing?
+    qrda = execution.qrda_errors.count
+    reporting = execution.reporting_errors.count
+    submit = TestExecution.find(execution.sibling_execution_id).execution_errors.count if execution.sibling_execution_id
+    total = qrda + reporting + submit
+    [qrda, reporting, submit, total]
+  end
+
   def get_select_history_message(execution, is_most_recent)
     msg = ''
     msg << 'Most Recent - ' if is_most_recent

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -45,7 +45,11 @@ module TestExecutionsHelper
     msg << execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p (%A)')
     msg << ' (passing)' if execution.passing?
     msg << ' (in progress)' if execution.incomplete?
-    msg << " (#{execution.execution_errors.count} errors)" if execution.failing?
+    if execution.failing?
+      num_errors = execution.execution_errors.count
+      num_errors += TestExecution.find(execution.sibling_execution_id).execution_errors.count if execution.sibling_execution_id
+      msg << " (#{num_errors} errors)"
+    end
     msg
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -12,6 +12,14 @@ class Task
   delegate :measures, :to => :product_test
   delegate :records, :to => :product_test
 
+  def passing?
+    status == 'passing'
+  end
+
+  def failing?
+    status == 'failing'
+  end
+
   def status
     Rails.cache.fetch("#{cache_key}/status") do
       report_status = 'incomplete'

--- a/app/views/test_executions/_execution_status_row.html.erb
+++ b/app/views/test_executions/_execution_status_row.html.erb
@@ -14,7 +14,7 @@
 
 <tr class = '<%= highlighter %>'>
   <td>
-    <% visibility = total == 0 && execution ? '' : 'invisible' %>
+    <% visibility = total == 0 && execution && execution.passing? ? '' : 'invisible' %>
     <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
     <strong><%= get_certification_types(task) %></strong>
   </td>

--- a/app/views/test_executions/_execution_status_row.html.erb
+++ b/app/views/test_executions/_execution_status_row.html.erb
@@ -1,0 +1,73 @@
+<%
+
+# local variables:
+#
+#   task
+#   is_current_task   true if this row has the same task as the current page
+
+%>
+
+<% qrda, reporting, submission, total = get_error_counts(task) %>
+<% execution = task.most_recent_execution %>
+
+<% highlighter = is_current_task && get_other_task(task) ? 'highlight-row' : '' %>
+
+<tr class = '<%= highlighter %>'>
+  <td>
+    <% visibility = total == 0 && execution ? '' : 'invisible' %>
+    <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
+    <strong><%= get_certification_types(task) %></strong>
+  </td>
+  <td>
+    <% if execution && execution.passing? %>
+      <strong class = 'text-success'>Passing</strong>
+    <% elsif execution && execution.failing? %>
+      <strong class = 'text-danger'>Failing</strong>
+    <% else %>
+      Not Started
+    <% end %>
+  </td>
+  <td>
+    <% if !execution || execution.incomplete? %>
+      --
+    <% elsif qrda == 0 %>
+      <strong class = 'text-success'>0</strong>
+    <% else %>
+      <strong class = 'text-danger'><%= qrda %></strong>
+    <% end %>
+  </td>
+  <td>
+    <% if !execution || execution.incomplete? %>
+      --
+    <% elsif reporting == 0 %>
+      <strong class = 'text-success'>0</strong>
+    <% else %>
+      <strong class = 'text-danger'><%= reporting %></strong>
+    <% end %>
+  </td>
+  <% if task.product_test.product.c3_test %>
+    <td>
+      <% if !execution || execution.incomplete? %>
+        --
+      <% elsif submission == 0 %>
+        <strong class = 'text-success'>0</strong>
+      <% else %>
+        <strong class = 'text-danger'><%= submission %></strong>
+      <% end %>
+    </td>
+  <% end %>
+  <td>
+    <% if execution %>
+      <%= execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p') %>
+    <% else %>
+      --
+    <% end %>
+  </td>
+  <td>
+    <% if task && !is_current_task %>
+      <% switch_text = 'start' %>
+      <% switch_text = 'view' if task.failing? || task.passing? %>
+      <%= link_to switch_text, "/tasks/#{task.id}/test_executions/new" %>
+    <% end %>
+  </td>
+</tr>

--- a/app/views/test_executions/_execution_status_table.html.erb
+++ b/app/views/test_executions/_execution_status_table.html.erb
@@ -1,0 +1,29 @@
+<%
+
+# local variable 'task' is required
+
+%>
+
+<table class = 'table table-condensed execution-status-table'>
+  <thead>
+    <tr>
+      <td class = 'col-sm-2'></td>
+      <td class = 'col-sm-1'></td>
+      <td class = 'col-sm-2'>QRDA Errors</td>
+      <td class = 'col-sm-2'>Reporting Errors</td>
+      <% if task.product_test.product.c3_test %>
+        <td class = 'col-sm-2'>Submission Errors</td>
+      <% end %>
+      <td class = 'col-sm-2'>Last Execution Date</td>
+      <td class = 'col-sm-1'></td>
+    </tr>
+  </thead>
+  <tbody>
+    <% if task.product_test.product.c1_test %>
+      <%= render partial: 'execution_status_row', locals: { task: task.product_test.c1_task, is_current_task: task._type == 'C1Task' } %>
+    <% end %>
+    <% if task.product_test.product.c2_test %>
+      <%= render partial: 'execution_status_row', locals: { task: task.product_test.c2_task, is_current_task: task._type == 'C2Task' } %>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/test_executions/show.erb
+++ b/app/views/test_executions/show.erb
@@ -7,30 +7,8 @@
 <h3 class = 'page-title'><%= "#{certification_types} certification for #{@product_test.cms_id} #{@product_test.name}" %></h3>
 
 <div class = 'row'>
-  <div class = 'col-sm-12'>
-    <table class = 'table table-condensed execution-status-table'>
-      <thead>
-        <tr>
-          <td class = 'col-sm-2'></td>
-          <td class = 'col-sm-1'></td>
-          <td class = 'col-sm-2'>QRDA Errors</td>
-          <td class = 'col-sm-2'>Reporting Errors</td>
-          <% if @task.product_test.product.c3_test %>
-            <td class = 'col-sm-2'>Submission Errors</td>
-          <% end %>
-          <td class = 'col-sm-2'>Last Execution Date</td>
-          <td class = 'col-sm-1'></td>
-        </tr>
-      </thead>
-      <tbody>
-        <% if @task.product_test.product.c1_test %>
-          <%= render partial: 'execution_status_row', locals: { task: @task.product_test.c1_task, is_current_task: @task._type == 'C1Task' } %>
-        <% end %>
-        <% if @task.product_test.product.c2_test %>
-          <%= render partial: 'execution_status_row', locals: { task: @task.product_test.c2_task, is_current_task: @task._type == 'C2Task' } %>
-        <% end %>
-      </tbody>
-    </table>
+  <div class = 'col-sm-12' id = 'execution_status_table'>
+    <%= render partial: 'execution_status_table', locals: { task: @task } %>
   </div>
 </div>
 

--- a/app/views/test_executions/show.erb
+++ b/app/views/test_executions/show.erb
@@ -7,24 +7,31 @@
 <h3 class = 'page-title'><%= "#{certification_types} certification for #{@product_test.cms_id} #{@product_test.name}" %></h3>
 
 <div class = 'row'>
-  <div class = 'col-sm-8'>
-    <div class = 'panel panel-default'>
-      <div class = 'panel-heading'>
-        Product Information
-      </div>
-      <div class = 'panel-body'>
-        <%= "Vendor: #{@product_test.product.vendor.name}" %><br/>
-        <p><%= "Product: #{@product_test.product.name}" %></p>
-      </div>
-    </div>
+  <div class = 'col-sm-12'>
+    <table class = 'table table-condensed execution-status-table'>
+      <thead>
+        <tr>
+          <td class = 'col-sm-2'></td>
+          <td class = 'col-sm-1'></td>
+          <td class = 'col-sm-2'>QRDA Errors</td>
+          <td class = 'col-sm-2'>Reporting Errors</td>
+          <% if @task.product_test.product.c3_test %>
+            <td class = 'col-sm-2'>Submission Errors</td>
+          <% end %>
+          <td class = 'col-sm-2'>Last Execution Date</td>
+          <td class = 'col-sm-1'></td>
+        </tr>
+      </thead>
+      <tbody>
+        <% if @task.product_test.product.c1_test %>
+          <%= render partial: 'execution_status_row', locals: { task: @task.product_test.c1_task, is_current_task: @task._type == 'C1Task' } %>
+        <% end %>
+        <% if @task.product_test.product.c2_test %>
+          <%= render partial: 'execution_status_row', locals: { task: @task.product_test.c2_task, is_current_task: @task._type == 'C2Task' } %>
+        <% end %>
+      </tbody>
+    </table>
   </div>
-
-  <% # if the other (c1 or c2) task exists, then display a button to switch to that task %>
-  <% if other_task %>
-    <div class = 'col-sm-4'>
-      <%= button_to "Switch to #{other_certification_types} certification", "/tasks/#{other_task.id}/test_executions/new", method: 'get', class: 'btn btn-default' %>
-    </div>
-  <% end %>
 </div>
 
 <div class = 'row'>

--- a/app/views/test_executions/show.js.erb
+++ b/app/views/test_executions/show.js.erb
@@ -8,6 +8,8 @@
   <% else %>
     <% # don't wait. just load the test executions %>
     $('#display_execution_results').html("<%= escape_javascript render partial: 'execution_results', locals: { execution: @test_execution } %>");
+    <% # load the status table after test execution is displayed %>
+    $('#execution_status_table').html("<%= escape_javascript render partial: 'execution_status_table', locals: { task: @task } %>");
   <% end %>
 
 <% elsif params[:partial] == 'execution_download' %>

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -34,11 +34,11 @@ And(/^the user views a product test for that product$/) do
 end
 
 And(/^the user switches to c2 certification$/) do
-  page.click_button 'Switch to C2 certification'
+  page.click_link 'start'
 end
 
 And(/^the user switches to c2 and c3 certification$/) do
-  page.click_button 'Switch to C2 and C3 certification'
+  page.click_link 'start'
 end
 
 And(/^the product test state is set to ready$/) do

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -36,6 +36,12 @@ class ProductsControllerTest < ActionController::TestCase
     assert_not_nil assigns(:product)
   end
 
+  test 'should create' do
+    post :create, vendor_id: Vendor.first, product: { name: 'test_product', c1_test: true, measure_ids: [Measure.first.id] }
+    assert_response :redirect
+    assert_not_nil assigns(:product)
+  end
+
   test 'should be able to update measures' do
     pt = Product.new(vendor: Vendor.first, name: 'test_product', c1_test: true)
 


### PR DESCRIPTION
added execution status display to tests execution page. table displays the number of qrda errors, reporting errors, submission errors, and date of most recent execution. table includes link to switch to sibling task (C2 for C1 task and vice versa). removed separate switch button. removed test execution information panel. fixed test execution history selector to include submission errors in total number of errors