### PR TITLE
API Response with Error Message

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!, :check_bundle_installed, except: [:page_not_found, :server_error]
   around_action :catch_not_found
-  around_action :catch_parameter_missing
 
   rescue_from CanCan::AccessDenied do |exception|
     render text: exception, status: 401
@@ -112,11 +111,5 @@ class ApplicationController < ActionController::Base
     yield
   rescue Mongoid::Errors::DocumentNotFound, Mongoid::Errors::InvalidFind
     render :nothing => true, :status => :not_found
-  end
-
-  def catch_parameter_missing
-    yield
-  rescue ActionController::ParameterMissing
-    render :nothing => true, :status => :bad_request
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -110,8 +110,6 @@ class ProductsController < ApplicationController
   end
 
   def product_params
-    params.require(:product).require(:measure_ids)
-    params.require(:product).require(:name)
     params.require(:product).permit(:name, :version, :description, :randomize_records, :duplicate_records, :bundle_id, :measure_selection,
                                     :c1_test, :c2_test, :c3_test, :c4_test, measure_ids: [])
   end

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -48,13 +48,12 @@ class TestExecutionsController < ApplicationController
 
   private
 
-  # in separate function because rubocop assignment branch condition size was too high
   def rescue_create
     alert = 'Invalid file upload. Please make sure you upload an XML or zip file.'
     respond_with(@test_execution) do |f|
       f.html { redirect_to new_task_test_execution_path(task_id: @task.id), flash: { alert: alert.html_safe } }
-      f.json { render :nothing => true, :status => :unprocessable_entity }
-      f.xml  { render :nothing => true, :status => :unprocessable_entity }
+      f.json { render :json => { errors: 'invalid file upload. upload a zip for CAT I or XML for CAT III' }, :status => :unprocessable_entity }
+      f.xml  { render :xml => { errors: 'invalid file upload. upload a zip for CAT I or XML for CAT III' }, :status => :unprocessable_entity }
     end
   end
 
@@ -74,6 +73,6 @@ class TestExecutionsController < ApplicationController
   end
 
   def results_params
-    params.require(:results)
+    params[:results]
   end
 end

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -40,7 +40,7 @@ class VendorsController < ApplicationController
     end
   rescue Mongoid::Errors::Validations
     respond_with(@vendor) do |f|
-      f.html { render :new }
+      f.html { render :new, :status => :bad_request }
     end
   end
 
@@ -56,7 +56,7 @@ class VendorsController < ApplicationController
     end
   rescue Mongoid::Errors::Validations
     respond_with(@vendor) do |f|
-      f.html { render :edit }
+      f.html { render :edit, :status => :bad_request }
     end
   end
 
@@ -75,7 +75,6 @@ class VendorsController < ApplicationController
   end
 
   def vendor_params
-    params.require(:vendor).require(:name)
     params.require(:vendor).permit(:name, :vendor_id, :url, :address, :state, :zip,
                                    points_of_contact_attributes: [:id, :name, :email, :phone, :contact_type, :_destroy])
   end

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -349,7 +349,7 @@ class ProductsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
       post :create, :format => :json, :vendor_id => vendor.id, :product => { c1_test: true, bundle_id: '4fdb62e01d41c820f6000001',
                                                                              measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'] }
-      assert_response 400, 'response should be Bad Request on product create'
+      assert_response 422, 'response should be Unprocessable Entity on product create with no name'
     end
   end
 
@@ -368,10 +368,10 @@ class ProductsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
       post :create, :format => :json, :vendor_id => vendor.id, :product => { name: "Product JSON post #{rand}", c1_test: true,
                                                                              bundle_id: '4fdb62e01d41c820f6000001' }
-      assert_response 400, 'response should be Bad Request on product create'
+      assert_response 422, 'response should be Unprocessable Entity on product create with no measure_ids'
       post :create, :format => :json, :vendor_id => vendor.id, :product => { name: "Product JSON post #{rand}", c1_test: true, measure_ids: [],
                                                                              bundle_id: '4fdb62e01d41c820f6000001' }
-      assert_response 400, 'response should be Bad Request on product create'
+      assert_response 422, 'response should be Unprocessable Entity on product create with empty measure_ids'
     end
   end
 

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -356,8 +356,8 @@ class TestExecutionsControllerTest < ActionController::TestCase
   test 'should see execution_errors when test_execution is ready after xml request' do
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       perform_enqueued_jobs do
-        @first_task.product_test = @first_product.product_tests.build({ name: 'mtest2', measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
-                                                                        bundle_id: '4fdb62e01d41c820f6000001' }, MeasureTest)
+        @first_task.product_test = @first_product.product_tests.build({ name: 'mtest2',
+                                                                        measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'] }, MeasureTest)
         @first_task.product_test.save!
         @first_task.save!
         post :create, :format => :xml, :task_id => @first_task.id, :results => xml_upload

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -225,7 +225,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @task_cat1.id, :results => xml_upload
       assert_response 422, 'response should be Unprocessable Entity if invalid upload type'
-      assert_equal '', response.body
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 
@@ -234,7 +234,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @task_cat3.id, :results => zip_upload
       assert_response 422, 'response should be Unprocessable Entity if invalid upload type'
-      assert_equal '', response.body
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 
@@ -383,8 +383,8 @@ class TestExecutionsControllerTest < ActionController::TestCase
     make_first_task_type('C1Task')
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @first_task.id
-      assert_response 400, 'response should be Bad Request if no results given'
-      assert_equal '', response.body
+      assert_response 422, 'response should be Unprocessable Entity if no results given'
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 
@@ -392,8 +392,8 @@ class TestExecutionsControllerTest < ActionController::TestCase
     make_first_task_type('C1Task')
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @first_task.id, :results => nil
-      assert_response 400, 'response should be Bad Request if nil results given'
-      assert_equal '', response.body
+      assert_response 422, 'response should be Unprocessable Entity if nil results given'
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 
@@ -402,7 +402,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @first_task.id, :results => xml_upload
       assert_response 422, 'response should be Unprocessable Entity if no test_execution'
-      assert_equal '', response.body
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 

--- a/test/controllers/vendors_controller_test.rb
+++ b/test/controllers/vendors_controller_test.rb
@@ -99,8 +99,8 @@ class VendorsControllerTest < ActionController::TestCase
   test 'should not post create with json request if no name' do
     for_each_logged_in_user([ADMIN, ATL, USER]) do
       post :create, :format => :json, :vendor => { poc_attributes: { name: 'test poc' } }
-      assert_response 400, 'response should be Bad Request if no name given'
-      assert_equal '', response.body
+      assert_response 422, 'response should be Unprocessable Entity if no name given'
+      assert_not_nil JSON.parse(response.body)['errors']
     end
   end
 
@@ -197,8 +197,8 @@ class VendorsControllerTest < ActionController::TestCase
   test 'should not post create with xml request if no name' do
     for_each_logged_in_user([ADMIN, ATL, USER]) do
       post :create, :format => :xml, :vendor => { poc_attributes: { name: 'test poc' } }
-      assert_response 400, 'response should be Bad Request if no name given'
-      assert_equal '', response.body
+      assert_response 422, 'response should be Unprocessable Entity if no name given'
+      assert_not_nil Hash.from_trusted_xml(response.body)['errors']
     end
   end
 


### PR DESCRIPTION
- changed 400 (bad request) response for not including required attributes to 422 (unprocessable entity) response. 422 is the rails default response for this
- check for required parameters in product removed in place of validation errors in models
- added error messages to response body for 422 (unprocessable entity) responses