### PR TITLE
ensure that deleting a bundle deletes all the associated pieces

### DIFF
--- a/config/initializers/mongo.rb
+++ b/config/initializers/mongo.rb
@@ -1,0 +1,17 @@
+module QME
+  patient_cache = Mongoid.default_client['patient_cache']
+  # create a unique index for patient cache, this prevents a race condition where the same patient can be entered multiple times for a patient
+  patient_cache.indexes.create_one({ 'value.measure_id' => 1, 'value.sub_id' => 1, 'value.effective_date' => 1, 'value.patient_id' => 1 },
+                                   'unique' => true)
+
+  patient_cache.indexes.create_one('value.last' => 1)
+
+  base_fields = [['value.measure_id', 1], ['value.sub_id', 1], ['value.effective_date', 1], ['value.test_id', 1], ['value.manual_exclusion', 1]]
+
+  %w(population denominator numerator antinumerator exclusions).each do |group|
+    patient_cache.indexes.create_one(Hash[*base_fields.clone.concat([["value.#{group}", 1]]).flatten(1)], name: "#{group}_index")
+  end
+
+  # Make sure we're indexing records by test_id so we can find them quickly during measure calculation
+  Mongoid.default_client['records'].indexes.create_one('value.test_id' => 1)
+end

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -8,8 +8,8 @@ class Bundle
                                           .order_by(['value.last', :asc])
   end
 
-  def delete(options = {})
-    super
+  def destroy
     results.destroy
+    delete
   end
 end

--- a/test/controllers/bundles_controller_test.rb
+++ b/test/controllers/bundles_controller_test.rb
@@ -3,7 +3,7 @@ class BundlesControllerTest < ActionController::TestCase
   include Devise::TestHelpers
 
   setup do
-    collection_fixtures('bundles', 'users')
+    collection_fixtures('bundles', 'measures', 'records', 'users')
     enable_page
     sign_in User.first
   end
@@ -63,13 +63,17 @@ class BundlesControllerTest < ActionController::TestCase
   end
 
   test 'should be able to remove bundle' do
-    orig_count = Bundle.count
+    orig_bundle_count = Bundle.count
+    orig_measure_count = Measure.count
+    orig_record_count = Record.count
     id = Bundle.first._id
 
     delete :destroy, id: id
 
     assert_equal 0, Bundle.where(_id: id).count, 'Should have deleted bundle'
-    assert_equal orig_count - 1, Bundle.count, 'Should have deleted Bundle'
+    assert_equal orig_bundle_count - 1, Bundle.count, 'Should have deleted Bundle'
+    assert orig_measure_count > Measure.count, 'Should have removed measures in the bundle'
+    assert orig_record_count > Record.count, 'Should have removed records in the bundle'
   end
 
   test 'should not import new bundle when page disabled' do
@@ -106,7 +110,7 @@ class BundlesControllerTest < ActionController::TestCase
 
     delete :destroy, id: id
 
-    assert_equal 1, Bundle.where(_id: id).count, 'Should have deleted bundle'
-    assert_equal orig_count, Bundle.count, 'Should have deleted Bundle'
+    assert_equal 1, Bundle.where(_id: id).count, 'Should not have deleted bundle'
+    assert_equal orig_count, Bundle.count, 'Should not have deleted Bundle'
   end
 end


### PR DESCRIPTION
associated pieces being measures, patient cache, records.

note: initializers/mongo.rb came from cypress2 and needed some cleanup but there is probably more that could be done - open to suggestions