### PR TITLE
debug features for qa

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   include API::Controller
 
-  before_action :set_task, only: [:edit, :update, :destroy, :show]
+  before_action :set_task, only: [:edit, :update, :destroy, :show, :good_results]
   before_action :set_product_test, only: [:index, :new]
   before_action :authorize_vendor
 
@@ -24,6 +24,24 @@ class TasksController < ApplicationController
 
   def show
     respond_with(@task)
+  end
+
+  def good_results
+    redirect_to(:back) && return unless APP_CONFIG['enable_debug_features']
+    task_type = @task._type
+    redirect_to(:back) && return if %w(C3Cat1Task C3Cat3Task).include? task_type
+
+    file_type = if %w(C1Task Cat1FilterTask).include? task_type
+                  'zip'
+                elsif %w(C2Task Cat3FilterTask).include? task_type
+                  'xml'
+                end
+
+    file_content = @task.good_results
+    pt = @task.product_test
+    file_name = "#{pt.cms_id}_#{pt.id}.debug.#{file_type}".tr(' ', '_')
+
+    send_data file_content, type: "application/#{file_type}", disposition: 'attachment', filename: file_name
   end
 
   private

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -31,6 +31,10 @@ class C1Task < Task
     product_test.records.in('_id' => patient_ids)
   end
 
+  def good_results
+    Cypress::CreateDownloadZip.create_zip(records, 'qrda').read
+  end
+
   # returns combined status including c3_cat1 task
   def status_with_sibling
     sibling = product_test.tasks.c3_cat1_task

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -24,6 +24,13 @@ class C2Task < Task
     te
   end
 
+  def good_results
+    cat1_zip = Cypress::CreateDownloadZip.create_zip(records, 'qrda')
+    c3c = Cypress::Cat3Calculator.new(product_test.measure_ids, product_test.bundle)
+    c3c.import_cat1_zip(cat1_zip)
+    c3c.generate_cat3
+  end
+
   # returns combined status including c3_cat3 task
   def status_with_sibling
     sibling = product_test.tasks.c3_cat3_task

--- a/app/models/cat1_filter_task.rb
+++ b/app/models/cat1_filter_task.rb
@@ -21,6 +21,10 @@ class Cat1FilterTask < Task
     te
   end
 
+  def good_results
+    Cypress::CreateDownloadZip.create_zip(records, 'qrda').read
+  end
+
   def records
     patient_ids = product_test.results.where('value.IPP' => { '$gt' => 0 }).collect { |pc| pc.value.patient_id }
     product_test.filtered_records.in('_id' => patient_ids)

--- a/app/models/cat3_filter_task.rb
+++ b/app/models/cat3_filter_task.rb
@@ -12,4 +12,11 @@ class Cat3FilterTask < Task
     te.save
     te
   end
+
+  def good_results
+    cat1_zip = Cypress::CreateDownloadZip.create_zip(product_test.filtered_records, 'qrda')
+    c3c = Cypress::Cat3Calculator.new(product_test.measure_ids, product_test.bundle)
+    c3c.import_cat1_zip(cat1_zip)
+    c3c.generate_cat3
+  end
 end

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -23,4 +23,8 @@
 
   <br/>
   <%= link_to 'View Patients', { controller: 'records', task_id: @task.id}, method: :get %>
+  <% if APP_CONFIG['enable_debug_features'] %>
+  <br/>
+  <%= link_to 'Get Known Good Result', good_results_task_path(@task), data: { no_turbolink: true } %>
+  <% end %>
 </div>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -18,6 +18,9 @@ bundle_file_path: "temp/bundles"
 # ignore roles completely -- this is essientially the same as everyone in the system being an admin
 ignore_roles: true
 
+# enable the "debug features" such as allowing QA testers to produce known good results for a task
+enable_debug_features: false
+
 # the default role to assign to a user upon at creation -- this should be either admin,atl, user or nil
 # a user without a role will not be able to create or view any vendors .  You may want to set this to nil
 # when an admin is required to approve new users and have the admin set the role there

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,9 @@ Rails.application.routes.draw do
   end
 
   resources :tasks, only: [:show] do
+    member do
+      get :good_results
+    end
     resources :test_executions, only: [:index, :show, :new, :create, :destroy]
   end
 

--- a/test/models/c1_task_test.rb
+++ b/test/models/c1_task_test.rb
@@ -109,6 +109,17 @@ class C1TaskTest < ActiveSupport::TestCase
       # extra record has qrda errors but those should not be validated (in either case)
     end
   end
