### PR TITLE
Additional NPI/TIN filter test

### DIFF
--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -20,9 +20,7 @@ module FilteringTestsHelper
     arr = []
     arr << "NPIS: #{val.npis.join(', ')}"
     arr << "TINS: #{val.tins.join(', ')}"
-    val.addresses.each do |address|
-      arr << address.map { |_k, v| v }.join(', ')
-    end
+    val.addresses.each { |address| arr << address.map { |_k, v| v }.join(', ') } if val.key?('addresses') || val.key?(:addresses)
     arr.join(' | ')
   end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -71,6 +71,7 @@ module ProductsHelper
     test = filter_tests.pop
     test.generate_records
     test.save
+    test.queued
     ProductTestSetupJob.perform_later(test)
     records = test.records
     filter_tests.each do |ft|
@@ -81,6 +82,7 @@ module ProductsHelper
         r2
       end
       ft.save
+      ft.queued
       ProductTestSetupJob.perform_later(ft)
     end
   end

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -1,5 +1,7 @@
 class FilteringTest < ProductTest
   field :options, type: Hash
+  field :incl_addr, type: Boolean
+  field :display_name, type: String
   accepts_nested_attributes_for :tasks
 
   after_create :create_tasks
@@ -69,7 +71,9 @@ class FilteringTest < ProductTest
       addresses << { 'street' => address.street, 'city' => address.city, 'state' => address.state, 'zip' => address.zip,
                      'country' => address.country }
     end
-    { 'npis' => [provider.npi], 'tins' => [provider.tin], 'addresses' => addresses }
+
+    return { 'npis' => [provider.npi], 'tins' => [provider.tin], 'addresses' => addresses } if incl_addr
+    { 'npis' => [provider.npi], 'tins' => [provider.tin] }
   end
 
   def lookup_problem
@@ -86,11 +90,7 @@ class FilteringTest < ProductTest
       end
     end
 
-    if code_list_id.empty?
-      fallback_id
-    else
-      code_list_id
-    end
+    code_list_id.empty? ? fallback_id : code_list_id
   end
 
   # Final Rule defines 9 different criteria that can be filtered:

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -97,8 +97,8 @@ class Product
       filter_tests = []
       filter_tests << build_filtering_test(measure, criteria[0, 2])
       filter_tests << build_filtering_test(measure, criteria[2, 2])
-      filter_tests << build_filtering_test(measure, ['providers'])
-
+      filter_tests << build_filtering_test(measure, ['providers'], 'Providers 1')
+      filter_tests << build_filtering_test(measure, ['providers'], 'Providers 2', false)
       filter_tests << if ApplicationController.helpers.measure_has_diagnosis_criteria?(measure)
                         build_filtering_test(measure, ['problems'])
                       else
@@ -111,10 +111,10 @@ class Product
     end
   end
 
-  def build_filtering_test(measure, criteria)
+  def build_filtering_test(measure, criteria, display_name = '', incl_addr = true)
     # construct options hash from criteria array and create the test
     options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
     product_tests.create({ name: measure.name, product: self, measure_ids: [measure.hqmf_id], cms_id: measure.cms_id,
-                           bundle_id: measure.bundle_id, options: options }, FilteringTest)
+                           bundle_id: measure.bundle_id, incl_addr: incl_addr, display_name: display_name, options: options }, FilteringTest)
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -97,8 +97,8 @@ class Product
       filter_tests = []
       filter_tests << build_filtering_test(measure, criteria[0, 2])
       filter_tests << build_filtering_test(measure, criteria[2, 2])
-      filter_tests << build_filtering_test(measure, ['providers'], 'Providers 1')
-      filter_tests << build_filtering_test(measure, ['providers'], 'Providers 2', false)
+      filter_tests << build_filtering_test(measure, ['providers'], 'NPI, TIN & Provider Location')
+      filter_tests << build_filtering_test(measure, ['providers'], 'NPI & TIN', false)
       filter_tests << if ApplicationController.helpers.measure_has_diagnosis_criteria?(measure)
                         build_filtering_test(measure, ['problems'])
                       else

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -21,7 +21,7 @@
           <% if test.display_name.to_s == '' %>
             <%= test.options.filters.keys.join('/').titleize %>
           <% else %>
-            <%= test.display_name.titleize %>
+            <%= test.display_name %>
           <% end %>
         </td>
         <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task } %></td>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -18,7 +18,11 @@
         <td>
           <% visibility = test.task_status('Cat1FilterTask') == 'passing' && test.task_status('Cat3FilterTask') == 'passing' ? '' : 'invisible' %>
           <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
-          <%= test.options.filters.keys.join('/').titleize %>
+          <% if test.display_name.to_s == '' %>
+            <%= test.options.filters.keys.join('/').titleize %>
+          <% else %>
+            <%= test.display_name.titleize %>
+          <% end %>
         </td>
         <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task } %></td>
         <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task } %></td>

--- a/test/models/filtering_test_test.rb
+++ b/test/models/filtering_test_test.rb
@@ -20,7 +20,7 @@ class FilteringTestTest < ActiveJob::TestCase
   def test_pick_filter_criteria
     criteria = %w(races ethnicities genders payers providers problems)
     options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
-    ft = FilteringTest.new(name: 'test_for_measure_1a', product: @product, options: options,
+    ft = FilteringTest.new(name: 'test_for_measure_1a', product: @product, incl_addr: true, options: options,
                            measure_ids: ['8A4D92B2-397A-48D2-0139-C648B33D5582'], bundle_id: '4fdb62e01d41c820f6000001')
     ft.save!
     ft.generate_records

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -115,7 +115,7 @@ class ProducTest < ActiveSupport::TestCase
     pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, c4_test: true)
     measure = Measure.top_level.find_by(hqmf_id: '40280381-4600-425F-0146-1F8D3B750FAC')
     pt.add_filtering_tests(measure)
-    assert pt.product_tests.filtering_tests.count == 4
+    assert pt.product_tests.filtering_tests.count == 5
   end
 end
 


### PR DESCRIPTION
C4 now generates an additional provider filter test with NPI and TIN only (no address). I changed the names of the tests in the UI to "Providers 1" and "Providers 2".

I also fixed a tiny "reticulating splines" bug where it was inaccurately showing "building" instead of "queued" as the status of the filter tests.

<img width="1126" alt="screen shot 2016-02-19 at 1 21 17 pm" src="https://cloud.githubusercontent.com/assets/8235974/13184758/bb46e21a-d70b-11e5-915e-c503f1f0438a.png">
