### PR TITLE
View Patient Breadcrumbs should lead back to task, and not product te…

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -35,13 +35,13 @@ class RecordsController < ApplicationController
       @bundle = Bundle.find(params[:bundle_id])
       @source = @bundle
       add_breadcrumb 'Master Patient List', :records_path
-    elsif params[:product_test_id]
-      @product_test = ProductTest.find(params[:product_test_id])
+    elsif params[:task_id]
+      @task = Task.find(params[:task_id])
+      @product_test = @task.product_test
       @measure = Measure.where(hqmf_id: @product_test.measure_ids.first).first
       @source = @product_test
-      add_breadcrumb 'Test: ' + @product_test.name, product_product_test_path(product_id: @product_test.product.id,
-                                                                              id: @product_test.id)
-      add_breadcrumb 'Patient List', records_path(product_test_id: @product_test.id)
+      add_breadcrumb 'Test: ' + @product_test.name, new_task_test_execution_path(task_id: @task.id)
+      add_breadcrumb 'Patient List', records_path(task_id: @task.id)
     else
       @bundle = Bundle.where(active: true).first
       @source = @bundle

--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -34,7 +34,7 @@
       <% @records.each do |r| %>
         <tr>
           <% if @product_test %>
-            <td><%= link_to full_name(r), record_path(:id => r.id, :product_test_id => @product_test.id) %></td>
+            <td><%= link_to full_name(r), record_path(:id => r.id, :task_id => @task.id) %></td>
           <% else %>
             <td><%= link_to full_name(r), record_path(:id => r.id) %></td>
           <% end %>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -22,5 +22,5 @@
   <% end %>
 
   <br/>
-  <%= link_to 'View Patients', { controller: 'records', product_test_id: test.id}, method: :get %>
+  <%= link_to 'View Patients', { controller: 'records', task_id: @task.id}, method: :get %>
 </div>

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -23,12 +23,12 @@ class RecordsControllerTest < ActionController::TestCase
     assert assigns(:bundle)
   end
 
-  test 'should get index scoped to product_test' do
-    get :index, product_test_id: ProductTest.first
+  test 'should get index scoped to task' do
+    get :index, task_id: Task.first
     assert_response :success
     assert assigns(:records)
     assert assigns(:source)
-    assert assigns(:product_test)
+    assert assigns(:task)
   end
 
   test 'should get show' do


### PR DESCRIPTION
…st.  Before it would always bring C1 and C2 back to the C1 task.  Patient List breadcrumbs was totally broken for C4 tests