### PR TITLE
Stopped using 'first' in a couple of places in text_executions_controller_test

### DIFF
--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -11,10 +11,10 @@ class TestExecutionsControllerTest < ActionController::TestCase
                         'bundles', 'measures', 'health_data_standards_svs_value_sets', 'artifacts',
                         'records', 'patient_populations')
     @vendor = Vendor.find(EHR1)
-    @first_product = @vendor.products.first
+    @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').first
     @first_product.bundle = Bundle.default
     @first_product.save
-    @first_test = @first_product.product_tests.first
+    @first_test = @first_product.product_tests.where(name: 'vendor1 product1 test1').first
     @first_task = @first_test.tasks.first
     @first_execution = @first_task.test_executions.first
   end


### PR DESCRIPTION
I'm not sure if this is the issue, but it could be that using `.first` to pick products/product_tests was giving us ones that aren't finished, and so their status was `pending`. Now we pick them by name, and the `.first` at the end is just to get what should be the only entry out of the `Mongoid::Criteria`.