### PR TITLE
adds provider type validator for c4 tasks

### DIFF
--- a/app/models/cat1_filter_task.rb
+++ b/app/models/cat1_filter_task.rb
@@ -8,8 +8,8 @@ class Cat1FilterTask < Task
   # do that validation here
   def validators
     @validators = [::Validators::CalculatingSmokingGunValidator.new(product_test.measures, records, product_test.id),
-                   QrdaCat1Validator.new(product_test.bundle, false, product_test.product.c3_test, product_test.measures)]
-
+                   QrdaCat1Validator.new(product_test.bundle, false, product_test.product.c3_test, product_test.measures),
+                   ::Validators::ProviderTypeValidator.new]
     @validators
   end
 

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -130,7 +130,8 @@ module Cypress
     end
 
     def generate_provider
-      @generated_providers << Provider.generate_provider
+      measure = @test.measures.first
+      @generated_providers << Provider.generate_provider(measure_type: measure.type)
     end
   end
 end

--- a/lib/cypress/provider_filter.rb
+++ b/lib/cypress/provider_filter.rb
@@ -16,7 +16,7 @@ module Cypress
       end
 
       if input_filters['types']
-        query_pieces << { 'type' => { '$in' => input_filters['types'] } }
+        query_pieces << { 'specialty' => { '$in' => input_filters['types'] } }
       end
 
       if input_filters['addresses']

--- a/lib/ext/provider.rb
+++ b/lib/ext/provider.rb
@@ -9,13 +9,19 @@ class Provider
     prov
   end
 
-  def self.generate_provider
+  def self.generate_provider(options = {})
     prov = Provider.new
     Cypress::DemographicsRandomizer.randomize_address(prov)
     prov.given_name = APP_CONFIG['randomization']['names']['first'][%w(M F).sample].sample
     prov.family_name = APP_CONFIG['randomization']['names']['last'].sample
     prov.npi = NpiGenerator.generate
     prov.tin = rand.to_s[2..10]
+    prov.specialty = case options[:measure_type]
+                     when 'ep'
+                       '207Q00000X' # (Allopathic & Osteopathic Physicians/Family Practice)
+                     when 'eh'
+                       '282N00000X' # (Hospitals/General Acute Care Hospital)
+                     end
     prov.save!
     prov
   end

--- a/lib/validators/provider_type_validator.rb
+++ b/lib/validators/provider_type_validator.rb
@@ -1,0 +1,35 @@
+module Validators
+  class ProviderTypeValidator < QrdaFileValidator
+    include Validators::Validator
+
+    self.validator = :provider_type
+
+    PROVIDER_TYPE_SELECTOR = '/cda:ClinicalDocument/cda:documentationOf/cda:serviceEvent/cda:performer/cda:assignedEntity/cda:code/@code'.freeze
+
+    def initialize
+    end
+
+    def validate(file, options = {})
+      @document = get_document(file)
+      @options = options
+
+      # find the mrn for the document, borrowed from smoking gun validator
+      first = @document.at_xpath('/cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:patient/cda:name/cda:given/text()')
+      last = @document.at_xpath('/cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:patient/cda:name/cda:family/text()')
+
+      record = options['task'].records.where(first: first, last: last).first
+
+      expected_provider_types = record.provider_performances.collect { |pp| pp.provider.specialty }
+
+      found_provider_types = @document.xpath(PROVIDER_TYPE_SELECTOR).map(&:value)
+
+      expected_provider_types.sort
+      found_provider_types.sort
+
+      if expected_provider_types != found_provider_types
+        add_error("Provider specialties (#{found_provider_types.join(', ')}) do not match expected value (#{expected_provider_types.join(', ')})",
+                  file_name: options[:file_name])
+      end
+    end
+  end
+end

--- a/test/unit/lib/provider_filter_test.rb
+++ b/test/unit/lib/provider_filter_test.rb
@@ -45,7 +45,7 @@ class ProviderFilterTest < ActiveSupport::TestCase
   end
 
   def test_filter_type
-    selected_type = 'ep'
+    selected_type = '200000000X'
 
     filters = { 'types' => [selected_type] }
 
@@ -55,9 +55,9 @@ class ProviderFilterTest < ActiveSupport::TestCase
 
     @all_providers.each do |p|
       if filtered_providers.include? p
-        assert_equal selected_type, p['type'], 'Filtered record set includes a record that does not match criteria'
+        assert_equal selected_type, p.specialty, 'Filtered record set includes a record that does not match criteria'
       else
-        assert_not_equal selected_type, p['type'], 'Filtered record set does not include a record that matches criteria'
+        assert_not_equal selected_type, p.specialty, 'Filtered record set does not include a record that matches criteria'
       end
     end
   end


### PR DESCRIPTION
validates that the provider type on submitted files matches what we provided. requires the pull request on HDS before it will actually export provider type. 
![type_error](https://cloud.githubusercontent.com/assets/13512036/15686097/c1c97342-273c-11e6-953f-1569bca7e37f.JPG)

also switches the provider filter logic to use the correct provider type field in case we ever want to go in that direction