### PR TITLE
Application Modes

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -32,6 +32,18 @@ $(document).ready(assignmentsReady)
 var ready;
 ready = function() {
   $('.settings-tabs').tabs();
+
+  var $customModeButtons = $('[name="[mode]"]');
+
+  $customModeButtons.on('change', function() {
+    if ($customModeButtons.filter(':checked').val() == "custom") {
+      $('#settings-custom').show();
+    } else {
+      $('#settings-custom').hide();
+    }
+  });
+
+  $customModeButtons.trigger('change');
 };
 
 $(document).ready(ready);

--- a/app/assets/stylesheets/cypress/_text.scss
+++ b/app/assets/stylesheets/cypress/_text.scss
@@ -50,3 +50,14 @@ main a:not(.btn):not(.task-switch-link) {
 }
 
 main:focus { outline: none; }
+
+.configured-banner { margin-bottom: 2em; }
+
+.configured-mailer {
+  dt {
+    font-weight: normal;
+    text-align: left;
+  }
+
+  dd { font-weight: bold; }
+}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -10,7 +10,9 @@ class AdminController < ApplicationController
       port: smtp_settings.port,
       domain: smtp_settings.domain,
       user_name: smtp_settings.user_name,
-      password: smtp_settings.password
+      password: smtp_settings.password,
+      mode_settings: ApplicationController.helpers.application_mode_settings,
+      mode: ApplicationController.helpers.application_mode
     }
   end
 end

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -1,0 +1,32 @@
+module AdminHelper
+  def application_mode
+    return 'Internal' if mode_internal?
+    return 'Demo' if mode_demo?
+    return 'ATL' if mode_atl?
+    'Custom'
+  end
+
+  def application_mode_settings
+    settings_hash = { auto_approve: Settings[:auto_approve], ignore_roles: Settings[:ignore_roles] }
+    settings_hash[:default_role] = if Settings[:default_role].nil?
+                                     'None'
+                                   elsif Settings[:default_role] == :atl
+                                     'ATL'
+                                   else
+                                     Settings[:default_role].to_s.humanize
+                                   end
+    settings_hash
+  end
+
+  def mode_internal?
+    !Settings[:auto_approve] && Settings[:ignore_roles] && Settings[:default_role].nil?
+  end
+
+  def mode_demo?
+    !Settings[:auto_approve] && !Settings[:ignore_roles] && Settings[:default_role] == :user
+  end
+
+  def mode_atl?
+    Settings[:auto_approve] && !Settings[:ignore_roles] && Settings[:default_role].nil?
+  end
+end

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   # local variables:
   #
-  #   banner_message, address, port, domain, user_name, password
+  #   banner_message, address, port, domain, user_name, password, mode, mode_settings, roles
 %>
 
 <div class="panel panel-default">
@@ -16,6 +16,23 @@
         <%= f.text_field :mailer_domain, label: "Mailer Domain", value: domain %>
         <%= f.text_field :mailer_user_name, label: "Mailer Username", value: user_name %>
         <%= f.password_field :mailer_password, label: "Mailer Password", value: password %>
+        <%= f.form_group :mode, label: { text: "Application Mode" } do %>
+          <%= f.radio_button :mode, "internal", label: "Internal", checked: mode == "Internal" %>
+          <%= f.radio_button :mode, "demo", label: "Demo", checked: mode == "Demo" %>
+          <%= f.radio_button :mode, "atl", label: "ATL", checked: mode == "ATL" %>
+          <%= f.radio_button :mode, "custom", label: "Custom", checked: mode == "Custom" %>
+          <%=f.fields_for :custom_options do |custom_form| %>
+            <%= custom_form.form_group :auto_approve, label: { text: "Auto Approve" } do %>
+              <%= custom_form.radio_button :auto_approve, "enable", label: "Enable", inline: true, checked: mode_settings.auto_approve %>
+              <%= custom_form.radio_button :auto_approve, "disable", label: "Disable", inline: true, checked: !mode_settings.auto_approve %>
+            <% end %>
+            <%= custom_form.form_group :ignore_roles, label: { text: "Ignore Roles" } do %>
+              <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: mode_settings.ignore_roles %>
+              <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: !mode_settings.ignore_roles  %>
+            <% end %>
+            <%= custom_form.select :default_role, roles, selected: mode_settings.default_role %>
+          <% end %>
+        <% end %>
     </div>
     <div class="panel-footer">
       <%= f.submit "Submit Changes", :class => "btn btn-success", :id => "submit_button" %>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -8,7 +8,10 @@
   <div class="panel-heading"><h1 class='panel-title'>Edit Settings</h1></div>
   <%= bootstrap_form_tag url: admin_settings_path, method: :put do |f| %>
     <div class="panel-body">
