### PR TITLE
Supplemental Data Error Reporting

### DIFF
--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -1,4 +1,6 @@
 module TestExecutionsHelper
+  include TestExecutionsResultsHelper
+
   def displaying_cat1?(task)
     test = task.product_test
     (test._type == 'MeasureTest' && task._type == 'C1Task') || (test._type == 'FilteringTest' && task._type == 'Cat1FilterTask')
@@ -18,6 +20,21 @@ module TestExecutionsHelper
   def current_certifications(task_type, c3_task)
     return [false, false, false, true] if task_type == 'Cat1FilterTask' || task_type == 'Cat3FilterTask'
     [task_type == 'C1Task', task_type == 'C2Task', c3_task, false]
+  end
+
+  # returns the number of each type of error
+  def get_error_counts(execution, task)
+    h = Hash[['QRDA Errors', 'Reporting Errors', 'Submission Errors'].zip(get_error_counts_helper(execution))]
+    h.except!('Submission Errors') unless task.product_test.product.c3_test
+    h
+  end
+
+  def get_error_counts_helper(execution)
+    return ['--', '--', '--'] unless execution && execution.failing?
+    qrda = execution.qrda_errors.count
+    reporting = execution.reporting_errors.count
+    submit = execution.sibling_execution ? execution.sibling_execution.execution_errors.count : 0
+    [qrda, reporting, submit]
   end
 
   def date_of_execution(execution)
@@ -45,74 +62,5 @@ module TestExecutionsHelper
     else
       'QRDA Category III XML document'
     end
-  end
-
-  # returns the number of each type of error
-  def get_error_counts(execution, task)
-    h = Hash[['QRDA Errors', 'Reporting Errors', 'Submission Errors'].zip(get_error_counts_helper(execution))]
-    h.except!('Submission Errors') unless task.product_test.product.c3_test
-    h
-  end
-
-  def get_error_counts_helper(execution)
-    return ['--', '--', '--'] unless execution && execution.failing?
-    qrda = execution.qrda_errors.count
-    reporting = execution.reporting_errors.count
-    submit = execution.sibling_execution ? execution.sibling_execution.execution_errors.count : 0
-    [qrda, reporting, submit]
-  end
-
-  def get_select_history_message(execution, is_most_recent)
-    msg = ''
-    msg << 'Most Recent - ' if is_most_recent
-    msg << execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p (%A)')
-    msg << ' (passing)' if execution.passing?
-    msg << ' (in progress)' if execution.incomplete?
-    if execution.failing?
-      num_errors = execution.execution_errors.count
-      num_errors += execution.sibling_execution.execution_errors.count if execution.sibling_execution
-      msg << " (#{num_errors} errors)"
-    end
-    msg
-  end
-
-  # only use if an xpath location is specified for error
-  def get_line_number(error)
-    error_to_line_number(error, get_doc(error.test_execution.artifact, error.file_name))
-  end
-
-  # inputs: a and b are execution errors
-  # returns: 1 if a should be sorted first or -1 if b should be sorted first
-  #   1 if a is from an aphabetically higher document or higher location in the same document
-  #  -1 if b is ...
-  def compare_error_locations_across_files(a, b)
-    return 1 if a.file_name.nil?
-    return -1 if b.file_name.nil?
-    return a.file_name <=> b.file_name if a.file_name != b.file_name
-    return 1 if a.location.nil?
-    return -1 if b.location.nil?
-    a.location <=> b.location
-  end
-
-  private
-
-  def currently_viewing_c1?(task)
-    task._type == 'C1Task'
-  end
-
-  # used for sorting errors by appearance in xml
-  #   if no doc or xml element found then line number of 0 is returned
-  def error_to_line_number(error, doc)
-    return 0 unless doc
-    nodes = doc.search(error.location)
-    return 0 if nodes.count == 0 || nodes.first.class != Nokogiri::XML::Element
-    nodes.first.line
-  end
-
-  def get_doc(artifact, file_name)
-    artifact.each_file do |name, data|
-      return data_to_doc(data) if name == file_name
-    end
-    false
   end
 end

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -1,0 +1,69 @@
+module TestExecutionsResultsHelper
+  def get_select_history_message(execution, is_most_recent)
+    msg = ''
+    msg << 'Most Recent - ' if is_most_recent
+    msg << execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p (%A)')
+    msg << ' (passing)' if execution.passing?
+    msg << ' (in progress)' if execution.incomplete?
+    if execution.failing?
+      num_errors = execution.execution_errors.count
+      num_errors += execution.sibling_execution.execution_errors.count if execution.sibling_execution
+      msg << " (#{num_errors} errors)"
+    end
+    msg
+  end
+
+  # # # # # # # # # # # # # # # #
+  #   E r r o r   T a b l e s   #
+  # # # # # # # # # # # # # # # #
+
+  def supplemental_data_errors(errors)
+    return_errors = errors.select do |err|
+      err.has_attribute?('error_details') && err['error_details'].key?('type') && err['error_details']['type'] == 'supplemental_data'
+    end
+    # sort by population key (IPP, DENOM, ...)
+    return_errors.sort do |a, b|
+      a.error_details.population_key <=> a.error_details.population_key
+    end
+  end
+
+  # only use if an xpath location is specified for error
+  def get_line_number(error)
+    error_to_line_number(error, get_doc(error.test_execution.artifact, error.file_name))
+  end
+
+  # inputs: a and b are execution errors
+  # returns: 1 if a should be sorted first or -1 if b should be sorted first
+  #   1 if a is from an aphabetically higher document or higher location in the same document
+  #  -1 if b is ...
+  def compare_error_locations_across_files(a, b)
+    return 1 if a.file_name.nil?
+    return -1 if b.file_name.nil?
+    return a.file_name <=> b.file_name if a.file_name != b.file_name
+    return 1 if a.location.nil?
+    return -1 if b.location.nil?
+    a.location <=> b.location
+  end
+
+  private
+
+  def currently_viewing_c1?(task)
+    task._type == 'C1Task'
+  end
+
+  # used for sorting errors by appearance in xml
+  #   if no doc or xml element found then line number of 0 is returned
+  def error_to_line_number(error, doc)
+    return 0 unless doc
+    nodes = doc.search(error.location)
+    return 0 if nodes.count == 0 || nodes.first.class != Nokogiri::XML::Element
+    nodes.first.line
+  end
+
+  def get_doc(artifact, file_name)
+    artifact.each_file do |name, data|
+      return data_to_doc(data) if name == file_name
+    end
+    false
+  end
+end

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -64,7 +64,10 @@
       <%= render partial: 'test_executions/results/error_table', locals: { errors: qrda_errors, displaying_cat1: displaying_cat1, message_title: 'Error' } %>
     </div>
     <div class = 'tab-pane' id = <%= "reporting_tab_execution_#{execution.id}" %>>
