### PR TITLE
Organize and refactor various parts of admin system

### DIFF
--- a/app/controllers/admin/bundles_controller.rb
+++ b/app/controllers/admin/bundles_controller.rb
@@ -1,9 +1,8 @@
 module Admin
-  class BundlesController < ApplicationController
+  class BundlesController < AdminController
     respond_to :html
 
     before_action :find_bundle, only: [:set_default, :destroy]
-    before_action :require_admin
 
     add_breadcrumb 'Admin', :admin_bundles_path
     add_breadcrumb 'Add Bundle', :new_admin_bundle_path, only: [:new]
@@ -57,10 +56,6 @@ module Admin
 
     def generate_file_path
       "bundle_#{rand(Time.now.to_i)}.zip"
-    end
-
-    def require_admin
-      raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.has_role? :admin
     end
   end
 end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,22 +1,16 @@
 module Admin
-  class SettingsController < ApplicationController
+  class SettingsController < AdminController
     add_breadcrumb 'Admin', :admin_path
-    before_action -> { raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.has_role? :admin }
 
     def show
       redirect_to admin_path(anchor: 'application_settings')
     end
 
     def edit
-      add_breadcrumb 'Edit', :edit_settings_path
-      smtp_settings = Rails.application.config.action_mailer.smtp_settings
+      add_breadcrumb 'Edit Settings', :edit_settings_path
       render locals: {
         banner_message: Settings.banner_message,
-        address: smtp_settings.address,
-        port: smtp_settings.port,
-        domain: smtp_settings.domain,
-        user_name: smtp_settings.user_name,
-        password: smtp_settings.password,
+        smtp_settings: Rails.application.config.action_mailer.smtp_settings,
         mode: ApplicationController.helpers.application_mode,
         mode_settings: ApplicationController.helpers.application_mode_settings,
         roles: %w(User ATL Admin None)
@@ -24,6 +18,8 @@ module Admin
     end
 
     def update
+      # require 'pry'
+      # binding.pry
       update_application_mode params[:mode], params[:custom_options]
       write_settings_to_yml(params)
       redirect_to admin_path(anchor: 'application_settings')

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,14 +1,13 @@
 module Admin
-  class UsersController < ApplicationController
-    before_action -> { authorize! :manage, User }
-    add_breadcrumb 'Users', '/admin/users'
+  class UsersController < AdminController
+    add_breadcrumb 'Admin', :admin_path
 
     def index
-      # dont allow them to muck with their own account
-      @users = User.excludes(id: current_user.id).order_by(email:  1)
+      redirect_to admin_path(anchor: 'user_management')
     end
 
     def edit
+      add_breadcrumb 'Edit Users', :edit_users_path
       @user = User.find(params[:id])
     end
 

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -1,20 +1,23 @@
 class AdminController < ApplicationController
   add_breadcrumb 'Admin', :admin_path
-  before_action -> { raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.has_role? :admin }
+  before_action :require_admin
 
   def show
-    smtp_settings = Rails.application.config.action_mailer.smtp_settings
     @bundles = Bundle.all
+    # dont allow them to muck with their own account
+    @users = User.excludes(id: current_user.id).order_by(email:  1)
     render locals: {
       banner_message: Settings.banner_message,
-      address: smtp_settings.address,
-      port: smtp_settings.port,
-      domain: smtp_settings.domain,
-      user_name: smtp_settings.user_name,
-      password: smtp_settings.password,
-      mode_settings: ApplicationController.helpers.application_mode_settings,
+      smtp_settings: Rails.application.config.action_mailer.smtp_settings,
       mode: ApplicationController.helpers.application_mode,
+      mode_settings: ApplicationController.helpers.application_mode_settings,
       debug_features: Settings.enable_debug_features
     }
+  end
+
+  private
+
+  def require_admin
+    raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.has_role? :admin
   end
 end

--- a/app/views/admin/_show_settings.html.erb
+++ b/app/views/admin/_show_settings.html.erb
@@ -1,0 +1,36 @@
+<%
+  # local variables:
+  #
+  #   banner_message, smtp_settings, mode, mode_settings, debug_features
+%>
+<div class="inline-block pull-right">
+  <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-default" do %>
+    <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Application Settings
+  <% end %>
+</div>
+
+<legend>Banner Message</legend>
+<p class="configured-banner">
+  <%= banner_message %>
+</p>
+
+<div class="row">
+  <div class="col-sm-6">
+    <legend>Mailer</legend>
+    <dl class="dl-horizontal configured-mailer">
+      <dt>SMTP Server</dt><dd><%= smtp_settings.address.present? ? smtp_settings.address : 'not configured' %></dd>
+      <dt>Port</dt><dd><%= smtp_settings.port.present? ? smtp_settings.port : 'not configured' %></dd>
+      <dt>Domain</dt><dd><%= smtp_settings.domain.present? ? smtp_settings.domain : 'not configured' %></dd>
+      <dt>Username</dt><dd><%= smtp_settings.user_name.present? ? smtp_settings.user_name : 'not configured' %></dd>
+    </dl>
+  </div>
+
+  <div class="col-sm-6">
+    <legend>Application Mode</legend>
+    <div>Cypress is currently running in <strong><%= mode %> mode</strong>.</div>
+    <div>Users <strong><%= mode_settings.auto_approve ? "will" : "will not" %></strong> be automatically approved.</div>
+    <div>Access <strong><%= mode_settings.ignore_roles ? "will not" : "will" %></strong> be restricted by role.</div>
+    <div>A default role <strong><%= mode_settings.default_role == "None"  ? "will not" : "will" %></strong> be set for new users<%= mode_settings.default_role == "None" ? "." : ": #{mode_settings.default_role}" %></div>
+    <div>Debug features are currently <strong><%= debug_features ? "enabled" : "disabled" %></strong>.</div>
+  </div>
+</div>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -1,7 +1,7 @@
 <%
   # local variables:
   #
-  #   banner_message, address, port, domain, user_name, password, mode, mode_settings, roles
+  #   banner_message, smtp_settings, mode, mode_settings, roles
 %>
 
 <div class="panel panel-default">
@@ -13,12 +13,12 @@
       <fieldset>
         <legend>Email Settings</legend>
         <div class="row">
-          <%= f.text_field :mailer_address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: address %>
-          <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: port %>
+          <%= f.text_field :mailer_address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: smtp_settings.address %>
+          <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: smtp_settings.port %>
         </div>
-        <%= f.text_field :mailer_domain, label: "Mailer Domain", value: domain %>
-        <%= f.text_field :mailer_user_name, label: "Mailer Username", value: user_name %>
-        <%= f.password_field :mailer_password, label: "Mailer Password", value: password %>
+        <%= f.text_field :mailer_domain, label: "Mailer Domain", value: smtp_settings.domain %>
+        <%= f.text_field :mailer_user_name, label: "Mailer Username", value: smtp_settings.user_name %>
+        <%= f.password_field :mailer_password, label: "Mailer Password", value: smtp_settings.password %>
       </fieldset>
 
       <fieldset>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -1,7 +1,7 @@
 <%
   # local variables:
   #
-  #   banner_message, address, port, domain, user_name, password, mode, mode_settings, debug_features
+  #   banner_message, smtp_settings, mode, mode_settings, debug_features
 %>
 
 <div data-no-turbolink class="settings-tabs">
@@ -10,38 +10,10 @@
       <li><a href = '#<%= target_id %>'><%= target_id.humanize.titleize %></a></li>
     <% end %>
   </ul>
-  <div id = "application_settings">
-    <div class="inline-block pull-right">
-      <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-default" do %>
-        <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Application Settings
-      <% end %>
-    </div>
 
-    <legend>Banner Message</legend>
-    <p class="configured-banner">
-      <%= banner_message %>
-    </p>
-
-    <div class="row">
-      <div class="col-sm-6">
-        <legend>Mailer</legend>
-        <dl class="dl-horizontal configured-mailer">
-          <dt>SMTP Server</dt><dd><%= address.present? ? address : 'not configured' %></dd>
-          <dt>Port</dt><dd><%= port.present? ? port : 'not configured' %></dd>
-          <dt>Domain</dt><dd><%= domain.present? ? domain : 'not configured' %></dd>
-          <dt>Username</dt><dd><%= user_name.present? ? user_name : 'not configured' %></dd>
-        </dl>
-      </div>
-
-      <div class="col-sm-6">
-        <legend>Application Mode</legend>
-        <div>Cypress is currently running in <strong><%= mode %> mode</strong>.</div>
-        <div>Users <strong><%= mode_settings.auto_approve ? "will" : "will not" %></strong> be automatically approved.</div>
-        <div>Access <strong><%= mode_settings.ignore_roles ? "will not" : "will" %></strong> be restricted by role.</div>
-        <div>A default role <strong><%= mode_settings.default_role == "None"  ? "will not" : "will" %></strong> be set for new users<%= mode_settings.default_role == "None" ? "." : ": #{mode_settings.default_role}" %></div>
-        <div>Debug features are currently <strong><%= debug_features ? "enabled" : "disabled" %></strong>.</div>
-      </div>
-    </div>
+  <div id="application_settings">
+    <%= render partial: "show_settings", locals: { banner_message: banner_message, smtp_settings: smtp_settings,
+                                                  mode: mode, mode_settings: mode_settings, debug_features: debug_features } %>
   </div>
 
   <div id="user_management" >

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class SettingsControllerTest < ActionController::TestCase
+class Admin::SettingsControllerTest < ActionController::TestCase
   setup do
     collection_fixtures('users', 'roles')
     @controller = Admin::SettingsController.new
@@ -11,7 +11,8 @@ class SettingsControllerTest < ActionController::TestCase
     begin
       for_each_logged_in_user([ADMIN]) do
         patch :update, banner_message: 'banner test', mailer_address: 'smtp.example.com', mailer_port: 3000, mailer_domain: 'example.com',
-                       mailer_user_name: 'testuser', mailer_password: 'password123'
+                       mailer_user_name: 'testuser', mailer_password: 'password123', mode: 'custom',
+                       custom_options: { auto_approve: 'disable', ignore_roles: 'disable', default_role: 'admin', debug_features: 'disable' }
       end
       assert_equal 'banner test', Settings['banner_message']
       assert_equal 'smtp.example.com', Rails.application.config.action_mailer.smtp_settings.address
@@ -19,6 +20,11 @@ class SettingsControllerTest < ActionController::TestCase
       assert_equal 'example.com', Rails.application.config.action_mailer.smtp_settings.domain
       assert_equal 'testuser', Rails.application.config.action_mailer.smtp_settings.user_name
       assert_equal 'password123', Rails.application.config.action_mailer.smtp_settings.password
+      assert_equal 'Custom', ApplicationController.helpers.application_mode
+      assert_equal false, Settings['auto_approve']
+      assert_equal false, Settings['ignore_roles']
+      assert_equal :admin, Settings['default_role']
+      assert_equal false, Settings['enable_debug_features']
     ensure
       File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts orig_yml }
     end