-        <%= f.text_area :banner_message, label: "Banner", value: banner_message %>
+      <%= f.text_area :banner_message, label: "Banner", value: banner_message %>
+
+      <fieldset>
+        <legend>Email Settings</legend>
         <div class="row">
           <%= f.text_field :mailer_address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: address %>
           <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: port %>
@@ -16,23 +19,34 @@
         <%= f.text_field :mailer_domain, label: "Mailer Domain", value: domain %>
         <%= f.text_field :mailer_user_name, label: "Mailer Username", value: user_name %>
         <%= f.password_field :mailer_password, label: "Mailer Password", value: password %>
-        <%= f.form_group :mode, label: { text: "Application Mode" } do %>
-          <%= f.radio_button :mode, "internal", label: "Internal", checked: mode == "Internal" %>
-          <%= f.radio_button :mode, "demo", label: "Demo", checked: mode == "Demo" %>
-          <%= f.radio_button :mode, "atl", label: "ATL", checked: mode == "ATL" %>
-          <%= f.radio_button :mode, "custom", label: "Custom", checked: mode == "Custom" %>
-          <%=f.fields_for :custom_options do |custom_form| %>
-            <%= custom_form.form_group :auto_approve, label: { text: "Auto Approve" } do %>
-              <%= custom_form.radio_button :auto_approve, "enable", label: "Enable", inline: true, checked: mode_settings.auto_approve %>
-              <%= custom_form.radio_button :auto_approve, "disable", label: "Disable", inline: true, checked: !mode_settings.auto_approve %>
+      </fieldset>
+
+      <fieldset>
+        <legend>Application Mode</legend>
+        <%= f.radio_button :mode, "internal", label: "Internal", checked: mode == "Internal" %>
+        <%= f.radio_button :mode, "demo", label: "Demo", checked: mode == "Demo" %>
+        <%= f.radio_button :mode, "atl", label: "ATL", checked: mode == "ATL" %>
+        <%= f.radio_button :mode, "custom", label: "Custom", checked: mode == "Custom" %>
+      </fieldset>
+
+      <div id="settings-custom" class="panel panel-default">
+        <div class="panel-body">
+          <fieldset>
+            <legend>Custom Mode Options</legend>
+            <%= f.fields_for :custom_options do |custom_form| %>
+              <%= custom_form.form_group :auto_approve, label: { text: "Auto Approve", id: "auto-approve" } do %>
+                <%= custom_form.radio_button :auto_approve, "enable", label: "Enable", inline: true, checked: mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
+                <%= custom_form.radio_button :auto_approve, "disable", label: "Disable", inline: true, checked: !mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
+              <% end %>
+              <%= custom_form.form_group :ignore_roles, label: { text: "Ignore Roles", id: "ignore-roles" } do %>
+                <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
+                <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: !mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles"  %>
+              <% end %>
+              <%= custom_form.select :default_role, roles, selected: mode_settings.default_role %>
             <% end %>
-            <%= custom_form.form_group :ignore_roles, label: { text: "Ignore Roles" } do %>
-              <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: mode_settings.ignore_roles %>
-              <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: !mode_settings.ignore_roles  %>
-            <% end %>
-            <%= custom_form.select :default_role, roles, selected: mode_settings.default_role %>
-          <% end %>
-        <% end %>
+          </fieldset>
+        </div>
+      </div>
     </div>
     <div class="panel-footer">
       <%= f.submit "Submit Changes", :class => "btn btn-success", :id => "submit_button" %>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -19,7 +19,7 @@
 
     <legend>Banner Message</legend>
     <p class="configured-banner">
-      <%= banner_message.html_safe %>
+      <%= banner_message %>
     </p>
 
     <div class="row">

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -11,32 +11,35 @@
     <% end %>
   </ul>
   <div id = "application_settings">
-    <div class="inline-block pull-right" >
-      <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-sm btn-default" do %>
-      <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Application Settings
-    <% end %>
+    <div class="inline-block pull-right">
+      <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-default" do %>
+        <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Application Settings
+      <% end %>
     </div>
