### PR TITLE
Added C3 Cat1 and C3 Cat3 to Product Status Display

### DIFF
--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -4,7 +4,7 @@ module VendorsHelper
 
     if statezip
       address = vendor.address? ? "#{vendor.address}, #{statezip}" : statezip
-    elsif vendor.address
+    elsif vendor.address != ''
       address = vendor.address.to_s
     end
 

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -39,4 +39,17 @@ class C1Task < Task
     patient_ids = product_test.results.where('value.IPP' => { '$gt' => 0 }).collect { |pc| pc.value.patient_id }
     product_test.records.in('_id' => patient_ids)
   end
+
+  # should only be used if product.c3_test is true
+  def c3_status
+    Rails.cache.fetch("#{cache_key}/status") do
+      report_status = 'incomplete'
+      recent_execution = most_recent_execution
+      if recent_execution
+        recent_c3_execution = TestExecution.find(recent_execution.sibling_execution_id)
+        report_status = recent_c3_execution.passing? ? 'passing' : 'failing'
+      end
+      report_status
+    end
+  end
 end

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -30,4 +30,17 @@ class C2Task < Task
     te.save
     te
   end
+
+  # should only be used if product.c3_test is true
+  def c3_status
+    Rails.cache.fetch("#{cache_key}/status") do
+      report_status = 'incomplete'
+      recent_execution = most_recent_execution
+      if recent_execution
+        recent_c3_execution = TestExecution.find(recent_execution.sibling_execution_id)
+        report_status = recent_c3_execution.passing? ? 'passing' : 'failing'
+      end
+      report_status
+    end
+  end
 end

--- a/app/models/c3_task.rb
+++ b/app/models/c3_task.rb
@@ -41,35 +41,4 @@ class C3Task < Task
     te.save
     te
   end
-
-  def status
-    Rails.cache.fetch("#{cache_key}/status") do
-      report_status = 'incomplete'
-      statuses = []
-      statuses << test_execution_status('Cat1') if has_cat_1
-      statuses << test_execution_status('Cat3') if has_cat_3
-      if statuses.include? 'failing'
-        report_status = 'failing'
-      elsif statuses.include? 'incomplete'
-        report_status = 'incomplete'
-      elsif statuses.size > 0
-        report_status = 'passing'
-      end
-      report_status
-    end
-  end
-
-  def test_execution_status(qrda_type)
-    if test_executions.where(qrda_type: qrda_type).order_by(created_at: 'desc').size > 0
-      recent_execution = test_executions.where(qrda_type: qrda_type).order_by(created_at: 'desc').first
-      if recent_execution.passing?
-        report_status = 'passing'
-      elsif recent_execution.failing?
-        report_status = 'failing'
-      end
-    else
-      report_status = 'incomplete'
-    end
-    report_status
-  end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,13 +25,9 @@ class Task
   def status
     Rails.cache.fetch("#{cache_key}/status") do
       report_status = 'incomplete'
-      if test_executions.exists? && test_executions.count > 0
-        recent_execution = test_executions.order_by(created_at: 'desc').first
-        if recent_execution.passing?
-          report_status = 'passing'
-        elsif recent_execution.failing?
-          report_status = 'failing'
-        end
+      recent_execution = most_recent_execution
+      if recent_execution
+        report_status = recent_execution.passing? ? 'passing' : 'failing'
       end
       report_status
     end
@@ -40,7 +36,45 @@ class Task
   # returns the most recent execution for this task
   # if there are none, returns false
   def most_recent_execution
-    return false unless test_executions.any?
-    test_executions.order_by(created_at: 'desc').first
+    test_executions.any? ? test_executions.order_by(created_at: 'desc').first : false
   end
