### PR TITLE
Added filters to API filtering test responses

### DIFF
--- a/api/schema/json/product_test.json
+++ b/api/schema/json/product_test.json
@@ -9,6 +9,33 @@
     "measure_id": {"type": "string"},
     "type": {"type": "string"},
     "state": {"type": "string"},
+    "filters" : {
+      "type" : "object",
+      "properties" : {
+        "problem" : {"type": "string"},
+        "gender" : {"type": "string"},
+        "payer" : {"type": "string"},
+        "race" : {"type": "string"},
+        "ethnicity" : {"type": "string"},
+        "provider" : {
+          "type" : "object",
+          "properties" : {
+            "npi" : {"type": "string"},
+            "tin" : {"type": "string"},
+            "provider" : {
+              "type" : "object",
+              "properties" : {
+                "street" : {"type": "string"},
+                "city" : {"type": "string"},
+                "state" : {"type": "string"},
+                "zip" : {"type": "string"},
+                "country" : {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
     "created_at": {"type": "string", "format": "date-time"},
     "updated_at": {"type": "string", "format": "date-time"}
   },

--- a/api/schema/json/product_test.json
+++ b/api/schema/json/product_test.json
@@ -22,7 +22,7 @@
           "properties" : {
             "npi" : {"type": "string"},
             "tin" : {"type": "string"},
-            "provider" : {
+            "address" : {
               "type" : "object",
               "properties" : {
                 "street" : {"type": "string"},

--- a/app/representers/product_test_representer.rb
+++ b/app/representers/product_test_representer.rb
@@ -1,3 +1,4 @@
+require 'representable/xml'
 module ProductTestRepresenter
   include API::Representer
 

--- a/app/representers/product_test_representer.rb
+++ b/app/representers/product_test_representer.rb
@@ -7,6 +7,41 @@ module ProductTestRepresenter
   property :type, getter: ->(_args) { _type == 'MeasureTest' ? 'measure' : 'filter' }
   property :state
 
+  module ProviderRepresenter
+    include Representable::XML
+    include Representable::JSON
+
+    module AddressRepresenter
+      include Representable::XML
+      include Representable::JSON
+
+      self.representation_wrap = ->(obj) { obj.key?(:doc) ? :address : false }
+
+      property :street, getter: ->(_) { self['street'].first }
+      property :city
+      property :state
+      property :zip, getter: -> (_) { self['zip'] }
+      property :country
+    end
+
+    self.representation_wrap = ->(obj) { obj.key?(:doc) ? :provider : false }
+
+    property :npi, getter: ->(_) { self['npis'].first }
+    property :tin, getter: ->(_) { self['tins'].first }
+    property :address, extend: AddressRepresenter, if: ->(_) { self['addresses'] }, getter: ->(_) { self['addresses'].first }
+  end
+
+  hash :provider_filters, :if => ->(_) { _type == 'FilteringTest' && options.filters.key?('providers') }, :wrap => :filters,
+                          :as => :filters, :extend => ProviderRepresenter,
+                          :getter => (lambda do |*|
+                            filters_copy = options.filters.clone
+                            filters_copy['provider'] = filters_copy.delete 'providers'
+                            filters_copy
+                          end)
+
+  hash :other_filters, :getter => ->(_) { options.filters.map { |filter_type, filter_val| [filter_type.to_s.singularize, filter_val.first] }.to_h },
+                       :if => ->(_) { _type == 'FilteringTest' && !options.filters['providers'] }, :wrap => :filters, :as => :filters
+
   self.links = {
     self: proc { product_product_test_path(product, self) },
     tasks: proc { product_test_tasks_path(self) },


### PR DESCRIPTION
Here are examples of what the additions look like in JSON and XML:

**JSON:**
```JSON
"filters": {
    "ethnicity": "2186-5",
    "race": "2106-3"
}


"filters": {
    "problem": "2.16.840.1.113883.3.464.1003.103.12.1001"
}

"filters": {
    "provider": {
        "npi": "6892960108",
        "tin": "1554520",
        "address": {
            "street": "11 Main St",
            "city": "Allston",
            "state": "MA",
            "zip": "02134",
            "country": "us"
        }
    }
}
```

**XML:**
```XML
<filters>
  <ethnicity>2186-5</ethnicity>
  <race>2106-3</race>
</filters>


<filters>
  <problem>2.16.840.1.113883.3.464.1003.103.12.1001</problem>
</filters>


<filters>
  <provider>
    <npi>6892960108</npi>
    <tin>1554520</tin>
    <address>
      <street>11 Main St</street>
      <city>Allston</city>
      <state>MA</state>
      <zip>02134</zip>
      <country>us</country>
    </address>
  </provider>
</filters>
```

@jaebird123 and @okeefm with the assists on this one :sparkles: 