### PR TITLE
Add browser tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :development, :test do
   gem 'scss_lint', require: false
   gem 'capybara'
   gem 'capybara-accessible'
+  gem 'selenium-webdriver', '2.48.0'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gem 'mongoid', '~> 5.0.0'
 # gem 'mongoid', '~> 4.0.2'
 gem 'bson_ext'
 
-gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'bump_mongoid'
+gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'bump_rubyzip'
 
 gem 'quality-measure-engine',
-    git: 'https://github.com/projectcypress/quality-measure-engine.git', branch: 'bump_mongoid'
+    git: 'https://github.com/projectcypress/quality-measure-engine.git', branch: 'bump_rubyzip'
 
 # Use faker to generate addresses
 gem 'faker', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,6 +380,11 @@ GEM
       rdoc (~> 4.0)
     select2-rails (4.0.1)
       thor (~> 0.14)
+    selenium-webdriver (2.48.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.6.0)
     simplecov (0.11.1)
       docile (~> 1.1.0)
@@ -494,6 +499,7 @@ DEPENDENCIES
   scss_lint
   sdoc (~> 0.4.0)
   select2-rails
+  selenium-webdriver (= 2.48.0)
   simplecov
   spring
   travis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/DatabaseCleaner/database_cleaner.git
-  revision: b87f00320f8aa0f7e499d183128f05ce29cedc33
+  revision: 49b314f688a5501429f50365086d8275489956b5
   specs:
     database_cleaner (1.5.1)
 
@@ -13,8 +13,8 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: e4f4f52a28efa4ba5fb48dee19a297ca90aae62d
-  branch: bump_mongoid
+  revision: b073e1bbe25a71c5582d1bcc6863691978508bf7
+  branch: bump_rubyzip
   specs:
     health-data-standards (3.6.1)
       activesupport (~> 4.2.0)
@@ -28,18 +28,20 @@ GIT
       nokogiri (~> 1.6.7.1)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
-      rubyzip (= 0.9.9)
+      rubyzip (>= 1.0.0)
       uuid (~> 2.3.7)
+      zip-zip
 
 GIT
   remote: https://github.com/projectcypress/quality-measure-engine.git
-  revision: e3f54c420ff52e74ff3c3da9790a46695829dfc5
-  branch: bump_mongoid
+  revision: 694184ec0de92c02a568ad406e12543cb0fe85ba
+  branch: bump_rubyzip
   specs:
     quality-measure-engine (3.1.1)
       delayed_job_mongoid (~> 2.2.0)
       mongoid (~> 5.0.0)
-      rubyzip (~> 0.9.9)
+      rubyzip (>= 1.0.0)
+      zip-zip
 
 GEM
   remote: https://rubygems.org/
@@ -80,31 +82,31 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
-    addressable (2.3.8)
+    addressable (2.4.0)
     ansi (1.5.0)
     arel (6.0.3)
-    ast (2.1.0)
+    ast (2.2.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    autoprefixer-rails (6.1.0.1)
+    autoprefixer-rails (6.2.3)
       execjs
       json
     backports (3.6.7)
     bcrypt (3.1.10)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass (3.3.5.1)
-      autoprefixer-rails (>= 5.0.0.1)
-      sass (>= 3.3.0)
-    brakeman (3.1.2)
+    bootstrap-sass (3.3.6)
+      autoprefixer-rails (>= 5.2.1)
+      sass (>= 3.3.4)
+    brakeman (3.1.4)
       erubis (~> 2.6)
       fastercsv (~> 1.5)
       haml (>= 3.0, < 5.0)
-      highline (~> 1.6)
+      highline (>= 1.6.20, < 2.0)
       multi_json (~> 1.2)
       ruby2ruby (>= 2.1.1, < 2.3.0)
       ruby_parser (~> 3.7.0)
-      safe_yaml
+      safe_yaml (>= 1.0)
       sass (~> 3.0)
       slim (>= 1.3.6, < 4.0)
       terminal-table (~> 1.4)
@@ -112,10 +114,10 @@ GEM
     bson (4.0.0)
     bson_ext (1.5.1)
     builder (3.2.2)
-    bundler-audit (0.3.1)
+    bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.2.0)
+    byebug (8.2.1)
     cancancan (1.13.1)
     capybara (2.5.0)
       mime-types (>= 1.16)
@@ -134,13 +136,13 @@ GEM
       carrierwave (>= 0.8.0, < 0.11.0)
       mongoid (>= 3.0, < 6.0)
       mongoid-grid_fs (>= 1.3, < 3.0)
