### PR TITLE
Error messages when records not expected to be returned

### DIFF
--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -30,7 +30,6 @@ module Validators
       doc_name = build_doc_name(doc)
       mrn = @names[doc_name]
       return nil unless mrn
-      @found_names << doc_name
       mrn
     end
 
@@ -86,7 +85,17 @@ module Validators
 
     def validate(doc, options)
       @can_continue = true
-      super unless validate_calculated_results(doc, options)
+      valid = validate_calculated_results(doc, options)
+      if valid
+        doc_name = build_doc_name(doc)
+        mrn = @names[doc_name]
+        @found_names << doc_name if mrn
+        # we still need to validate that the returned record is one of the test records
+        # and that it was expected to be returned (ie, in the IPP)
+        validate_name(doc_name, options) && validate_expected_results(doc_name, mrn, options)
+      else
+        super
+      end
     end
   end
 end

--- a/test/models/c1_task_test.rb
+++ b/test/models/c1_task_test.rb
@@ -41,6 +41,7 @@ class C1TaskTest < ActiveSupport::TestCase
       te = task.execute(zip)
       te.reload
       assert_equal 1, te.execution_errors.length, 'should be 1 error from cat I archive'
+      assert_equal '4 files expected but was 5', te.execution_errors[0].message
     end
   end
 
@@ -51,6 +52,8 @@ class C1TaskTest < ActiveSupport::TestCase
       te = task.execute(zip)
       te.reload
       assert_equal 2, te.execution_errors.length, 'should be 2 errors from cat I archive'
+      assert_equal 'Patient name \'GP_PEDS CPPP\' declared in file not found in test records', te.execution_errors[0].message
+      assert_equal 'Records for patients GP_PEDS C not found in archive as expected', te.execution_errors[1].message
     end
   end
 


### PR DESCRIPTION
Reverts #370 and switches the if condition to fix the bug it addressed. That change was previously made to prevent the original smoking gun validator from running when the calculating smoking gun validator passes. 

What should happen is that the record inclusion checks from the SMG should always occur, whether or not the calcSMG passes. These inclusion checks result in the error messages "Patient name XYZ declared in file not found in test records" and "Patient XYZ not expected to be returned"