### PR TITLE
Randomize records option at the product level

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -102,7 +102,8 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params[:product].permit(:name, :version, :description, :ehr_type, :c1_test, :c2_test, :c3_test, :c4_test, :measure_selection,
+    params[:product].permit(:name, :version, :description, :ehr_type, :randomize_records,
+                            :c1_test, :c2_test, :c3_test, :c4_test, :measure_selection,
                             product_tests_attributes: [:id, :name, :measure_ids, :bundle_id, :_destroy])
   end
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -16,6 +16,7 @@ class Product
   field :c2_test, type: Boolean
   field :c3_test, type: Boolean
   field :c4_test, type: Boolean
+  field :randomize_records, type: Boolean
   # field :measure_selection, type: String
 
   validates :name, presence: true,

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -49,9 +49,14 @@ class ProductTest
       pcv.value['medical_record_id']
     end
     ids.uniq!
-    random_ids = Record.where(test_id: nil).pluck('medical_record_number').uniq
-    Cypress::PopulationCloneJob.new('test_id' => id, 'patient_ids' => ids, 'randomization_ids' => random_ids,
-                                    'randomize_demographics' => true).perform
+
+    if product.randomize_records
+      random_ids = Record.where(test_id: nil).pluck('medical_record_number').uniq
+      Cypress::PopulationCloneJob.new('test_id' => id, 'patient_ids' => ids, 'randomization_ids' => random_ids,
+                                      'randomize_demographics' => true).perform
+    else
+      Cypress::PopulationCloneJob.new('test_id' => id, 'patient_ids' => ids, 'disable_randomization' => true).perform
+    end
   end
 
   def archive_records

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -22,6 +22,10 @@
           <%= f.check_box c.downcase + '_test', label: certification["title"], label_class: "btn btn-checkbox", disabled: params[:action] == "edit" %>
         <% end %>
       <% end %>
+
+      <%= f.form_group :randomize_records do %>
+        <%= f.check_box :randomize_records, label: 'Randomize Records', checked: true, disabled: params[:action] == "edit" %>
+      <% end %>
     </div>
 </div>
 

--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -44,6 +44,7 @@ module Cypress
     FORMAT_EXTENSIONS = { html: 'html', qrda: 'xml', json: 'json' }.freeze
 
     def self.zip(file, patients, format)
+      patients = apply_sort_to patients
       mes, sd, ed = mes_start_end(patients)
 
       formatter = if format.to_sym == :qrda
@@ -64,6 +65,14 @@ module Cypress
                  formatter.export(patient)
                end
         end
+      end
+    end
+
+    def self.apply_sort_to(patients)
+      if patients.is_a? Array
+        patients.sort_by { |p| p.first + '_' + p.last }
+      else
+        patients.order_by(:first.asc, :last.asc)
       end
     end
 

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -17,6 +17,10 @@ module Cypress
 
     def initialize(options)
       @options = options
+
+      if @options['disable_randomization']
+        %w(randomize_demographics generate_provider randomization_ids).each { |k| @options.delete k }
+      end
     end
 
     def perform
@@ -60,12 +64,12 @@ module Cypress
     def clone_and_save_record(record, date_shift = nil)
       cloned_patient = record.clone
       cloned_patient[:original_medical_record_number] = cloned_patient.medical_record_number
-      cloned_patient.medical_record_number = next_medical_record_number
+      cloned_patient.medical_record_number = next_medical_record_number unless options['disable_randomization']
       DemographicsRandomizer.randomize(cloned_patient) if options['randomize_demographics']
       cloned_patient.shift_dates(date_shift) if date_shift
       cloned_patient.test_id = options['test_id']
       patch_insurance_provider(record)
-      randomize_entry_ids(cloned_patient)
+      randomize_entry_ids(cloned_patient) unless options['disable_randomization']
       assign_provider(cloned_patient)
       cloned_patient.save!
     end

--- a/test/fixtures/products/product1.json
+++ b/test/fixtures/products/product1.json
@@ -4,6 +4,7 @@
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"},
   "name" : "Vendor 1 Product 1",
   "description" : "first product",
+  "randomize_records" : true,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/fixtures/products/product2.json
+++ b/test/fixtures/products/product2.json
@@ -3,6 +3,7 @@
   "user_ids" : ["4def93dd4f85cf8968000010"],
   "description" : "second product",
   "name" : "vendor2 product1",
+  "randomize_records" : true,
   "vendor_id" : {"$oid" : "4f636aba1d41c851eb00048c"}
 }
 