+
+  def test_task_good_results_should_pass
+    task = @product_test.tasks.create({}, C1Task)
+    testfile = Tempfile.new(['good_results_debug_file', '.zip'])
+    testfile.write task.good_results
+    perform_enqueued_jobs do
+      te = task.execute(testfile)
+      te.reload
+      assert_equal 0, te.execution_errors.count, 'test execution with known good results should have no errors'
+    end
+  end
 end
 
 require_relative '../helpers/caching_test'

--- a/test/models/cat1_filter_task_test.rb
+++ b/test/models/cat1_filter_task_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+class Cat1FilterTaskTest < ActiveSupport::TestCase
+  include ::Validators
+  include ActiveJob::TestHelper
+
+  def setup
+    collection_fixtures('product_tests', 'products', 'bundles',
+                        'measures', 'records', 'patient_cache',
+                        'health_data_standards_svs_value_sets')
+
+    vendor = Vendor.create(name: 'test_vendor_name')
+    product = vendor.products.create(name: 'test_product', randomize_records: true, c2_test: true, c4_test: true,
+                                     bundle_id: '4fdb62e01d41c820f6000001', measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'])
+
+    options = { 'filters' => { 'genders' => ['F'] } }
+    @product_test = product.product_tests.create({ name: 'test_for_measure_1a',
+                                                   measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'],
+                                                   options: options }, FilteringTest)
+  end
+
+  def test_create
+    assert @product_test.tasks.create({}, Cat1FilterTask)
+  end
+
+  def test_task_good_results_should_pass
+    task = @product_test.tasks.create({}, Cat1FilterTask)
+    testfile = Tempfile.new(['good_results_debug_file', '.zip'])
+    testfile.write task.good_results
+    perform_enqueued_jobs do
+      te = task.execute(testfile)
+      te.reload
+      assert_equal 0, te.execution_errors.count, 'test execution with known good results should have no errors'
+    end
+  end
+end

--- a/test/models/cat3_filter_task_test.rb
+++ b/test/models/cat3_filter_task_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Cat3FilterTaskTest < ActiveSupport::TestCase
+  include ::Validators
+  include ActiveJob::TestHelper
+
+  def setup
+    collection_fixtures('product_tests', 'products', 'bundles',
+                        'measures', 'records', 'patient_cache',
+                        'health_data_standards_svs_value_sets')
+
+    vendor = Vendor.create(name: 'test_vendor_name')
+    product = vendor.products.create(name: 'test_product', randomize_records: true, c2_test: true, c4_test: true,
+                                     bundle_id: '4fdb62e01d41c820f6000001', measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'])
+
+    product.save!
+    options = { 'filters' => { 'genders' => ['F'] } }
+    @product_test = product.product_tests.create({ name: 'test_for_measure_1a',
+                                                   measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'],
+                                                   options: options }, FilteringTest)
+  end
+
+  def test_create
+    assert @product_test.tasks.create({}, Cat3FilterTask)
+  end
+
+  def test_task_good_results_should_pass
+    task = @product_test.tasks.create({ expected_results: @product_test.expected_results }, Cat3FilterTask)
+    xml = Tempfile.new(['good_results_debug_file', '.xml'])
+    xml.write task.good_results
+    perform_enqueued_jobs do
+      te = task.execute(xml)
+      te.reload
+      assert_equal 0, te.execution_errors.count, 'test execution with known good results should not have any errors'
+    end
+  end
+end

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 class MeasureTestTest < ActiveJob::TestCase
   def setup
-    collection_fixtures('patient_cache', 'records', 'bundles', 'measures')
+    collection_fixtures('patient_cache', 'records', 'bundles', 'measures',
+                        'health_data_standards_svs_value_sets')
     @vendor = Vendor.create!(name: 'test_vendor_name')
     @product = @vendor.products.create(name: 'test_product', measure_ids: ['8A4D92B2-397A-48D2-0139-C648B33D5582'], bundle_id: '4fdb62e01d41c820f6000001')
   end


### PR DESCRIPTION
Adds the ability to generate a known good result for tasks, to allow QA testers to see what things should look like when everything passes.
The link is available on the test execution page, below View Patients:
![known_good_result](https://cloud.githubusercontent.com/assets/13512036/14350238/32abecb0-fc96-11e5-8b95-78340621ea59.JPG)
The link is enabled with the use of a new config setting.

Note: The "known good result" is created by task, and all task subtypes except the C3 tasks can generate them. C3 tasks are not standalone so there's no way to view just a c3 task.