+
+  # def status
+  #   report_status = 'incomplete'
+  #   statuses = [c1_c2_status]
+  #   statuses << c3_status if product_test.product.c3_test
+  #   report_status = 'failing' if statuses.any? { |stat| stat == 'failing' }
+  #   report_status = 'passing' if statuses.all? { |stat| stat == 'passing' }
+  #   report_status
+  # end
+
+  # def c1_c2_status
+  #   Rails.cache.fetch("#{cache_key}/status") do
+  #     report_status = 'incomplete'
+  #     if test_executions.exists? && test_executions.count > 0
+  #       recent_execution = test_executions.order_by(created_at: 'desc').first
+  #       if recent_execution.passing?
+  #         report_status = 'passing'
+  #       elsif recent_execution.failing?
+  #         report_status = 'failing'
+  #       end
+  #     end
+  #     report_status
+  #   end
+  # end
+
+  # # should only be used on c1 and c2 tasks
+  # # should only be used if product.c3_test is true
+  # def c3_status
+  #   report_status = 'incomplete'
+  #   if test_executions.exists? && test_executions.count > 0
+  #     recent_execution = TestExecution.find(test_executions.order_by(created_at: 'desc').first.sibling_execution_id)
+  #     if recent_execution.passing?
+  #       report_status = 'passing'
+  #     elsif recent_execution.failing?
+  #       report_status = 'failing'
+  #     end
+  #   end
+  #   report_status
+  # end
 end

--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -11,14 +11,16 @@
       <% end %>
     </div>
     <h3 class="summary-title"><%= @vendor.name %> <% if @vendor.vendor_id? %>(ID: <%= @vendor.vendor_id %>)<% end %></h3>
+
     <% if @vendor.url? %>
       <p><a href="<%= @vendor.url %>">Website</a>
     <% end %>
-    <% if formatted_vendor_address(@vendor) %>
-      | <%= formatted_vendor_address(@vendor) %>
-    <% end %>
-    <% unless @vendor.pocs.empty? %>
-      | <%= pluralize(@vendor.pocs.length, 'POC') %>
-    <% end %>
+
+    <% vendor_address = formatted_vendor_address(@vendor) %>
+    <%= ' | ' if vendor_address && @vendor.url? %>
+    <%= vendor_address if vendor_address %>
+
+    <%= ' | ' if !@vendor.pocs.empty? && (@vendor.url? || vendor_address) %>
+    <%= pluralize(@vendor.pocs.length, 'POC') unless @vendor.pocs.empty? %>
   </div>
 </div>

--- a/app/views/products/_product_status_row.html.erb
+++ b/app/views/products/_product_status_row.html.erb
@@ -2,17 +2,28 @@
 
 # local variables:
 #
-#   product
-#   test_type  can be 'Checklist Test', 'Measure Tests', or 'Filtering Tests'
-#   task_type  can be 'C1', 'C2', or 'C4' (C3 will be included with C1 and/or C2)
+#   product, test_type, cert_type, show_c3, test_display_name
+#
+#   variables should fit one of these combinations:
+#
+#   test_type     cert_type     show_c3
+#
+#   'checklist'   'C1'
+#   'measure'     'C1'
+#   'measure'     'C2'
+#   'measure'     'C1'          true
+#   'measure'     'C2'          true
+#   'filter'      'C4'
 
 %>
 
-<% if test_type == 'Checklist Test' %>
+<% show_c3 ||= false %>
+
+<% if test_type == 'checklist' %>
   <% passing, failing, total = checklist_status_values(product.product_tests.checklist_tests.first) %>
-<% elsif test_type == 'Measure Tests' %>
-  <% passing, failing, not_started, total = measure_test_status_values(product.product_tests.measure_tests, "#{task_type}Task") %>
-<% elsif test_type == 'Filtering Tests' %>
+<% elsif test_type == 'measure' %>
+  <% passing, failing, not_started, total = measure_test_status_values(product.product_tests.measure_tests, "#{cert_type}Task", show_c3) %>
+<% elsif test_type == 'filter' %>
   <% passing, failing, not_started, total = filtering_test_status_values(product.product_tests.filtering_tests) %>
 <% else %>
   <% # no other test_type should be specified. please don't do this %>
@@ -22,16 +33,14 @@
   <td>
     <% visibility = (passing == total) && (total != 0) ? '' : 'invisible' %>
     <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
-    <% # include C3 if we are on C1 or C2 and product has C3 %>
-    <% task_type_display = @product.c3_test && ['C1', 'C2'].include?(task_type) ? "#{task_type}, C3" : task_type %>
-    <strong><%= task_type_display %></strong>
+    <strong><%= show_c3 ? 'C3' : cert_type %></strong>
   </td>
