### PR TITLE
Fix measure sorting and fix product measure editing 

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -64,14 +64,16 @@ ready = function() {
 
   // Checking a radio button indicating measure selection
   $('.btn-checkbox input[name="product[measure_selection]"]').on('change', function() {
-    var selection = $(this).val();
+    if ($(this).attr('disabled') != true) {
+      var selection = $(this).val();
 
-    if (selection == 'custom') {
-      ToggleCustomSelection('open');
-    }
-    else {
-      ToggleCustomSelection('close');
-      CheckMany(selection);
+      if (selection == 'custom') {
+        ToggleCustomSelection('open');
+      }
+      else {
+        ToggleCustomSelection('close');
+        CheckMany(selection);
+      }
     }
   });
 
@@ -83,6 +85,15 @@ ready = function() {
 
   // Checking an individual measure
   $('.measure-checkbox').on('change', this, UpdateGroupSelections);
+
+  // Enable changing measures
+  $('#measures_options').find('button.confirm').on('click', function (event) {
+    event.preventDefault();
+    $('.measure-list [type="checkbox"]').attr('disabled', false);
+    $('input[name="product[measure_selection]"]').attr('disabled', false);
+    $('input[name="product[measure_selection]"]').closest('.radio').removeClass('disabled');
+    $(event.currentTarget).closest('alert').find('.close').click();
+  });
 
   ///////////////////////
   // Do things on load //

--- a/app/assets/stylesheets/cypress/_alerts.scss
+++ b/app/assets/stylesheets/cypress/_alerts.scss
@@ -30,3 +30,7 @@
 .breadcrumb-responsive + .alert {
   margin: -.5em 1em 2em;
 }
+// or for alerts shown after a .control-label
+.control-label + .alert {
+  margin: 1em auto;
+}

--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -44,7 +44,7 @@ class ChecklistTestsController < ProductTestsController
   end
 
   def set_measures
-    @measures = Measure.top_level.where(:hqmf_id.in => @test.measure_ids)
+    @measures = Measure.top_level.where(:hqmf_id.in => @test.measure_ids).sort_by(&:cms_int)
   end
 
   # CHOOSE INTERESTING CRITERIA HERE - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - #

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -1,4 +1,12 @@
 module ProductsHelper
+  def cms_int(cms_id)
+    # this is here because sometimes we only have the cms_id string and not the measure
+    return 0 unless cms_id
+    start_marker = 'CMS'
+    end_marker = 'v'
+    cms_id[/#{start_marker}(.*?)#{end_marker}/m, 1].to_i
+  end
+
   # returns zero for all values if test is false
   def checklist_status_values(test)
     return [0, 0, 0, 0] unless test

--- a/app/views/application/_alerts.html.erb
+++ b/app/views/application/_alerts.html.erb
@@ -1,3 +1,8 @@
+<%
+ #locals
+ confirmable ||= false
+%>
+
 <% if notice || alert %>
     <div class="clearfix alert <%= flash[:notice_type] ? "alert-#{flash[:notice_type]}" : "alert-info" %> <%= alert ? "alert-danger" : "" %> alert-dismissible" role="alert" aria-live="polite">
         <button type="button" class="close fa fa-fw fa-close" data-dismiss="alert" aria-label="Close"></button>
@@ -8,6 +13,9 @@
           </div>
           <div class="alertContent">
             <p><%= alert %></p>
+            <% if confirmable %>
+              <button type="button" class="btn btn-default btn-sm pull-right confirm" data-dismiss="alert">OK, I understand</button>
+            <% end %>
           </div>
         <% elsif notice %>
           <% if flash[:notice_type] == 'warning' %>
@@ -25,6 +33,9 @@
           <% end %>
           <div class="alertContent">
             <p><%= notice %></p>
+            <% if confirmable %>
+              <button type="button" class="btn btn-default btn-sm pull-right confirm" data-dismiss="alert">OK, I understand</button>
+            <% end %>
           </div>
         <% end %>
     </div>

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -12,7 +12,7 @@
     <td class = 'col-sm-2'></td>
   </thead>
   <tbody>
-    <% Measure.top_level.where(:hqmf_id.in => checklist_test.measure_ids).each do |measure| %>
+    <% Measure.top_level.where(:hqmf_id.in => checklist_test.measure_ids).sort_by(&:cms_int).each do |measure| %>
       <tr>
         <td><%= link_to "#{measure.cms_id} #{measure.name}", product_checklist_test_path(product, checklist_test, anchor: measure.cms_id) %></td>
         <td class = 'text-right'>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -20,7 +20,7 @@
       <th scope="col" class = 'col-sm-6 pointer-on-hover'>
         Measure Name
         <a>[sort]</a>
-      </th>  
+      </th>
     <% else %>
       <th scope="col" class = 'col-sm-8 pointer-on-hover'>
         Measure Name
@@ -43,7 +43,7 @@
   <tbody data-no-turbolink>
     <% tests.each do |test| %>
       <tr>
-        <td data-sort="<%= test.measures.first.cms_int %>"><%= test.cms_id %></td>
+        <td data-sort="<%= cms_int(test.cms_id) %>"><%= test.cms_id %></td>
         <td><%= test.name %></td>
         <% if @product.c1_test %>
           <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -43,7 +43,7 @@
   <tbody data-no-turbolink>
     <% tests.each do |test| %>
       <tr>
-        <td><%= test.cms_id %></td>
+        <td data-sort="<%= test.measures.first.cms_int %>"><%= test.cms_id %></td>
         <td><%= test.name %></td>
         <% if @product.c1_test %>
           <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -29,8 +29,13 @@
             <% end %>
           </fieldset>
 
-          <fieldset>
+          <fieldset id="measures_options">
             <legend class="control-label">Measures Options</legend>
+
+            <% unless @product.new_record? %>
+              <%= render :partial => 'alerts', locals: { alert: 'Changing selected measures will delete all associated product tests and test execution results for any removed measures. Be sure you want to do this before changing your selection.', confirmable: true } %>
+            <% end %>
+
             <div id="simple_measures_errors_container"></div>
             <%= f.form_group :measure_selection, help: "Indicate the clinical quality measures Cypress should use to certify this product. Testing will be performed on a measure-by-measure basis. Click 'Custom' to specify individual measures." do %>
               <%= f.radio_button :measure_selection, "eh", label: "Eligible Hospital eCQMs", label_class: "btn btn-checkbox", disabled: !@product.new_record?, data: { 'parsley-required': '', 'parsley-error-message': 'Must select measures.', 'parsley-errors-container': "#simple_measures_errors_container" } %>
@@ -65,14 +70,17 @@
                 </ul>
               </div>
               <div class="measure-list">
-
                 <% @measures_categories.sort.each do |category, measures| %>
                   <!-- set up a checkbox for each top-level measure in the group -->
                   <div id="<%= category.tr(" '", "_") %>_div" class="measure_group">
                     <% if measures.length > 1 %>
                     <div class="checkbox">
                       <label class="btn btn-checkbox">
-                        <input type="checkbox" id="<%= category.tr(" '", "_") %>" class="measure_group_all" /> Select all <%= measures.length %> <%= category %> measures
+                        <input type="checkbox"
+                          id="<%= category.tr(" '", "_") %>"
+                          class="measure_group_all"
+                          <%= 'disabled' if defined?(@selected_measure_ids) && !@product.new_record? %>/>
+                        Select all <%= measures.length %> <%= category %> measures
                       </label>
                     </div>
                     <% end %>
@@ -92,7 +100,7 @@
                             aria-labelledby="select_custom_measures"
                             class="measure-checkbox"
                             <%= 'checked' if defined?(@selected_measure_ids) && @selected_measure_ids.include?(m.hqmf_id) %>
-                            <%= 'disabled' if defined?(@selected_measure_ids) && params[:action] == "edit"  %>/>
+                            <%= 'disabled' if defined?(@selected_measure_ids) && !@product.new_record? %>/>
                           <strong><%= m.cms_id %></strong> <%= m.name %> (<%= m.type.upcase %>)
                         </label>
                       </div>


### PR DESCRIPTION
Now measures are sorted on the product show page as expected.

Also re-added a confirmation before enabling the editing of a product's measures.
![screen shot 2016-03-10 at 5 46 13 pm](https://cloud.githubusercontent.com/assets/2136286/13687213/040262e0-e6e8-11e5-83f3-cf85a85ab820.png)
