### PR TITLE
Move highlight to right side instead of left to avoid the shiftiness in the checkboxes.

### DIFF
--- a/app/assets/stylesheets/cypress/_buttons.scss
+++ b/app/assets/stylesheets/cypress/_buttons.scss
@@ -74,7 +74,7 @@
 
   &.active,
   &:active {
-    border-left: 8px solid $brand-primary;
+    border-right: 8px solid $brand-primary;
     background-color: $body-bg;
     color: $gray-darker;
   }


### PR DESCRIPTION
![cert-checkbox-shift](https://cloud.githubusercontent.com/assets/329127/12756675/ca68e3c2-c9a2-11e5-8194-a56ea5b17074.gif)
 

Does also change the checkboxes in the measure select.

![measure-checkbox-shift](https://cloud.githubusercontent.com/assets/329127/12756724/fceaa826-c9a2-11e5-8e93-3630247cb027.gif)
