### PR TITLE
better handling of incomplete sibling tests/tasks

### DIFF
--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -33,8 +33,10 @@ class C1Task < Task
 
   # returns combined status including c3_cat1 task
   def status_with_sibling
-    return status unless product_test.tasks.c3_cat1_task
-    return status if status == product_test.tasks.c3_cat1_task.status
+    sibling = product_test.tasks.c3_cat1_task
+    return status unless sibling
+    return status if status == sibling.status
+    return 'incomplete' if incomplete? || sibling.incomplete?
     'failing'
   end
 end

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -26,8 +26,10 @@ class C2Task < Task
 
   # returns combined status including c3_cat3 task
   def status_with_sibling
-    return status unless product_test.tasks.c3_cat3_task
-    return status if status == product_test.tasks.c3_cat3_task.status
+    sibling = product_test.tasks.c3_cat3_task
+    return status unless sibling
+    return status if status == sibling.status
+    return 'incomplete' if incomplete? || sibling.incomplete?
     'failing'
   end
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -58,6 +58,10 @@ class Task
     status == 'failing'
   end
 
+  def incomplete?
+    status == 'incomplete'
+  end
+
   def status
     Rails.cache.fetch("#{cache_key}/status") do
       recent_execution = most_recent_execution

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -93,10 +93,12 @@ class TestExecution
   end
 
   # returns combined status including c3 test execution
-  # returns passing if both passing, incomplete if both incomplete, failing if both failing or mismatched
+  # returns passing if both passing, incomplete if either incomplete, failing if both complete and at least one failing
   def status_with_sibling
-    return status unless sibling_execution
-    return status if status == sibling_execution.status
+    sibling = sibling_execution
+    return status unless sibling
+    return status if status == sibling.status
+    return 'incomplete' if incomplete? || sibling.incomplete?
     'failing' # failing if status's do not match
   end
 end


### PR DESCRIPTION
Fixes the "combined status" for tasks/tests that have a sibling. Previously if the 2 items had different statuses that was considered failing, but really if 1 is passing and the other is incomplete, the combined status should be incomplete.

This manifested as the test execution page reloading when only 1 of 2 jobs was complete, and potentially displaying as "failed with 0 errors" because the status was "failed" when 1 task was passing and the other incomplete