-  <td><%= test_type %></td>
+  <td><%= test_display_name %></td>
   <% passing_display = total == 0 ? '--' : "#{passing}/#{total}" %>
   <td><strong class = 'text-success'><%= passing_display %></strong></td>
   <% failing_display = failing == 0 ? '--' : "#{failing}/#{total}" %>
   <td><strong class = 'text-danger'><%= failing_display %></strong></td>
-  <% if test_type == 'Checklist Test' %>
+  <% if test_type == 'checklist' %>
     <td>--</td>
   <% else %>
     <% not_started_display = not_started == 0 ? '--' : "#{not_started}/#{total}" %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,30 +1,35 @@
 <%= render partial: 'header_product', locals: { product: @product } %>
 
 <div class="row">
+
   <div class = 'col-sm-8'>
     <div class = 'panel panel-default'>
-      <div class = 'panel-heading'><h3 class='panel-title'>Product Status</h3></div>
+      <div class = 'panel-heading'><h3 class = 'panel-title'>Product Status</h3></div>
       <div class = 'panel-body'>
         <table class = 'table table-hover table-condensed'>
           <thead>
             <tr>
-              <th scope="col" class = 'col-sm-1'></th>
-              <th scope="col" class = 'col-sm-2'></th>
-              <th scope="col" class = 'col-sm-1'>Passing</th>
-              <th scope="col" class = 'col-sm-1'>Failing</th>
-              <th scope="col" class = 'col-sm-1'>Not Started</th>
+              <th scope = 'col' class = 'col-sm-1'></th>
+              <th scope = 'col' class = 'col-sm-2'></th>
+              <th scope = 'col' class = 'col-sm-1'>Passing</th>
+              <th scope = 'col' class = 'col-sm-1'>Failing</th>
+              <th scope = 'col' class = 'col-sm-1'>Not Started</th>
             </tr>
           </thead>
           <tbody>
             <% if @product.c1_test %>
-              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Checklist Test', task_type: 'C1' } %>
-              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Measure Tests', task_type: 'C1' } %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'checklist', cert_type: 'C1', test_display_name: 'Manual Entry' } %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'measure', cert_type: 'C1', test_display_name: 'Measure Tests' } %>
             <% end %>
             <% if @product.c2_test %>
-              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Measure Tests', task_type: 'C2' } %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'measure', cert_type: 'C2', test_display_name: 'Measure Tests' } %>
+            <% end %>
+            <% if @product.c3_test %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'measure', cert_type: 'C1', test_display_name: 'Cat 1 Measure Tests', show_c3: true } if @product.c1_test %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'measure', cert_type: 'C2', test_display_name: 'Cat 3 Measure Tests', show_c3: true } if @product.c2_test %>
             <% end %>
             <% if @product.c4_test %>
-              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'Filtering Tests', task_type: 'C4' } %>
+              <%= render partial: 'product_status_row', locals: { product: @product, test_type: 'filter', cert_type: 'C4', test_display_name: 'Filtering Tests' } %>
             <% end %>
           </tbody>
         </table>
@@ -44,6 +49,7 @@
       </div>
     <% end %>
   </div>
+
 </div>
 
 <div class="product-test-tabs">

--- a/test/models/filtering_test_test.rb
+++ b/test/models/filtering_test_test.rb
@@ -45,8 +45,10 @@ class FilteringTestTest < ActiveJob::TestCase
   end
 
   def test_task_status_with_existing_tasks
-    test = @product.product_tests.create({}, FilteringTest)
-    test.create_tasks
+    # valid filter test should call create_tasks after filter test is created
+    test = @product.product_tests.create!({ name: 'test_for_measure_1a',
+                                            measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'],
+                                            bundle_id: '4fdb62e01d41c820f6000001', options: { 'filters' => {} } }, FilteringTest)
     test.tasks.first.test_executions.build(:state => :passed).save!
 
     assert_equal 'passing', test.task_status('Cat1FilterTask')


### PR DESCRIPTION
separated (c1,c3) and (c2,c3) measure tests into c1, c3 cat1, c2, c3 cat3 for product status display.
fixed issue with measure_tests table not reporting the status of c3 test executions (used to just report status of c1 or c2).

fixed issue on vendor show page. spacer " | " was showing up in inappropriate situations