### PR TITLE
remove text that shouldn't be there

### DIFF
--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -10,7 +10,7 @@
 <% num_measure_tests_ready = product.product_tests.measure_tests.where(state: :ready).count %>
 <% if num_measure_tests_ready == num_measure_tests %>
   <p>This download contains a folder for each measure selected for this product. Inside these folders are XML documents for each patient associated with that measure.</p>
-  <%= form_for product, url: { controller: 'products', action: 'patients' }, :html => { :method => 'GET' } do |f| %>to report and patients respectively.
+  <%= form_for product, url: { controller: 'products', action: 'patients' }, :html => { :method => 'GET' } do |f| %>
     <%= button_tag(type: 'submit', class: 'btn btn-primary') do %>
       <i class = 'fa fa-fw fa-download'></i> Download All Patients (.zip)
     <% end %>


### PR DESCRIPTION
remove the extra text above the bulk download button:

![text](https://cloud.githubusercontent.com/assets/13512036/14439053/2801dd92-fff7-11e5-9b20-6a65ae2d1f23.JPG)
