### PR TITLE
Fixed all_records_for_product so it returns something

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -81,6 +81,6 @@ module ProductsHelper
       end
     end
 
-    records.any? ? records.sort_by! { |r| r[:new_name] }.uniq! : records
+    records.any? ? records.sort_by { |r| r[:new_name] }.uniq : records
   end
 end

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -192,4 +192,9 @@ class ProductsHelperTest < ActiveJob::TestCase
     assert_equal 1, passing
     assert_equal 2, total
   end
+
+  def test_all_records_for_product
+    records = all_records_for_product(@product)
+    assert_equal 0, records.length
+  end
 end


### PR DESCRIPTION
`ProductsHelper::all_records_for_product` now it uses the non-destructive versions of `sort_by` and `uniq`, so it actually returns something, rather than just modifying the `records` object in place