### PR TITLE
Add browser tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ group :development, :test do
   gem 'capybara'
   gem 'capybara-accessible'
   gem 'axe-matchers'
+  gem 'selenium-webdriver', '2.48.0'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,11 @@ GEM
       rdoc (~> 4.0)
     select2-rails (4.0.1)
       thor (~> 0.14)
+    selenium-webdriver (2.48.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sexp_processor (4.6.1)
     simplecov (0.11.1)
       docile (~> 1.1.0)
@@ -510,6 +515,7 @@ DEPENDENCIES
   scss_lint
   sdoc (~> 0.4.0)
   select2-rails
+  selenium-webdriver (= 2.48.0)
   simplecov
   spring
   travis

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 274a786e5b9f03ac4412a95d193a6198d35d8516
+  revision: fdbb91ab48048a72995060be34cd298e28d05b09
   branch: bump_mongoid
   specs:
     health-data-standards (3.6.1)
@@ -28,18 +28,20 @@ GIT
       nokogiri (~> 1.6.7.1)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
-      rubyzip (= 0.9.9)
+      rubyzip (>= 1.0.0)
       uuid (~> 2.3.7)
+      zip-zip
 
 GIT
   remote: https://github.com/projectcypress/quality-measure-engine.git
-  revision: 6cc278c0cd3e830daaa4cebf384ea297b0b35982
+  revision: 9f2efa88332acccd75bf92f55424583f173a3859
   branch: bump_mongoid
   specs:
     quality-measure-engine (3.1.1)
       delayed_job_mongoid (~> 2.2.0)
       mongoid (~> 5.0.0)
-      rubyzip (~> 0.9.9)
+      rubyzip (>= 1.0.0)
+      zip-zip
 
 GEM
   remote: https://rubygems.org/
@@ -101,7 +103,7 @@ GEM
     bootstrap-sass (3.3.6)
       autoprefixer-rails (>= 5.2.1)
       sass (>= 3.3.4)
-    brakeman (3.1.4)
+    brakeman (3.1.5)
       erubis (~> 2.6)
       fastercsv (~> 1.5)
       haml (>= 3.0, < 5.0)
@@ -120,9 +122,9 @@ GEM
     bundler-audit (0.4.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (8.2.1)
+    byebug (8.2.2)
     cancancan (1.13.1)
-    capybara (2.6.1)
+    capybara (2.6.2)
       addressable
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -180,7 +182,7 @@ GEM
       mongoid-compatibility
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (3.5.5)
+    devise (3.5.6)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 3.2.6, < 5)
@@ -189,7 +191,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20160128)
       unf (>= 0.0.5, < 1.0.0)
     dumb_delegator (0.8.0)
     equalizer (0.0.11)
@@ -199,7 +201,7 @@ GEM
     execjs (2.6.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.5.0)
+    factory_girl_rails (4.6.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
     faker (1.5.0)
@@ -307,7 +309,7 @@ GEM
     pdf-core (0.6.0)
     pdf-reader (0.9.0)
       Ascii85 (>= 0.9)
-    phantomjs (1.9.8.0)
+    phantomjs (2.1.1.0)
     poltergeist (1.8.1)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -376,7 +378,7 @@ GEM
       sexp_processor (~> 4.0)
     ruby_parser (3.7.3)
       sexp_processor (~> 4.1)
-    rubyzip (0.9.9)
+    rubyzip (1.1.7)
     safe_yaml (1.0.4)
     sass (3.4.21)
     sass-rails (5.0.4)
@@ -412,7 +414,7 @@ GEM
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.0.0)
+    sprockets-rails (3.0.1)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
@@ -451,7 +453,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
-    warden (1.2.4)
+    warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
       activemodel (>= 4.0)
@@ -464,6 +466,8 @@ GEM
     websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    zip-zip (0.3)
+      rubyzip (>= 1.0.0)
 
 PLATFORMS
   ruby
@@ -522,3 +526,6 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -21,10 +21,9 @@ if ENV['IN_BROWSER']
   # IN_BROWSER=true bundle exec cucumber
   # or (to have a pause of 1 second between each step):
   # IN_BROWSER=true PAUSE=1 bundle exec cucumber
-  # FIXME this doesn't work yet
-  Capybara.default_driver = :selenium
+  Capybara.default_driver = :accessible_selenium
   AfterStep do
-    sleep(ENV['PAUSE'] || 0).to_i
+    sleep(ENV['PAUSE'].to_i || 0)
   end
 else
   Capybara.default_driver    = :accessible_poltergeist

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+class HomeControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+
+  test 'should get index without logged in user' do
+    get :index
+    assert_response :redirect
+    assert_redirected_to controller: 'devise/sessions', action: 'new'
+  end
+
+  test 'should get index with logged in user' do
+    collection_fixtures('users')
+    sign_in User.first
+
+    get :index
+    assert_response :redirect
+    assert_redirected_to controller: 'vendors', action: 'index'
+  end
+end

--- a/test/controllers/vendors_controller_test.rb
+++ b/test/controllers/vendors_controller_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+class VendorsControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+
+  setup do
+    collection_fixtures('vendors', 'products', 'users')
+    sign_in User.first
+  end
+
+  test 'should get index' do
+    get :index
+    assert_response :success
+    assert assigns(:vendors)
+  end
+
+  test 'should get show' do
+    get :show, id: Vendor.first.id
+    assert_response :success
+    assert assigns(:vendor)
+    assert assigns(:products)
+  end
+
+  test 'should get new' do
+    get :new
+    assert_response :success
+    assert assigns(:vendor)
+  end
+end


### PR DESCRIPTION
(Hoping the new updates help).

Surprise!

With this change you can run your Cucumber tests in a browser. This can be helpful in trying to understand what on earth your test is actually doing.

For example,
```
IN_BROWSER=true PAUSE=1 bundle exec cucumber -n "Successful Create Vendor"
```
The `PAUSE` adds time between the steps.