### PR TITLE
Parallelize tests to speed up cucumber testing in development.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -85,6 +85,7 @@ group :development, :test do
   gem 'capybara-accessible'
   gem 'axe-matchers'
   gem 'selenium-webdriver', '2.48.0'
+  gem "parallel_tests", group: :development
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -85,7 +85,7 @@ group :development, :test do
   gem 'capybara-accessible'
   gem 'axe-matchers'
   gem 'selenium-webdriver', '2.48.0'
-  gem "parallel_tests", group: :development
+  gem 'parallel_tests'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -304,6 +304,9 @@ GEM
     overcommit (0.31.0)
       childprocess (~> 0.5.8)
       iniparse (~> 1.4)
+    parallel (1.6.1)
+    parallel_tests (2.4.0)
+      parallel
     parser (2.3.0.2)
       ast (~> 2.2)
     pdf-core (0.6.0)
@@ -506,6 +509,7 @@ DEPENDENCIES
   mongoid (~> 5.0.0)
   nested_form
   overcommit
+  parallel_tests
   pdf-reader (= 0.9.0)
   phantomjs
   poltergeist
@@ -528,4 +532,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.10.6

--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -16,7 +16,7 @@ measure_eval:
 test:
   clients:
     default:
-      database: cypress_test
+      database: cypress_test<%= ENV['TEST_ENV_NUMBER'] %>
       hosts:
         - <%= ENV['TEST_DB_HOST'] || 'localhost' %>:27017
 production:


### PR DESCRIPTION
Parallelize cucumber tests in development if you use `bundle exec rake parallel:features` 