### PR TITLE
508 fixes from 4/20 review

### DIFF
--- a/app/assets/javascripts/test_executions.js
+++ b/app/assets/javascripts/test_executions.js
@@ -1,6 +1,11 @@
 
 var ready;
 ready = function() {
+  // switch view to selected test execution
+  $("#view_execution").click(function(event) {
+    window.location.href = $("#select_execution").val();
+  });
+
   $("#submit-upload").click(function(event) {
     event.preventDefault();
     $("#new_test_execution").submit();

--- a/app/assets/stylesheets/cypress/_text.scss
+++ b/app/assets/stylesheets/cypress/_text.scss
@@ -39,3 +39,5 @@ main a:not(.btn):not(.task-switch-link) {
     margin-top: 1em;
   }
 }
+
+main:focus { outline: none; }

--- a/app/assets/stylesheets/cypress/_xml_view.scss
+++ b/app/assets/stylesheets/cypress/_xml_view.scss
@@ -1,20 +1,15 @@
 
-$xml-orange:            #F4A460 !default;
-$xml-light-orange:      lighten($xml-orange, 25%) !default;
-$xml-dark-orange:       darken($xml-orange, 25%) !default;
-$xml-red:               #FF6347 !default;
-$xml-light-red:         lighten($xml-red, 25%) !default;
-$xml-green:             green !default;
-$xml-gray:              lighten($gray-base, 60%) !default;
+$xml-orange:            lighten($brand-warning, 10%) !default;
+$xml-light-orange:      lighten($xml-orange, 15%) !default;
+$xml-dark-orange:       darken($xml-orange, 10%) !default;
+$xml-red:               lighten($brand-danger, 15%) !default;
+$xml-light-red:         lighten($xml-red, 15%) !default;
+$xml-green:             $brand-success !default;
+$xml-gray:              $gray !default;
 
 .xml-frame {
-  
-    .indent {
+  .indent {
     margin-left: 1em;
-  }
-
-  .markup {
-    /*color: #00008b;*/
   }
 
   .comment {
@@ -25,12 +20,7 @@ $xml-gray:              lighten($gray-base, 60%) !default;
     color: $brand-primary;
   }
 
-  .start-tag, .end-tag {
-    /*color: $brand-info;*/
-  }
-
   .pi {
-    /*color: #9932CC;*/
     color: $xml-green;
   }
 
@@ -47,7 +37,7 @@ $xml-gray:              lighten($gray-base, 60%) !default;
       display: inline;
       vertical-align: -webkit-baseline-middle;
     }
-    
+
     .nav-link:hover {
       background: $gray-lighter;
       cursor: pointer;
@@ -64,9 +54,8 @@ $xml-gray:              lighten($gray-base, 60%) !default;
     }
   }
 
-  .attribute_error {  
+  .attribute_error {
     border: 2px dotted $xml-red;
-    /*background-color: #FF5F3;*/
     background-color: $xml-light-red;
     padding: 10px;
   }
@@ -80,11 +69,11 @@ $xml-gray:              lighten($gray-base, 60%) !default;
   .error-popup-btn {
     padding: 0;
     background-color: $xml-dark-orange;
-    
+
     i.fa-comment {
       background-color: $xml-orange;
       border: 5px solid $xml-orange;
-      margin-top:-4px;
+      margin-top: -4px;
     }
   }
 

--- a/app/views/application/_alerts.html.erb
+++ b/app/views/application/_alerts.html.erb
@@ -5,7 +5,7 @@
 
 <% if notice || alert || flash[:backend_job_alert] %>
     <div class="clearfix alert <%= flash[:notice_type] ? "alert-#{flash[:notice_type]}" : "alert-info" %> <%= alert ? "alert-danger" : "" %> alert-dismissible" role="alert" aria-live="polite">
-        <button type="button" class="close fa fa-fw fa-close" data-dismiss="alert" aria-label="Close"></button>
+        <button type="button" class="close fa fa-fw fa-close" data-dismiss="alert" aria-label="Close"><span class="sr-only">Close alert</span></button>
 
         <% if flash[:backend_job_alert] %>
           <div class="iconSpan pull-left">

--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -51,7 +51,7 @@
                       <i class="fa-li fa fa-phone" aria-hidden="true"></i>
                       <span class="sr-only">Phone number for <%= poc.name %></span>
                       <% if poc.phone.gsub(/[^0-9]/, '').length == 10 %>
-                        <a href="tel:<%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), country_code: 1) %>">
+                        <a href="tel:<%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), country_code: 1) %>" title="phone number for point of contact <%= poc.name %>">
                           <%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), area_code: true) %>
                         </a>
                       <% else %>

--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -18,8 +18,10 @@
         <% if @vendor.url? %>
           <li>
             <i class="fa-li fa fa-globe" aria-hidden="true"></i>
-            <span class="sr-only">Website for vendor <%= @vendor.name %></span>
-            <a href="<%= website_link(@vendor.url) %>"><%= website_link(@vendor.url) %></a>
+            <a href="<%= website_link(@vendor.url) %>">
+              <span class="sr-only">Website for vendor <%= @vendor.name %></span>
+              <%= website_link(@vendor.url) %>
+            </a>
           </li>
         <% end %>
         <% if @vendor.address? %>
@@ -40,8 +42,8 @@
                   <% if poc.email? %>
                     <li>
                       <i class="fa-li fa fa-envelope" aria-hidden="true"></i>
-                      <span class="sr-only">Email for <%= poc.name %></span>
                       <a href="mailto:<%= poc.email %>?subject=Cypress%20testing%20for%20<%= @vendor.name %>">
+                        <span class="sr-only">Email for <%= poc.name %></span>
                         <%= poc.email %>
                       </a>
                     </li>
@@ -49,13 +51,14 @@
                   <% if poc.phone? %>
                     <li>
                       <i class="fa-li fa fa-phone" aria-hidden="true"></i>
-                      <span class="sr-only">Phone number for <%= poc.name %></span>
                       <% if poc.phone.gsub(/[^0-9]/, '').length == 10 %>
-                        <a href="tel:<%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), country_code: 1) %>" title="phone number for point of contact <%= poc.name %>">
+                        <a href="tel:<%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), country_code: 1) %>">
+                          <span class="sr-only">Phone number for <%= poc.name %></span>
                           <%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), area_code: true) %>
                         </a>
                       <% else %>
                         <a href="tel:<%= poc.phone.gsub(/[^0-9]/, '') %>">
