### PR TITLE
C1 Manual 'Not Started' Status

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,12 +1,12 @@
 module ProductsHelper
   # returns zero for all values if test is false
   def checklist_status_values(test)
-    passing = failing = total = 0
-    return [passing, failing, total] unless test
+    return [0, 0, 0, 0] unless test
     passing = test.num_measures_complete
     total = test.num_measures
-    failing = total - passing
-    [passing, failing, total]
+    not_started = test.num_measures_not_started
+    failing = total - not_started - passing
+    [passing, failing, not_started, total]
   end
 
   def product_test_status_values(tests, task_type)

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -18,7 +18,7 @@ module VendorsHelper
 
   def c1_values(product)
     h = {}
-    h['checklist'] = Hash[%w(passing failing total).zip(checklist_status_values(product.product_tests.checklist_tests.first))]
+    h['checklist'] = Hash[%w(passing failing not_started total).zip(checklist_status_values(product.product_tests.checklist_tests.first))]
     h['checklist']['not_started'] = h['checklist']['total'] = 1 if h['checklist']['total'] == 0 # manual entry displays as not started if not started
     h['cat1'] = Hash[%w(passing failing not_started total).zip(product_test_status_values(product.product_tests.measure_tests, 'C1Task'))]
     h['sums'] = h['cat1'].merge(h['checklist']) { |_key, old_val, new_val| old_val + new_val }

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -8,18 +8,21 @@
 
 <table class = 'table table-hover table-condensed'>
   <thead>
-    <td class = 'col-sm-11'></td>
-    <td class = 'col-sm-1'></td>
+    <td class = 'col-sm-10'></td>
+    <td class = 'col-sm-2'></td>
   </thead>
   <tbody>
     <% Measure.top_level.where(:hqmf_id.in => checklist_test.measure_ids).each do |measure| %>
       <tr>
         <td><%= link_to "#{measure.cms_id} #{measure.name}", product_checklist_test_path(product, checklist_test, anchor: measure.cms_id) %></td>
-        <td>
-          <% if checklist_test.measure_complete?(measure.id) %>
+        <td class = 'text-right'>
+          <% case checklist_test.measure_status(measure.id) %>
+          <% when 'passed' %>
             <strong class = 'text-success'>Passing</strong>
-          <% else %>
+          <% when 'failed' %>
             <strong class = 'text-danger'>Failing</strong>
+          <% when 'not_started' %>
+            <strong class = 'text-info'>Not Started</strong>
           <% end %>
         </td>
       </tr>

--- a/app/views/products/_product_status_row.html.erb
+++ b/app/views/products/_product_status_row.html.erb
@@ -23,7 +23,7 @@
 %>
 
 <% if test_type == 'checklist' %>
-  <% passing, failing, total = checklist_status_values(product.product_tests.checklist_tests.first) %>
+  <% passing, failing, not_started, total = checklist_status_values(product.product_tests.checklist_tests.first) %>
 <% elsif test_type == 'measure' %>
   <% passing, failing, not_started, total = product_test_status_values(product.product_tests.measure_tests, "#{task_type}") %>
 <% elsif test_type == 'filter' %>
@@ -43,11 +43,6 @@
   <td><strong class = 'text-success'><%= passing_display %></strong></td>
   <% failing_display = failing == 0 ? '--' : "#{failing}/#{total}" %>
   <td><strong class = 'text-danger'><%= failing_display %></strong></td>
-  <% if test_type == 'checklist' %>
-    <td>--</td>
-  <% else %>
-    <% not_started_display = not_started == 0 ? '--' : "#{not_started}/#{total}" %>
-    <td><%= not_started_display %></td>
-  <% end %>
-  </td>
+  <% not_started_display = not_started == 0 ? '--' : "#{not_started}/#{total}" %>
+  <td><%= not_started_display %></td>
 </tr>

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -63,22 +63,35 @@ class ProductsHelperTest < ActiveJob::TestCase
   #   T E S T S   #
   # # # # # # # # #
 
+  def test_checklist_status_values_not_started
+    test = @product.product_tests.checklist_tests.first
+    passing, failing, not_started, total = checklist_status_values(test)
+
+    assert_equal 0, passing
+    assert_equal 0, failing
+    assert_equal 1, not_started
+    assert_equal 1, total
+  end
+
   def test_checklist_status_values_failing
     test = @product.product_tests.checklist_tests.first
-    passing, failing, total = checklist_status_values(test)
+    test.checked_criteria.first.completed = true
+    passing, failing, not_started, total = checklist_status_values(test)
 
     assert_equal 0, passing
     assert_equal 1, failing
+    assert_equal 0, not_started
     assert_equal 1, total
   end
 
   def test_checklist_status_values_passing
     test = @product.product_tests.checklist_tests.first
     test.checked_criteria.each { |criteria| criteria.completed = true }
-    passing, failing, total = checklist_status_values(test)
+    passing, failing, not_started, total = checklist_status_values(test)
 
     assert_equal 1, passing
     assert_equal 0, failing
