### PR TITLE
Fix C3 Status Not Shown

### DIFF
--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -24,17 +24,21 @@ module TestExecutionsHelper
 
   # returns the number of each type of error
   def get_error_counts(execution, task)
-    h = Hash[['QRDA Errors', 'Reporting Errors', 'Submission Errors'].zip(get_error_counts_helper(execution))]
-    h.except!('Submission Errors') unless task.product_test.product.c3_test
+    h = Hash[['QRDA Errors', 'Reporting Errors', 'Submission Errors', 'Warnings'].zip(get_error_counts_helper(execution))]
+    h.except!('Submission Errors', 'Warnings') unless task.product_test.product.c3_test
     h
   end
 
   def get_error_counts_helper(execution)
     return ['--', '--', '--'] unless execution && execution.failing?
-    qrda = execution.qrda_errors.count
-    reporting = execution.reporting_errors.count
-    submit = execution.sibling_execution ? execution.sibling_execution.execution_errors.count : 0
-    [qrda, reporting, submit]
+    qrda = execution.execution_errors.qrda_errors.count
+    reporting = execution.execution_errors.reporting_errors.count
+    submit_errors = submit_warnings = 0
+    if execution.sibling_execution
+      submit_errors = execution.sibling_execution.execution_errors.only_errors.count
+      submit_warnings = execution.sibling_execution.execution_errors.only_warnings.count
+    end
+    [qrda, reporting, submit_errors, submit_warnings]
   end
 
   def date_of_execution(execution)

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -3,9 +3,10 @@ module TestExecutionsResultsHelper
     msg = ''
     msg << 'Most Recent - ' if is_most_recent
     msg << execution.created_at.in_time_zone('Eastern Time (US & Canada)').strftime('%b %d, %Y at %I:%M %p (%A)')
-    msg << ' (passing)' if execution.passing?
-    msg << ' (in progress)' if execution.incomplete?
-    if execution.failing?
+    case execution.status_with_sibling
+    when 'passing' then msg << ' (passing)'
+    when 'incomplete' then msg << ' (in progress)'
+    else # failing
       num_errors = execution.execution_errors.count
       num_errors += execution.sibling_execution.execution_errors.count if execution.sibling_execution
       msg << " (#{num_errors} errors)"

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -30,4 +30,11 @@ class C1Task < Task
     patient_ids = product_test.results.where('value.IPP' => { '$gt' => 0 }).collect { |pc| pc.value.patient_id }
     product_test.records.in('_id' => patient_ids)
   end
+
+  # returns combined status including c3_cat1 task
+  def status_with_sibling
+    return status unless product_test.tasks.c3_cat1_task
+    return status if status == product_test.tasks.c3_cat1_task.status
+    'failing'
+  end
 end

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -23,4 +23,11 @@ class C2Task < Task
     te.save
     te
   end
+
+  # returns combined status including c3_cat3 task
+  def status_with_sibling
+    return status unless product_test.tasks.c3_cat3_task
+    return status if status == product_test.tasks.c3_cat3_task.status
+    'failing'
+  end
 end

--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -17,4 +17,40 @@ class ExecutionError
   scope :by_type, ->(type) { where(msg_type: type) }
   scope :by_validation_type, ->(type) { where(validator_type: type) }
   scope :by_file, ->(file) { where(file_name: file) }