--- a/test/fixtures/products/product3.json
+++ b/test/fixtures/products/product3.json
@@ -3,6 +3,7 @@
   "user_ids" : ["4def93dd4f85cf8968000010"],
   "description" : "passing",
   "name" : "vendor1 product2",
+  "randomize_records" : true,
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"}
 }
 

--- a/test/fixtures/products/product4_with_mapped_measures.json
+++ b/test/fixtures/products/product4_with_mapped_measures.json
@@ -7,6 +7,7 @@
             "0002" : "MAPPED2"
         },
  "user_ids" : ["4def93dd4f85cf8968000010"],
+ "randomize_records" : true,
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"}
 }
 

--- a/test/fixtures/products/product5.json
+++ b/test/fixtures/products/product5.json
@@ -4,6 +4,7 @@
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000003"},
   "name" : "Vendor 1 Product 5",
   "description" : "fifth product",
+  "randomize_records" : true,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/fixtures/products/product6.json
+++ b/test/fixtures/products/product6.json
@@ -4,6 +4,7 @@
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000003"},
   "name" : "Vendor 1 Product 6",
   "description" : "fifth product",
+  "randomize_records" : true,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class ProductTestTest < ActiveJob::TestCase
   def setup
     collection_fixtures('patient_cache', 'records', 'bundles', 'measures')
-    vendor = Vendor.create(name: 'test_vendor_name')
-    @product = vendor.products.create(name: 'test_product', c2_test: true)
+    @vendor = Vendor.create(name: 'test_vendor_name')
+    @product = @vendor.products.create(name: 'test_product', c2_test: true, randomize_records: true)
   end
 
   def test_create
@@ -16,7 +16,31 @@ class ProductTestTest < ActiveJob::TestCase
     perform_enqueued_jobs do
       assert pt.save, 'should be able to save valid product test'
       assert_performed_jobs 1
+
       assert pt.records.count > 0, 'product test creation should have created random number of test records'
+      pt.reload
+      assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
+      assert_not_nil pt.expected_results, 'Product test should have expected results'
+    end
+  end
+
+  def test_create_without_randomized_records
+    @product = @vendor.products.create(name: 'test_product_no_random', c2_test: true, randomize_records: false)
+    assert_enqueued_jobs 0
+    pt = @product.product_tests.build(name: 'test_for_measure_1a',
+                                      measure_ids: ['0001'],
+                                      bundle_id: '4fdb62e01d41c820f6000001')
+    assert pt.valid?, 'product test should be valid with product, name, and measure_id'
+    perform_enqueued_jobs do
+      assert pt.save, 'should be able to save valid product test'
+      assert_performed_jobs 1
+
+      assert_equal 1, pt.records.count, 'product test creation should have created specific number of test records'
+      patient = pt.records.first
+      assert_equal 'Rosa', patient.first, 'Patient name should not be randomized'
+      assert_equal 'Vasquez', patient.last, 'Patient name should not be randomized'
+      assert_equal '20', patient.medical_record_number, 'Patient record # should not be randomized'
+
       pt.reload
       assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
       assert_not_nil pt.expected_results, 'Product test should have expected results'


### PR DESCRIPTION
Add a new checkbox to product creation screen that allows users to choose whether or not the test records should be randomized.

![randomize_record_checkbox](https://cloud.githubusercontent.com/assets/13512036/12676157/006205a0-c65e-11e5-88f6-233a3fc1e339.JPG)