+                          <span class="sr-only">Phone number for <%= poc.name %></span>
                           <%= poc.phone.gsub(/[^0-9]/, '') %>
                         </a>
                       <% end %>

--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -32,10 +32,10 @@
           </li>
         <% end %>
         <% if !@vendor.points_of_contact.empty? %>
-        <span class="sr-only">Points of contact for vendor <%= @vendor.name %></span>
           <% @vendor.points_of_contact.each do |poc| %>
             <li class="point-of-contact">
               <i class="fa-li fa fa-user" aria-hidden="true"></i>
+              <span class="sr-only">Point of contact for vendor <%= @vendor.name %></span>
               <%= poc.name %> <%= "(#{poc.contact_type})" if poc.contact_type? %>
               <% if poc.email? || poc.phone? %>
                 <ul class="fa-ul">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -4,18 +4,19 @@
       <%= link_to root_path do %>cypress<% end %>
       <button type="button" class="navbar-toggle navbar-right" data-toggle="collapse" data-target="#cypressNavbar" aria-label="navigation menu" role="button" aria-controls="cypressNavbar" aria-expanded="false">
         <i class="fa fa-bars fa-2x" aria-hidden="true"></i>
+        <span class="sr-only">Expand navigation menu</span>
       </button>
     </div>
     <div class="collapse navbar-collapse" id="cypressNavbar">
       <ul class="nav navbar-nav navbar-right">
         <% if user_signed_in? %>
 
-          <% curr_page = if current_page?(edit_user_registration_path) 
+          <% curr_page = if current_page?(edit_user_registration_path)
                            :account
                          elsif (controller.controller_name == 'records' && params[:bundle_id]) || current_page?(:records)
-                           :master_patient_list 
+                           :master_patient_list
                          else
-                           :dashboard 
+                           :dashboard
                          end
            %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
   <%= csrf_meta_tags %>
 </head>
 <body>