-    childprocess (0.5.8)
+    childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.0)
-    coffee-rails (4.1.0)
+    coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
-      railties (>= 4.0.0, < 5.0)
+      railties (>= 4.0.0, < 5.1.x)
     coffee-script (2.4.1)
       coffee-script-source
       execjs
@@ -177,7 +179,7 @@ GEM
     domain_name (0.5.25)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    ethon (0.8.0)
+    ethon (0.8.1)
       ffi (>= 1.3.0)
     execjs (2.6.0)
     factory_girl (4.5.0)
@@ -212,11 +214,11 @@ GEM
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
-    iniparse (1.4.1)
+    iniparse (1.4.2)
     jasny-bootstrap-rails (3.1.3)
       railties (>= 3.0)
-    jbuilder (2.3.2)
-      activesupport (>= 3.0.0, < 5)
+    jbuilder (2.4.0)
+      activesupport (>= 3.0.0, < 5.1)
       multi_json (~> 1.2)
     jquery-datatables-rails (3.3.0)
       actionpack (>= 3.1)
@@ -248,7 +250,7 @@ GEM
     minitest-rails (2.2.0)
       minitest (~> 5.7)
       railties (~> 4.1)
-    minitest-reporters (1.1.5)
+    minitest-reporters (1.1.7)
       ansi
       builder
       minitest (>= 5.0)
@@ -282,7 +284,7 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     origin (2.1.1)
     orm_adapter (0.5.0)
-    overcommit (0.28.0)
+    overcommit (0.30.0)
       childprocess (~> 0.5.6)
       iniparse (~> 1.4)
     parser (2.2.3.0)
@@ -291,7 +293,7 @@ GEM
     pdf-reader (0.9.0)
       Ascii85 (>= 0.9)
     phantomjs (1.9.8.0)
-    poltergeist (1.8.0)
+    poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
@@ -304,9 +306,9 @@ GEM
       prawn (>= 1.3.0, < 3.0.0)
     protected_attributes (1.0.9)
       activemodel (>= 4.0.1, < 5.0)
-    pry (0.9.12.6)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
+    pry (0.10.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
       slop (~> 3.4)
     pusher-client (0.6.2)
       json
@@ -340,7 +342,8 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
     rake (10.5.0)
-    rdoc (4.2.0)
+    rdoc (4.2.1)
+      json (~> 1.4)
     responders (2.1.1)
       railties (>= 4.2.0, < 5.1)
     rest-client (1.8.0)
@@ -360,9 +363,9 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
-    rubyzip (0.9.9)
+    rubyzip (1.1.7)
     safe_yaml (1.0.4)
-    sass (3.4.19)
+    sass (3.4.21)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
       sass (~> 3.1)
@@ -378,7 +381,7 @@ GEM
     select2-rails (4.0.1)
       thor (~> 0.14)
     sexp_processor (4.6.0)
-    simplecov (0.10.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)
@@ -387,30 +390,28 @@ GEM
       temple (~> 0.7.3)
       tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
-    spring (1.4.1)
+    spring (1.6.2)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets-rails (3.0.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     systemu (2.6.5)
     temple (0.7.6)
     terminal-table (1.5.2)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.1)
+    tilt (2.0.2)
     tins (1.6.0)
-    travis (1.8.0)
-      addressable (~> 2.3)
+    travis (1.8.2)
       backports
       faraday (~> 0.9)
       faraday_middleware (~> 0.9, >= 0.9.1)
       gh (~> 0.13)
       highline (~> 1.6)
       launchy (~> 2.1)
-      pry (~> 0.9, < 0.10)
       pusher-client (~> 0.4)
       typhoeus (~> 0.6, >= 0.6.8)
     ttfunk (1.4.0)
@@ -441,6 +442,8 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,10 +19,10 @@ if ENV['IN_BROWSER']
   # IN_BROWSER=true bundle exec cucumber
   # or (to have a pause of 1 second between each step):
   # IN_BROWSER=true PAUSE=1 bundle exec cucumber
-  # FIXME this doesn't work yet
   Capybara.default_driver = :selenium
+  Capybara.default_driver = :accessible_selenium
   AfterStep do
-    sleep(ENV['PAUSE'] || 0).to_i
+    sleep(ENV['PAUSE'].to_i || 0)
   end
 else
   Capybara.default_driver    = :accessible_poltergeist


### PR DESCRIPTION
Surprise!

With this change you can run your Cucumber tests in a browser. This can be helpful in trying to understand what on earth your test is actually doing.

For example,
```
IN_BROWSER=true PAUSE=1 bundle exec cucumber -n "Successful Create Vendor"
```
The `PAUSE` adds time between the steps.