+
+  def self.only_errors
+    by_type(:error).entries
+  end
+
+  def self.only_warnings
+    by_type(:warning).entries
+  end
+
+  # only if validator is one of 'CDA SDTC Validator', 'QRDA Cat 1 R3 Validator', 'QRDA Cat 1 Validator', or 'QRDA Cat 3 Validator'
+  #   or if validator type is xml_validation
+  def self.qrda_errors
+    valid_strings = %w(CDA\ SDTC\ Validator QRDA\ Cat\ 1\ R3\ Validator QRDA\ Cat\ 1\ Validator QRDA\ Cat\ 3\ Validator)
+    all.select do |execution_error|
+      true if (execution_error.has_attribute?('validator') &&
+               valid_strings.include?(execution_error[:validator])) ||
+              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :xml_validation)
+    end
+  end
+
+  # only if validator is one of 'Cat 1 Measure ID Validator' or 'Cat 3 Measure ID Validator'
+  #   or if validator type is result_validation
+  def self.reporting_errors
+    all.select do |execution_error|
+      true if (execution_error.has_attribute?('validator') &&
+               %w(Cat\ 1\ Measure\ ID\ Validator Cat\ 3\ Measure\ ID\ Validator).include?(execution_error[:validator])) ||
+              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :result_validation)
+    end
+  end
+
+  # only if validator type is submission_validation
+  def self.submission_errors
+    all.select do |execution_error|
+      true if execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :submission_validation
+    end
+  end
 end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -49,4 +49,36 @@ class MeasureTest < ProductTest
       product.c2_test = true
     end
   end
+
+  # passing only if both c1 and c3_cat1 tasks pass
+  # failing if either fail, incomlete otherwise
+  # should only be called if product.c1_test == true
+  def cat1_status
+    c1_task = tasks.c1_task
+    c3_task = tasks.c3_cat1_task
+    return c1_task.status unless c3_task
+    if c1_task.passing? && c3_task.passing?
+      'passing'
+    elsif c1_task.failing? || c3_task.failing?
+      'failing'
+    else
+      'incomplete'
+    end
+  end
+
+  # passing only if both c2 and c3_cat3 tasks pass
+  # failing if either fail, incomlete otherwise
+  # should only be called if product.c2_test == true
+  def cat3_status
+    c2_task = tasks.c2_task
+    c3_task = tasks.c3_cat3_task
+    return c2_task.status unless c3_task
+    if c2_task.passing? && c3_task.passing?
+      'passing'
+    elsif c2_task.failing? || c3_task.failing?
+      'failing'
+    else
+      'incomplete'
+    end
+  end
 end

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -45,15 +45,7 @@ class TestExecution
       execution_errors.build(:message => "#{task.records.count} files expected but was #{file_count}",
                              :msg_type => :error, :validator_type => :result_validation)
     end
-    (only_errors.count > 0) ? fail : pass
-  end
-
-  def only_errors
-    execution_errors.by_type(:error).entries
-  end
-
-  def only_warnings
-    execution_errors.by_type(:warning).entries
+    execution_errors.only_errors.count > 0 ? fail : pass
   end
 
   # Get the expected result for a particular measure
@@ -94,36 +86,17 @@ class TestExecution
     nil
   end
 
-  def c1_task?
-    return false unless task.has_attribute?(:_type)
-    task._type == 'C1Task'
+  def status
+    return 'passing' if passing?
+    return 'failing' if failing?
+    'incomplete'
   end
 
-  # only if validator is one of 'CDA SDTC Validator', 'QRDA Cat 1 R3 Validator', 'QRDA Cat 1 Validator', or 'QRDA Cat 3 Validator'
-  #   or if validator type is xml_validation
-  def qrda_errors
-    valid_strings = %w(CDA\ SDTC\ Validator QRDA\ Cat\ 1\ R3\ Validator QRDA\ Cat\ 1\ Validator QRDA\ Cat\ 3\ Validator)
-    execution_errors.select do |execution_error|
-      true if (execution_error.has_attribute?('validator') &&
-               valid_strings.include?(execution_error[:validator])) ||
-              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :xml_validation)
-    end
-  end
-
-  # only if validator is one of 'Cat 1 Measure ID Validator' or 'Cat 3 Measure ID Validator'
-  #   or if validator type is result_validation
-  def reporting_errors
-    execution_errors.select do |execution_error|
-      true if (execution_error.has_attribute?('validator') &&
-               %w(Cat\ 1\ Measure\ ID\ Validator Cat\ 3\ Measure\ ID\ Validator).include?(execution_error[:validator])) ||
-              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :result_validation)
-    end
-  end
-
-  # only if validator type is submission_validation
-  def submission_errors
-    execution_errors.select do |execution_error|
-      true if execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :submission_validation
-    end
+  # returns combined status including c3 test execution
+  # returns passing if both passing, incomplete if both incomplete, failing if both failing or mismatched
+  def status_with_sibling
+    return status unless sibling_execution
+    return status if status == sibling_execution.status
+    'failing' # failing if status's do not match
   end
 end

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -24,8 +24,8 @@
             <%= test.display_name %>
           <% end %>
         </td>
