### PR TITLE
Added restart policies to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@ cypress:
   links:
     - mongodb:mongo
   env_file: .env-prod
+  restart: unless-stopped
 mongodb:
   image: mongo
   volumes:
     - /data/db:/data/db
   ports:
     - "27017:27017"
+  restart: unless-stopped


### PR DESCRIPTION
The docker way to restart containers when they get stopped is to define restart policies. The restart policies below will restart the docker containers if the daemon gets stopped, unless the containers are stopped first (for example, by a Ctrl-C to the window running them). I tested this in an ubuntu vm, and after rebooting the VM the docker containers came back up as well.