### PR TITLE
Persist settings changes to cypress.yml

### DIFF
--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -10,12 +10,12 @@
     <div class="panel-body">
         <%= f.text_area :banner_message, label: "Banner", value: banner_message %>
         <div class="row">
-          <%= f.text_field :address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: address %>
-          <%= f.number_field :port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: port %>
+          <%= f.text_field :mailer_address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: address %>
+          <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: port %>
         </div>
-        <%= f.text_field :domain, label: "Mailer Domain", value: domain %>
-        <%= f.text_field :user_name, label: "Mailer Username", value: user_name %>
-        <%= f.password_field :password, label: "Mailer Password", value: password %>
+        <%= f.text_field :mailer_domain, label: "Mailer Domain", value: domain %>
+        <%= f.text_field :mailer_user_name, label: "Mailer Username", value: user_name %>
+        <%= f.password_field :mailer_password, label: "Mailer Password", value: password %>
     </div>
     <div class="panel-footer">
       <%= f.submit "Submit Changes", :class => "btn btn-success", :id => "submit_button" %>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -13,6 +13,14 @@ enable_logging: false
 banner: false
 banner_message: "This server is for demonstration purposes; data on it will be removed every Saturday at 11:59 PM Eastern Time"
 
+# mailer settings
+mailer_address: ""
+mailer_port: 
+mailer_domain: ""
+mailer_user_name: ""
+mailer_password: ""
+mailer_authentication: :plain
+
 bundle_file_path: "temp/bundles"
 
 # ignore roles completely -- this is essientially the same as everyone in the system being an admin

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,12 +45,12 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: '',
-    port: '',
-    domain: '',
-    user_name: '',
-    password: '',
-    authentication: ''
+    address: Settings[:mailer_address],
+    port: Settings[:mailer_port],
+    domain: Settings[:mailer_domain],
+    user_name: Settings[:mailer_user_name],
+    password: Settings[:mailer_password],
+    authentication: Settings[:mailer_authentication]
   }
 
   # Raises error for missing translations

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -66,12 +66,12 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: '',
-    port: '',
-    domain: '',
-    user_name: '',
-    password: '',
-    authentication: ''
+    address: Settings[:mailer_address],
+    port: Settings[:mailer_port],
+    domain: Settings[:mailer_domain],
+    user_name: Settings[:mailer_user_name],
+    password: Settings[:mailer_password],
+    authentication: Settings[:mailer_authentication]
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -36,6 +36,16 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Note that these will not be used because delivery_method is :test. These are here so tests don't break.
+  config.action_mailer.smtp_settings = {
+    address: Settings[:mailer_address],
+    port: Settings[:mailer_port],
+    domain: Settings[:mailer_domain],
+    user_name: Settings[:mailer_user_name],
+    password: Settings[:mailer_password],
+    authentication: Settings[:mailer_authentication]
+  }
+
   # Randomize the order test cases are executed.
   config.active_support.test_order = :random
 
@@ -44,14 +54,4 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
-
-  config.action_mailer.delivery_method = :smtp
-  config.action_mailer.smtp_settings = {
-    address: '',
-    port: '',
-    domain: '',
-    user_name: '',
-    password: '',
-    authentication: ''
-  }
 end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+class SettingsControllerTest < ActionController::TestCase
+  setup do
+    collection_fixtures('users', 'roles')
+    @controller = Admin::SettingsController.new
+  end
+
+  test 'should successfully update yml' do
+    orig_yml = File.read("#{Rails.root}/config/cypress.yml")
+    begin
+      for_each_logged_in_user([ADMIN]) do
+        patch :update, banner_message: 'banner test', mailer_address: 'smtp.example.com', mailer_port: 3000, mailer_domain: 'example.com',
+                       mailer_user_name: 'testuser', mailer_password: 'password123'
+      end
+      assert_equal 'banner test', Settings['banner_message']
+      assert_equal 'smtp.example.com', Rails.application.config.action_mailer.smtp_settings.address
+      assert_equal 3000, Rails.application.config.action_mailer.smtp_settings.port
+      assert_equal 'example.com', Rails.application.config.action_mailer.smtp_settings.domain
+      assert_equal 'testuser', Rails.application.config.action_mailer.smtp_settings.user_name
+      assert_equal 'password123', Rails.application.config.action_mailer.smtp_settings.password
+    ensure
+      File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts orig_yml }
+    end
+  end
+end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class AdminControllerTest < ActionController::TestCase
+  setup do
+    collection_fixtures('users', 'roles')
+  end
+
+  test 'should get show' do
+    Rails.application.config.action_mailer.smtp_settings = {
+      address: Settings[:mailer_address],
+      port: Settings[:mailer_port],
+      domain: Settings[:mailer_domain],
+      user_name: Settings[:mailer_user_name],
+      password: Settings[:mailer_password],
+      authentication: Settings[:mailer_authentication]
+    }
+    for_each_logged_in_user([ADMIN]) do
+      get :show
+      assert_response :success
+    end
+  end
+end


### PR DESCRIPTION
Summary:
- Settings changed by an admin are now persisted, by overwriting the cypress.yml file
 - Note to devs that if you use the form to change settings, you need to be careful not to check in that file with future commits, unless you intend to change the default settings.

- Added tests for AdminController and SettingsController