-        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task } %></td>
-        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task } %></td>
+        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task, status: test.cat1_task.status } %></td>
+        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task, status: test.cat3_task.status } %></td>
       </tr>
     <% end %>
     <% if tests.any? { |test| test.state != :ready } %>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -46,10 +46,10 @@
         <td><%= test.cms_id %></td>
         <td><%= test.name %></td>
         <% if @product.c1_test %>
-          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task } %></td>
+          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>
         <% end %>
         <% if @product.c2_test %>
-          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task } %></td>
+          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task, status: test.cat3_status } %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -1,7 +1,10 @@
 <%
 
-# local variable 'task'
-# local variable 'test'
+# local variables
+#
+#   test   (MeasureTest)
+#   task   (C1Task or C2Task)
+#   status (String)
 
 %>
 <% if test.state != :ready %>
@@ -10,13 +13,16 @@
   <% else test.state == :building %>
     <i class="fa fa-fw fa-refresh fa-spin" aria-hidden="true"></i> building
   <% end %>
-<% elsif task.passing? %>
-  <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-  <%= link_to 'view', new_task_test_execution_path(task) %>
-<% elsif task.failing? %>
-  <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
-  <%= link_to 'retry', new_task_test_execution_path(task) %>
 <% else %>
-  <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-  <%= link_to 'start', new_task_test_execution_path(task) %>
+  <% case status %>
+  <% when 'passing' %>
+    <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+    <%= link_to 'view', new_task_test_execution_path(task) %>
+  <% when 'failing' %>
+    <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+    <%= link_to 'retry', new_task_test_execution_path(task) %>
+  <% else %>
+    <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+    <%= link_to 'start', new_task_test_execution_path(task) %>
+  <% end %>
 <% end %>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -6,28 +6,28 @@
 #
 %>
 
-<% if execution.incomplete? || (execution.sibling_execution && execution.sibling_execution.incomplete?) %>
+<% case execution.status_with_sibling %>
+<% when 'incomplete' %>
   <h4><i class="fa fa-fw fa-refresh fa-spin text-info"></i>In Progress</h4>
   <p>You do not need to reload your browser. Results will automatically display when the tests are done running.</p>
   <% # ajax contacts test_execution's show controller action with format: 'js'. controller then directs to show.js.erb which will wait, then re-render %>
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_results' }});
   </script>
-
-
-<% elsif execution.passing? %>
+  
+<% when 'passing' %>
   <h4><i class="fa fa-fw fa-check-circle text-success"></i> Passed</h4>
   <% if execution.task.product_test.product.c3_test && execution.task.product_test._type == 'MeasureTest' %>
-    <% submit_warnings = execution.sibling_execution.only_warnings %>
+    <% submit_warnings = execution.sibling_execution.execution_errors.only_warnings %>
     <%= render partial: 'test_executions/results/error_table', locals: { errors: submit_warnings, displaying_cat1: displaying_cat1?(execution.task), message_title: 'Warning' } if submit_warnings.any? %>
   <% end %>
 
-<% else %>
-  <% qrda_errors = execution.qrda_errors %>
-  <% report_errors = execution.reporting_errors %>
+<% else # failing %>
+  <% qrda_errors = execution.execution_errors.qrda_errors %>
+  <% report_errors = execution.execution_errors.reporting_errors %>
   <% should_display_c3 = execution.task.product_test.product.c3_test && execution.task.product_test._type == 'MeasureTest' %>