+    assert_equal 0, not_started
     assert_equal 1, total
   end
 

--- a/test/helpers/vendors_helper_test.rb
+++ b/test/helpers/vendors_helper_test.rb
@@ -97,7 +97,7 @@ class VendorsHelperTest < ActiveJob::TestCase
   end
 
   def assert_c1(cert)
-    assert_equal 1, cert.checklist.failing
+    assert_equal 1, cert.checklist.not_started
     assert_equal 1, cert.checklist.total
 
     assert_equal 1, cert.cat1.failing
@@ -105,8 +105,8 @@ class VendorsHelperTest < ActiveJob::TestCase
     assert_equal 2, cert.cat1.total
 
     assert_equal 0, cert.sums.passing
-    assert_equal 2, cert.sums.failing
-    assert_equal 1, cert.sums.not_started
+    assert_equal 1, cert.sums.failing
+    assert_equal 2, cert.sums.not_started
     assert_equal 3, cert.sums.total
   end
 
@@ -172,7 +172,7 @@ class VendorsHelperTest < ActiveJob::TestCase
   def test_status_to_display_text
     certs = get_product_status_values(@product)
     assert_equal 'C1 certified', status_to_display_text('Passing', 'C1', certs.C1)
-    assert_equal '2 tests failing', status_to_display_text('Failing', 'C1', certs.C1)
+    assert_equal '1 tests failing', status_to_display_text('Failing', 'C1', certs.C1)
     assert_equal '2 tests to go', status_to_display_text('Not Complete', 'C3', certs.C3)
   end
 end

--- a/test/models/checklist_test_test.rb
+++ b/test/models/checklist_test_test.rb
@@ -4,18 +4,48 @@ require 'pry'
 class ChecklistTestTest < ActiveJob::TestCase
   def setup
     collection_fixtures('patient_cache', 'records', 'bundles', 'measures')
-    vendor = Vendor.create(name: 'test_vendor_name')
-    @product = vendor.products.create(name: 'test_product', c1_test: true)
+    vendor = Vendor.create!(name: 'test_vendor_name')
+    product = vendor.products.create!(name: 'test_product', c1_test: true)
+    @test = product.product_tests.create!({ name: 'test_for_measure_1a',
+                                            measure_ids: ['40280381-4B9A-3825-014B-C1A59E160733'],
+                                            bundle_id: '4fdb62e01d41c820f6000001' }, ChecklistTest)
   end
 
   def test_create
     assert_enqueued_jobs 0
-    pt = @product.product_tests.build({ name: 'test_for_measure_1a',
-                                        measure_ids: ['40280381-4B9A-3825-014B-C1A59E160733'],
-                                        bundle_id: '4fdb62e01d41c820f6000001' }, ChecklistTest)
-    assert pt.valid?, 'product test should be valid with product, name, and measure_id'
-    assert pt.checked_criteria? == false
-    pt.create_checked_criteria
-    assert pt.checked_criteria?
+    assert @test.valid?, 'product test should be valid with product, name, and measure_id'
+    assert @test.checked_criteria? == false
+    @test.create_checked_criteria
+    assert @test.checked_criteria?
+  end
+
+  def test_create_checked_criteria
+    @test.create_checked_criteria
+    assert @test.checked_criteria.count > 0, 'should create checked criteria for one measure'
+  end
+
+  def test_num_measures_complete_and_num_measures_not_started
+    assert_equal 0, @test.num_measures_complete
+    assert_equal 1, @test.num_measures_not_started
+    @test.create_checked_criteria
+    @test.checked_criteria.each { |criteria| criteria.completed = true }
+    assert_equal 1, @test.num_measures_complete
+    assert_equal 0, @test.num_measures_not_started
+  end
+
+  def test_num_measures
+    assert_equal 1, @test.num_measures
+    @test.measure_ids << 'sample_measure_id'
+    assert_equal 2, @test.num_measures
+  end
+
+  def test_measure_status
+    measure_id = Measure.top_level.where(:hqmf_id.in => @test.measure_ids).first.id
+    @test.create_checked_criteria
+    assert_equal 'not_started', @test.measure_status(measure_id)
+    @test.checked_criteria.first.completed = true
+    assert_equal 'failed', @test.measure_status(measure_id)
+    @test.checked_criteria.each { |criteria| criteria.completed = true }
+    assert_equal 'passed', @test.measure_status(measure_id)
   end
 end


### PR DESCRIPTION
added 'not started' status to manual entry test. a measure is 'not started' if no criteria are checked, 'failed' if some but not all criteria are checked, or 'passed' if all criteria are checked. added the ability to show 'not started' status to views

<img width="1121" alt="screen shot 2016-02-23 at 1 25 07 pm" src="https://cloud.githubusercontent.com/assets/14349011/13262052/f49342b6-da30-11e5-8e63-5c46dbba01af.png">
