### PR TITLE
fix validation issue when filling out optional fields

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -21,11 +21,7 @@
         'data-parsley-required': '',
         'data-parsley-trigger': 'blur' %>
       <%= f.password_field :password, label: 'New Password', autocomplete: "off", autocapitalize: 'off', autocorrect: 'off', help: "leave blank if you don't want to change it" %>
-      <%= f.password_field :password_confirmation, label: 'Confirm New Password', autocomplete: "off", autocapitalize: 'off', autocorrect: 'off',
-        'data-parsley-required': '',
-        'data-parsley-equalto': '#user_password',
-        'data-parsley-equalto-message': 'Passwords do not match',
-        'data-parsley-trigger': 'blur' %>
+      <%= f.password_field :password_confirmation, label: 'Confirm New Password', autocomplete: "off", autocapitalize: 'off', autocorrect: 'off' %>
     </div>
     <div class="panel-footer">
       <%= f.primary "Update" %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -28,7 +28,7 @@
         'data-parsley-trigger': 'blur' %>
     </div>
     <div class="panel-footer">
-      <%= f.primary "Update", disabled: true %>
+      <%= f.primary "Update" %>
       <%= link_to "Back", :back, class: 'btn btn-default' %>
     </div>
   <% end %>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -83,7 +83,7 @@
     </div>
 
     <div class="panel-footer">
-      <%= f.submit submit_text, class: "btn btn-success", disabled: true %>
+      <%= f.submit submit_text, class: "btn btn-success", disabled: @product.new_record? %>
       <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>
     </div>
   <% end %>

--- a/app/views/vendors/_vendor_form.html.erb
+++ b/app/views/vendors/_vendor_form.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="panel-footer">
-    <%= f.submit submit_text, :class => "btn btn-success", :id => "submit_button", disabled: true %>
+    <%= f.submit submit_text, :class => "btn btn-success", :id => "submit_button", disabled: @vendor.new_record? %>
     <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>
   </div>
 <% end %>


### PR DESCRIPTION
Example: When editing a vendor's POCs, the submit button won't let you submit (until you have triggered parsley validation on required fields).
Fix: When updating or editing, don't disable the form.