-  <% submit_errors = should_display_c3 ? execution.sibling_execution.only_errors : [] %>
-  <% submit_warnings = should_display_c3 ? execution.sibling_execution.only_warnings : [] %>
+  <% submit_errors = should_display_c3 ? execution.sibling_execution.execution_errors.only_errors : [] %>
+  <% submit_warnings = should_display_c3 ? execution.sibling_execution.execution_errors.only_warnings : [] %>
 
   <% failure_message = " Failed with #{qrda_errors.count + report_errors.count + submit_errors.count} errors" %>
   <% failure_message += " and #{submit_warnings.count} warnings" if submit_warnings.any? %>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -11,6 +11,7 @@
 <% execution = task.most_recent_execution %>
 
 <% panel_class = current_task ? 'panel-primary' : 'panel-inactive' %>
+<% task_status = task.product_test._type == 'MeasureTest' ? task.status_with_sibling : task.status %>
 
 <div class = 'col-sm-4'>
   <div class = 'panel <%= panel_class %> task-panel'>
@@ -28,15 +29,15 @@
       <% if execution %>
         <div class = 'col-sm-6 text-center margin-top-1'>
           <% unless current_task %>
-            <span class = 'nested-link text-primary'><%= task.failing? || task.passing? ? 'view' : 'start' unless current_task %></span>
+            <span class = 'nested-link text-primary'><%= task_status == 'passing' || task_status == 'failing' ? 'view' : 'start' unless current_task %></span>
           <% end %>
         </div>
         <div class = 'col-sm-6 text-left margin-top-1'>
-          <% if task.passing? %>
+          <% if task_status == 'passing' %>
             <i class = 'fa fa-check text-success'></i><strong class = 'text-success'> Passing</strong>
-          <% elsif task.failing? %>
+          <% elsif task_status == 'failing' %>
             <i class = 'fa fa-times text-danger'></i><strong class = 'text-danger'> Failing</strong>
-          <% else %>
+          <% else # incomplete (in progress b/c execution exists) %>
             <strong class = 'text-info'>In Progress...</strong>
           <% end %>
         </div>

--- a/test/jobs/test_execution_job_test.rb
+++ b/test/jobs/test_execution_job_test.rb
@@ -38,6 +38,6 @@ class TestExecutionJobTest < ActiveJob::TestCase
 
     assert !te.incomplete?, 'test execution should not be incomplete after it is run'
     assert te.failing?, 'test execution with bad file should fail'
-    assert te.only_errors.count > 0, 'test execution should have errors'
+    assert te.execution_errors.only_errors.count > 0, 'test execution should have errors'
   end
 end

--- a/test/models/test_execution_test.rb
+++ b/test/models/test_execution_test.rb
@@ -26,12 +26,6 @@ class TestExecutionTest < ActiveSupport::TestCase
     assert te.passing?, 'te.passing? not returning true when execution is passing'
   end
 
-  def test_c1_task
-    task = @ptest.tasks.build({}, C1Task)
-    te = task.test_executions.build
-    assert te.c1_task?
-  end
-
   def test_qrda_reporting_and_submission_errors
     qrda_errors = [
       { validator: 'CDA SDTC Validator' },
@@ -52,8 +46,8 @@ class TestExecutionTest < ActiveSupport::TestCase
 
     te = TestExecution.new(execution_errors: execution_errors)
 
-    assert_equal te.qrda_errors.count, qrda_errors.count
-    assert_equal te.reporting_errors.count, reporting_errors.count
-    assert_equal te.submission_errors.count, submission_errors.count
+    assert_equal te.execution_errors.qrda_errors.count, qrda_errors.count
+    assert_equal te.execution_errors.reporting_errors.count, reporting_errors.count
+    assert_equal te.execution_errors.submission_errors.count, submission_errors.count
   end
 end


### PR DESCRIPTION
fixed issues with c3 errors not being accounted for in several places. measure_test table on product show page, task status divs on test_execution show page, test_execution results on test_execution show page all acount for c3 failing / passing / incomplete now. added warnings to task status divs on test_execution show page. refactored functions that scope execution_errors from test_execution model to execution_errors model

<img width="1126" alt="screen shot 2016-03-03 at 9 54 00 am" src="https://cloud.githubusercontent.com/assets/14349011/13498005/1721afce-e126-11e5-8bc3-f30b52282b94.png">
