### PR TITLE
Added a .gitattributes file to set resources/ as a vendored path 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+resources/* linguist-vendored


### PR DESCRIPTION
(this excludes it from language statistics, and diffs on github.com). This is useful because the schematrons in resources/ are 62% of Cypress's current codebase, so we're getting marked as a KiCad project rather than a Ruby one.