-  <a href="#main-content" class="sr-only">Skip to main content</a>
+  <a href="#main-content" class="sr-only sr-only-focusable">Skip to main content</a>
 
   <% if APP_CONFIG['banner'] %>
     <div class="demo"><%= APP_CONFIG['banner_message'].html_safe %></div>
@@ -34,7 +34,7 @@
 
   </header>
 
-  <main aria-label="main section" id="main-content" class="container" role="main">
+  <main aria-label="main section" id="main-content" class="container" role="main" tabindex="-1">
     <div class="col-sm-12">
       <%= yield %>
     </div>

--- a/app/views/products/_measure_selection.html.erb
+++ b/app/views/products/_measure_selection.html.erb
@@ -24,20 +24,25 @@
             <% @measures_categories.sort.each do |category, measures| %>
               <!-- set up a checkbox for each top-level measure in the group -->
               <div id="<%= category.tr(" '", "_") %>_div" class="measure_group">
-                <% if measures.length > 1 %>
-                <legend for="<%= category.tr(" '", "_") %>_fieldset">
-                <div class="checkbox">
-                  <label class="btn btn-checkbox">
-                    <input type="checkbox"
-                      id="<%= category.tr(" '", "_") %>"
-                      class="measure_group_all"
-                      <%= 'disabled' if defined?(@selected_measure_ids) && !@product.new_record? %>/>
-                    Select all <%= measures.length %> <%= category %> measures
-                  </label>
-                </div>
-                </legend>
-                <% end %>
                 <fieldset id="<%= category.tr(" '", "_") %>_fieldset">
+                    <% if measures.length > 1 %>
+                    <legend for="<%= category.tr(" '", "_") %>_fieldset">
+                    <div class="checkbox">
+                      <label class="btn btn-checkbox">
+                        <input type="checkbox"
+                          id="<%= category.tr(" '", "_") %>"
+                          class="measure_group_all"
+                          <%= 'disabled' if defined?(@selected_measure_ids) && !@product.new_record? %>/>
+                        Select all <%= measures.length %> <%= category %> measures
+                      </label>
+                    </div>
+                    </legend>
+                  <% else %>
+                    <legend class="sr-only">
+                      <%= category %> measures
+                    </legend>
+                  <% end %>
+
                 <% measures.sort_by(&:cms_int).each do |m| %>
                   <div class = 'checkbox'>
                     <label class = 'btn btn-checkbox'>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -42,13 +42,13 @@
           <fieldset>
             <legend class="control-label">Annual Update Bundle</legend>
             <% if Bundle.count == 1 %>
-              <label class="h5"> <%= @bundle.title %> </label>
+              <label for="product_bundle_id" class="h5"> <%= @bundle.title %> </label>
               <%= hidden_field_tag 'product[bundle_id]', @bundle.id %>
             <% elsif Bundle.count > 1 %>
               <!-- loop through bundles & use radio buttons -->
               <%= f.form_group :bundle_id, help: "Select the measure versions Cypress should use to certify this product." do %>
                 <% Bundle.all.each do |bundle| %>
-                  <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox", 
+                  <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
                                      checked: bundle == @bundle, disabled: !@product.new_record? %>
 
                 <% end # bundle loop %>

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -56,11 +56,12 @@
       <h1 class='panel-title'>
         Results
         <div class = 'pull-right'>
-          <select aria-label="View test execution" onchange = "location = this.options[this.selectedIndex].value;">
+          <select id="select_execution" aria-label="View test execution">
             <% @task.test_executions.sort_by { |obj| obj.created_at }.reverse.each_with_index do |execution, i| %>
               <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i == 0) %></option>
             <% end %>
           </select>
+          <button id="view_execution" class="btn btn-xs btn-info">Refresh View</button>
         </div>
       </h1>
     </div>


### PR DESCRIPTION
These are some small changes to address alerts and errors that came up via Eny and I testing Cypress to the WCAG 2.0 AA standard using both [WAVE](http://wave.webaim.org/extension/) and [CodeSniffer](http://squizlabs.github.io/HTML_CodeSniffer/). Then we can move on to our next audit!