### PR TITLE
api created success responses

### DIFF
--- a/api/api.raml
+++ b/api/api.raml
@@ -31,6 +31,9 @@ baseUriParameters:
     responses:
       201:
         description: Successfully created a new vendor
+        body:
+          application/json:
+            schema: !include schema/json/vendor.json
       422:
         description: Invalid vendor
         body:
@@ -84,6 +87,9 @@ baseUriParameters:
         responses:
           201:
             description: Product has been created
+            body:
+              application/json:
+                schema: !include schema/json/product.json
           422:
             description: Invalid Product
             body:
@@ -183,6 +189,9 @@ baseUriParameters:
     responses:
       201:
         description: File Uploaded Successfully. Cypress is checking data for accuracy and correctness
+        body:
+          application/json:
+            schema: !include schema/json/test_execution.json
       422:
         description: File uploaded is not processable by Cypress
         body:

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -34,8 +34,6 @@ class ProductsController < ApplicationController
     flash_comment(@product.name, 'success', 'created')
     respond_with(@product) do |f|
       f.html { redirect_to vendor_path(@vendor) }
-      f.json { render :nothing => true, :status => :created, :location => vendor_product_path(@vendor, @product.id) }
-      f.xml  { render :nothing => true, :status => :created, :location => vendor_product_path(@vendor, @product.id) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with_errors(@product) do |f|

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -19,8 +19,6 @@ class TestExecutionsController < ApplicationController
     @test_execution = @task.execute(results_params)
     respond_with(@test_execution) do |f|
       f.html { redirect_to task_test_execution_path(task_id: @task.id, id: @test_execution.id) }
-      f.json { render :nothing => true, :status => :created, :location => task_test_execution_path(@task.id, @test_execution.id) }
-      f.xml  { render :nothing => true, :status => :created, :location => task_test_execution_path(@task.id, @test_execution.id) }
     end
   rescue Mongoid::Errors::Validations
     rescue_create

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -35,8 +35,6 @@ class VendorsController < ApplicationController
     flash_comment(@vendor.name, 'success', 'created')
     respond_with(@vendor) do |f|
       f.html { redirect_to root_path }
-      f.json { render :nothing => true, :status => :created, :location => vendor_path(@vendor.id) }
-      f.xml  { render :nothing => true, :status => :created, :location => vendor_path(@vendor.id) }
     end
   rescue Mongoid::Errors::Validations
     respond_with_errors(@vendor) do |f|

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -261,8 +261,8 @@ class ProductsControllerTest < ActionController::TestCase
                                                                              measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
                                                                              bundle_id: '4fdb62e01d41c820f6000001' }
       assert_response 201, 'response should be Created on product create'
-      assert_equal(vendor_product_path(vendor, vendor.products.order_by(created_at: 'desc').first),
-                   response.location, 'response location should be product show')
+      assert response.location.end_with?(product_path(vendor.products.order_by(created_at: 'desc').first)),
+             'response location should be product show'
     end
   end
 
@@ -308,8 +308,8 @@ class ProductsControllerTest < ActionController::TestCase
                                                                             measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
                                                                             bundle_id: '4fdb62e01d41c820f6000001' }
       assert_response 201, 'response should be Created on product create'
-      assert_equal(vendor_product_path(vendor, vendor.products.order_by(created_at: 'desc').first),
-                   response.location, 'response location should be product show')
+      assert response.location.end_with?(product_path(vendor.products.order_by(created_at: 'desc').first)),
+             'response location should be product show'
     end
   end
 

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -179,9 +179,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @task_cat1.id, :results => zip_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@task_cat1, @task_cat1.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil JSON.parse(response.body)
+      assert_equal 'pending', JSON.parse(response.body)['state']
+      assert response.location.end_with?(test_execution_path(@task_cat1.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 
@@ -190,9 +191,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @task_cat3.id, :results => xml_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@task_cat3, @task_cat3.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil JSON.parse(response.body)
+      assert_equal 'pending', JSON.parse(response.body)['state']
+      assert response.location.end_with?(test_execution_path(@task_cat3.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 
@@ -203,9 +205,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :xml, :task_id => @task_cat1.id, :results => zip_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@task_cat1, @task_cat1.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil Hash.from_trusted_xml(response.body)
+      assert_equal 'pending', Hash.from_trusted_xml(response.body)['test_execution']['state']
+      assert response.location.end_with?(test_execution_path(@task_cat1.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 
@@ -214,9 +217,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :xml, :task_id => @task_cat3.id, :results => xml_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@task_cat3, @task_cat3.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil Hash.from_trusted_xml(response.body)
+      assert_equal 'pending', Hash.from_trusted_xml(response.body)['test_execution']['state']
+      assert response.location.end_with?(test_execution_path(@task_cat3.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 
@@ -295,9 +299,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :json, :task_id => @first_task.id, :results => zip_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@first_task, @first_task.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil JSON.parse(response.body)
+      assert_equal 'pending', JSON.parse(response.body)['state']
+      assert response.location.end_with?(test_execution_path(@first_task.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 
@@ -355,9 +360,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       post :create, :format => :xml, :task_id => @first_task.id, :results => xml_upload
       assert_response 201, 'response should be Created on test_execution creation'
-      assert_equal('', response.body, 'response body should be empty on test_execution creation')
-      assert_equal(task_test_execution_path(@first_task, @first_task.most_recent_execution), response.location,
-                   'response location should be test_execution show')
+      assert_not_nil Hash.from_trusted_xml(response.body)
+      assert_equal 'pending', Hash.from_trusted_xml(response.body)['test_execution']['state']
+      assert response.location.end_with?(test_execution_path(@first_task.most_recent_execution)),
+             'response location should be test_execution show'
     end
   end
 

--- a/test/controllers/vendors_controller_test.rb
+++ b/test/controllers/vendors_controller_test.rb
@@ -83,7 +83,8 @@ class VendorsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, USER]) do
       post :create, :format => :json, :vendor => { name: "test vendor #{vendor_index}", poc_attributes: { name: 'test poc' } }
       assert_response :created, 'response should be Created'
-      assert_equal '', response.body
+      assert_not_nil JSON.parse(response.body)
+      assert_equal "test vendor #{vendor_index}", JSON.parse(response.body)['name']
       assert assigns(:vendor)
       assert response.headers['Location']
       get :show, :format => :json, :id => response.headers['Location'].split('/').last
@@ -181,7 +182,8 @@ class VendorsControllerTest < ActionController::TestCase
     for_each_logged_in_user([ADMIN, ATL, USER]) do
       post :create, :format => :xml, :vendor => { name: "test vendor #{vendor_index}", poc_attributes: { name: 'test poc' } }
       assert_response :created, 'response should be Created'
-      assert_equal '', response.body
+      assert_not_nil Hash.from_trusted_xml(response.body)
+      assert_equal "test vendor #{vendor_index}", Hash.from_trusted_xml(response.body)['vendor']['name']
       assert assigns(:vendor)
       assert response.headers['Location']
       get :show, :format => :xml, :id => response.headers['Location'].split('/').last


### PR DESCRIPTION
api now responds with created object on product, vendor, test execution creation. Rails default is to respond with the object, so this just removes the custom respond options we were using previously