--- a/test/controllers/admin/user_controller_test.rb
+++ b/test/controllers/admin/user_controller_test.rb
@@ -1,132 +1,128 @@
 require 'test_helper'
-module Admin
-  class UsersControllerTest < ActionController::TestCase
-    include Devise::TestHelpers
+class Admin::UsersControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
 
-    def setup
-      collection_fixtures 'users', 'roles', 'vendors'
-      @user = User.first
+  def setup
+    collection_fixtures 'users', 'roles', 'vendors'
+    @user = User.first
+  end
+
+  test 'Admin can view index ' do
+    for_each_logged_in_user([ADMIN]) do
+      get :index
+      assert_redirected_to %r{/admin#user_management}
     end
+  end
 
-    test 'Admin can view index ' do
-      for_each_logged_in_user([ADMIN]) do
-        get :index
-        assert_response :success
-        assert assigns(:users)
-      end
+  test 'Non Admin cannot view index ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      get :index
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot view index ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        get :index
-        assert_response 401
-      end
+  test 'Admin can view edit screen ' do
+    for_each_logged_in_user([ADMIN]) do
+      get :edit, id: @user.id
+      assert_response :success
+      assert assigns(:user)
     end
+  end
 
-    test 'Admin can view edit screen ' do
-      for_each_logged_in_user([ADMIN]) do
-        get :edit, id: @user.id
-        assert_response :success
-        assert assigns(:user)
-      end
+  test 'Non Admin cannot view edit ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      get :edit, id: @user.id
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot view edit ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        get :edit, id: @user.id
-        assert_response 401
-      end
+  test 'Admin can update user' do
+    v = Vendor.first
+    APP_CONFIG['default_role'] = nil
+    u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
+
+    for_each_logged_in_user([ADMIN]) do
+      assert !u.has_role?(:user)
+      assert !u.has_role?(:owner, v)
+      patch :update, :id => u.id, :role => :user, :assignments => { '0' => { :role => :owner, :vendor_id => v.id } }
+      assert_response 302
+      u.reload
+      assert u.has_role?(:user)
+      assert u.has_role?(:owner, v)
     end
+  end
 
-    test 'Admin can update user' do
-      v = Vendor.first
-      APP_CONFIG['default_role'] = nil
-      u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
-
-      for_each_logged_in_user([ADMIN]) do
-        assert !u.has_role?(:user)
-        assert !u.has_role?(:owner, v)
-        patch :update, :id => u.id, :role => :user, :assignments => { '0' => { :role => :owner, :vendor_id => v.id } }
-        assert_response 302
-        u.reload
-        assert u.has_role?(:user)
-        assert u.has_role?(:owner, v)
-      end
+  test 'Non Admin cannot update user ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      post :update, id: @user.id
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot update user ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        post :update, id: @user.id
-        assert_response 401
-      end
+  test 'Admin can delete user' do
+    u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
+    for_each_logged_in_user([ADMIN]) do
+      delete :destroy, id: u.id
+      assert_response 302
+      assert_equal 0, User.where('_id' => u.id).count
     end
+  end
 
-    test 'Admin can delete user' do
-      u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
-      for_each_logged_in_user([ADMIN]) do
-        delete :destroy, id: u.id
-        assert_response 302
-        assert_equal 0, User.where('_id' => u.id).count
-      end
+  test 'Non Admin cannot delete user ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      delete :destroy, id: @user.id
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot delete user ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        delete :destroy, id: @user.id
-        assert_response 401
-      end
+  test 'Admin can send invitation ' do
+    for_each_logged_in_user([ADMIN]) do
+      get :send_invitation, id: @user.id
+      assert_response 302
     end
+  end
 
-    test 'Admin can send invitation ' do
-      for_each_logged_in_user([ADMIN]) do
-        get :send_invitation, id: @user.id
-        assert_response 302
-      end
+  test 'Non Admin cannot  send invitation ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      get :send_invitation, id: @user.id
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot  send invitation ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        get :send_invitation, id: @user.id
-        assert_response 401
-      end
+  test 'Admin can toggle approved status ' do
+    u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
+    approved = u.approved
+    for_each_logged_in_user([ADMIN]) do
+      get :toggle_approved, id: u.id
+      assert_response 302
+      assert_equal !approved, User.find(u.id).approved
+      get :toggle_approved, id: u.id
+      assert_response 302
+      assert_equal approved, User.find(u.id).approved
     end
+  end
 
-    test 'Admin can toggle approved status ' do
-      u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
-      approved = u.approved
-      for_each_logged_in_user([ADMIN]) do
-        get :toggle_approved, id: u.id
-        assert_response 302
-        assert_equal !approved, User.find(u.id).approved
-        get :toggle_approved, id: u.id
-        assert_response 302
-        assert_equal approved, User.find(u.id).approved
-      end
+  test 'Non Admin cannot toggle approved status ' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      get :toggle_approved, id: @user.id
+      assert_response 401
     end
+  end
 
-    test 'Non Admin cannot toggle approved status ' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        get :toggle_approved, id: @user.id
-        assert_response 401
-      end
+  test 'Admin can unlock a locked account ' do
+    u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1', locked_at: Time.now.utc)
+    for_each_logged_in_user([ADMIN]) do
+      assert !u.locked_at.nil?
+      get :unlock, id: u.id
+      assert_response 302
+      assert User.find(u.id).locked_at.nil?
     end
+  end
 
-    test 'Admin can unlock a locked account ' do
-      u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1', locked_at: Time.now.utc)
-      approved = u.approved
-      for_each_logged_in_user([ADMIN]) do
-        assert !u.locked_at.nil?
-        get :unlock, id: u.id
-        assert_response 302
-        assert User.find(u.id).locked_at.nil?
-      end
+  test 'Non Admin cannot unlock a locked account' do
+    for_each_logged_in_user([OWNER, ATL, VENDOR]) do
+      get :unlock, id: @user.id
+      assert_response 401
     end
-
-    test 'Non Admin cannot unlock a locked account' do
-      for_each_logged_in_user([OWNER, ATL, VENDOR]) do
-        get :unlock, id: @user.id
-        assert_response 401
-      end
-    end
-end
+  end
 end


### PR DESCRIPTION
**Summary**

- Redirect `/admin/users` to `/admin#user_management`. This, in addition to bad auth, was allowing non-admins to access user management.
- Correct inaccurate breadcrumbs.
- Cleanup and make consistent how admin authorization is managed.
- Improve tests.
- Small changes to make admin controllers, views, and tests cleaner and more consistent.