-    <div>
-      <b>Banner</b>
-      <p><%= banner_message %></p>
-    </div>
-    <br>
-    <div>
-      <b>Mailer</b>
-      <div>
-        <div>SMTP Server: <b><%= address %></b></div>
-        <div>Port: <b><%= port %></b></div>
-        <div>Domain: <b><%= domain %></b></div>
-        <div>Username: <b><%= user_name %></b></div>
+
+    <legend>Banner Message</legend>
+    <p class="configured-banner">
+      <%= banner_message.html_safe %>
+    </p>
+
+    <div class="row">
+      <div class="col-sm-6">
+        <legend>Mailer</legend>
+        <dl class="dl-horizontal configured-mailer">
+          <dt>SMTP Server</dt><dd><%= address.present? ? address : 'not configured' %></dd>
+          <dt>Port</dt><dd><%= port.present? ? port : 'not configured' %></dd>
+          <dt>Domain</dt><dd><%= domain.present? ? domain : 'not configured' %></dd>
+          <dt>Username</dt><dd><%= user_name.present? ? user_name : 'not configured' %></dd>
+        </dl>
       </div>
-    </div>
-    <br>
-    <div>
-      <p><b>Application Mode</b>
-      <p>Cypress is currently running in <b><%= mode %> mode</b></p>
-      <p>Users <b><%= mode_settings.auto_approve ? "will" : "will not" %></b> be automatically approved.</p>
-      <p>Access <b><%= mode_settings.ignore_roles ? "will not" : "will" %></b> be restricted by role.</p>
-      <p>A default role <b><%= mode_settings.default_role == "None"  ? "will not" : "will" %></b> be set for new users<%= mode_settings.default_role == "None" ? "." : ": #{mode_settings.default_role}" %></p>
+
+      <div class="col-sm-6">
+        <legend>Application Mode</legend>
+        <div>Cypress is currently running in <strong><%= mode %> mode</strong></div>
+        <div>Users <strong><%= mode_settings.auto_approve ? "will" : "will not" %></strong> be automatically approved.</div>
+        <div>Access <strong><%= mode_settings.ignore_roles ? "will not" : "will" %></strong> be restricted by role.</div>
+        <div>A default role <strong><%= mode_settings.default_role == "None"  ? "will not" : "will" %></strong> be set for new users<%= mode_settings.default_role == "None" ? "." : ": #{mode_settings.default_role}" %></div>
+      </div>
     </div>
   </div>
 

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,7 +1,7 @@
 <%
   # local variables:
   #
-  #   banner_message, address, port, domain, user_name, password
+  #   banner_message, address, port, domain, user_name, password, mode, mode_settings
 %>
 
 <div data-no-turbolink class="settings-tabs">
@@ -29,6 +29,14 @@
         <div>Domain: <b><%= domain %></b></div>
         <div>Username: <b><%= user_name %></b></div>
       </div>
+    </div>
+    <br>
+    <div>
+      <p><b>Application Mode</b>
+      <p>Cypress is currently running in <b><%= mode %> mode</b></p>
+      <p>Users <b><%= mode_settings.auto_approve ? "will" : "will not" %></b> be automatically approved.</p>
+      <p>Access <b><%= mode_settings.ignore_roles ? "will not" : "will" %></b> be restricted by role.</p>
+      <p>A default role <b><%= mode_settings.default_role == "None"  ? "will not" : "will" %></b> be set for new users<%= mode_settings.default_role == "None" ? "." : ": #{mode_settings.default_role}" %></p>
     </div>
   </div>
 

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -6,7 +6,7 @@
 
 <div data-no-turbolink class="settings-tabs">
   <ul data-no-turbolink>
-    <% ['application_settings', 'application_status', 'user_management', 'bundle'].each do |target_id| %>
+    <% ['application_settings', 'user_management', 'application_status', 'bundle'].each do |target_id| %>
       <li><a href = '#<%= target_id %>'><%= target_id.humanize.titleize %></a></li>
     <% end %>
   </ul>
@@ -43,9 +43,15 @@
     </div>
   </div>
 
-  <div id="application_status" ></div>
   <div id="user_management" >
     <%= render partial: "user_list" %>
   </div>
-  <div id="bundle" ></div>
+
+  <div id="application_status" >
+    <h2>This feature is coming soon</h2>
+  </div>
+  
+  <div id="bundle" >
+    <h2>This feature is coming soon</h2>
+  </div>
 </div>


### PR DESCRIPTION
### Summary:

- An admin user can now set the application mode to Internal, Demo, ATL, or something custom. Each mode is a different permutation of three settings: `auto_approve`, `ignore_roles`, and `default_role`.

### New/updated views:

**/admin#application_settings**

<img width="1091" alt="screen shot 2016-05-05 at 1 45 28 pm" src="https://cloud.githubusercontent.com/assets/8235974/15051664/d74afc7e-12c7-11e6-98a6-83cde7c92350.png">

**/admin/settings/edit?**

<img width="1118" alt="screen shot 2016-05-05 at 1 45 08 pm" src="https://cloud.githubusercontent.com/assets/8235974/15051651/bf853244-12c7-11e6-82f8-4b8f77035042.png">