### PR TITLE
Execution Error Total Includes Submission Errors

### DIFF
--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -25,7 +25,7 @@
   <% should_display_c3 = execution.task.product_test.product.c3_test && execution.task.product_test._type == 'MeasureTest' %>
   <% submit_errors = should_display_c3 ? TestExecution.find(execution.sibling_execution_id).execution_errors : [] %>
 
-  <h4><i class="fa fa-fw fa-times-circle text-danger"></i><%= " Failed with #{execution.execution_errors.count} errors" %></h4>
+  <h4><i class="fa fa-fw fa-times-circle text-danger"></i><%= " Failed with #{qrda_errors.count + report_errors.count + submit_errors.count} errors" %></h4>
   <ul class = 'nav nav-tabs'>
     <li class = 'active'>
       <a data-toggle = 'tab' class = 'tab' href = <%= "#QRDA_tab_execution_#{execution.id}" %>>


### PR DESCRIPTION
fixed the number of errors on test execution results section to include submission errors

<img width="1126" alt="screen shot 2016-02-18 at 11 42 10 am" src="https://cloud.githubusercontent.com/assets/14349011/13150659/b4447ea0-d634-11e5-94d3-106c62fed1ee.png">