-      <%= render partial: 'test_executions/results/error_table', locals: { errors: report_errors, displaying_cat1: displaying_cat1, message_title: 'Error' } %>
+      <% # supplemental data errors are reported in a separate table %>
+      <% report_sup_data_errors = supplemental_data_errors(report_errors) %>
+      <%= render partial: 'test_executions/results/error_table', locals: { errors: report_errors - report_sup_data_errors, displaying_cat1: displaying_cat1, message_title: 'Error' } %>
+      <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors } %>
     </div>
     <% if should_display_c3 %>
       <div class = 'tab-pane' id = <%= "submission_tab_execution_#{execution.id}" %>>

--- a/app/views/test_executions/results/_supplemental_data_error_table.html.erb
+++ b/app/views/test_executions/results/_supplemental_data_error_table.html.erb
@@ -1,0 +1,33 @@
+<%
+
+# requires local variables:
+#   errors   (Array) of errors
+
+# Note: all errors should be from the same test execution
+
+%>
+
+<% return if errors.count == 0 %>
+
+<table class = 'table table-hover table-condensed'>
+  <thead>
+    <tr>
+      <th scope = 'col' class = 'col-sm-2'>Population ID</th>
+      <th scope = 'col' class = 'col-sm-2'>Supplemental Data Type</th>
+      <th scope = 'col' class = 'col-sm-2'>Code</th>
+      <th scope = 'col' class = 'col-sm-2'>Expected Value</th>
+      <th scope = 'col' class = 'col-sm-4'>Reported Value</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% errors.each do |err| %>
+      <tr>
+        <td><%= err.error_details.population_key %></td>
+        <td><%= err.error_details.data_type %></td>
+        <td><%= err.error_details.code %></td>
+        <td><%= err.error_details.expected_value %></td>
+        <td><%= err.error_details.reported_value %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/test/models/c2_task_test.rb
+++ b/test/models/c2_task_test.rb
@@ -99,10 +99,11 @@ class C2TaskTest < ActiveSupport::TestCase
     perform_enqueued_jobs do
       te = task.execute(xml)
       te.reload
+
       # 9 is for all of the sub measures to be searched for
-      # 12 for missing supplemental data
+      # 46 for missing supplemental data
       # 2 for incorrect measure ids
-      assert_equal 23, te.execution_errors.length, 'should error on missing measure entry'
+      assert_equal 57, te.execution_errors.length, 'should error on missing measure entry'
     end
   end
 


### PR DESCRIPTION
added table for supplemental data reporting errors. errors are now reported for each supplemental data (Race, Sex, Ethnicity, Payer) with mismatched expected and reported values. this adds to the total possible number of execution errors

<img width="1126" alt="screen shot 2016-02-25 at 4 22 40 pm" src="https://cloud.githubusercontent.com/assets/14349011/13334871/1f80ff66-dbdc-11e5-85de-c531dd483bf9.png">
