### PR TITLE
Figure out standard sorting for listing vendors/products

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,6 +3,8 @@ class Product
   include Mongoid::Attributes::Dynamic
   include Mongoid::Timestamps
 
+  default_scope -> { order(:updated_at => :desc) }
+
   belongs_to :vendor, index: true, touch: true
   has_many :product_tests, :dependent => :destroy
   accepts_nested_attributes_for :product_tests, allow_destroy: true

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -5,6 +5,8 @@ class ProductTest
   include GlobalID::Identification
   include HealthDataStandards::CQM
 
+  default_scope -> { order(:updated_at => :desc) }
+
   # TODO: Use real attributes?
   scope :measure_tests, -> { where(_type: 'MeasureTest') }
   scope :checklist_tests, -> { where(_type: 'ChecklistTest') }

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -3,6 +3,9 @@ class Vendor
   include Mongoid::Attributes::Dynamic
   include Mongoid::Timestamps
   resourcify
+
+  default_scope -> { order(:updated_at => :desc) }
+
   has_many :products, :dependent => :destroy
   embeds_many :points_of_contact, class_name: 'PointOfContact', cascade_callbacks: true
 


### PR DESCRIPTION
I think sorting the list with most recently updated items at top makes sense.
My chosen approach was to set the default sorting on the relevant models.