### PR TITLE
Fix Cat 3 Warnings Display

### DIFF
--- a/app/views/test_executions/results/_error_table.html.erb
+++ b/app/views/test_executions/results/_error_table.html.erb
@@ -18,7 +18,7 @@
         <th scope="col" class = 'col-sm-8'><%= "#{message_title} message" %></th>
         <th scope="col" class = 'col-sm-2'>XML File</th>
       <% else %>
-        <th scope="col" class = 'col-sm-10'>Error message</th>
+        <th scope="col" class = 'col-sm-10'><%= "#{message_title} message" %></th>
       <% end %>
       <th scope="col" class = 'col-sm-2'>Go To in XML</th>
     </tr>


### PR DESCRIPTION
this unique and innovative feature will add a correct column header to ALL Cat 3 warning tables. The column header will say new and exciting things like "Warning message". To top it off, we gave this column header an ornate bolded text to match our other column headers. enjoy :kissing: 