### PR TITLE
Stop using document.ready to detect page loads

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -24,7 +24,7 @@ var assignmentsReady = function(){
 
 }
 
-$(document).ready(assignmentsReady)
+$(document).on('page:load', assignmentsReady)
 
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.
@@ -46,5 +46,4 @@ ready = function() {
   $customModeButtons.trigger('change');
 };
 
-$(document).ready(ready);
 $(document).on('page:load', ready);

--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -156,5 +156,4 @@ ready_run_once = function() {
   ready_run_on_refresh_bundle();
 };
 
-$(document).ready(ready_run_once);
 $(document).on('page:load', ready_run_once);

--- a/app/assets/javascripts/measure_tests.js
+++ b/app/assets/javascripts/measure_tests.js
@@ -4,5 +4,4 @@ ready = function() {
   $('.measure-test-tabs').tabs();
 }
 
-$(document).ready(ready);
 $(document).on('page:load', ready);

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -31,6 +31,5 @@ var reticulateSplines = function() {
     }
 };
 
-$(document).ready(ready);
 $(document).on('page:load', ready);
 $(document).on('page:change', reticulateSplines);

--- a/app/assets/javascripts/records.js
+++ b/app/assets/javascripts/records.js
@@ -11,5 +11,4 @@ ready = function() {
   });
 }
 
-$(document).ready(ready);
 $(document).on('page:load', ready);

--- a/app/assets/javascripts/remove_modal.js
+++ b/app/assets/javascripts/remove_modal.js
@@ -41,5 +41,4 @@ ready = function() {
 
 };
 
-$(document).ready(ready);
 $(document).on('page:load', ready);

--- a/app/assets/javascripts/test_executions.js
+++ b/app/assets/javascripts/test_executions.js
@@ -59,5 +59,4 @@ ready = function() {
   }
 }
 
-$(document).ready(ready);
 $(document).on('page:load', ready);

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -4,8 +4,8 @@
   #   banner_message, smtp_settings, mode, mode_settings, debug_features
 %>
 
-<div data-no-turbolink class="settings-tabs">
-  <ul data-no-turbolink>
+<div class="settings-tabs">
+  <ul>
     <% ['application_settings', 'user_management', 'bundles', 'application_status'].each do |target_id| %>
       <li><a href = '#<%= target_id %>'><%= target_id.humanize.titleize %></a></li>
     <% end %>


### PR DESCRIPTION
- Removed all calls to `$(document).ready`, because turbolinks prevents that event from being fired. We use the `page:load` event instead.
- Removed an instance of `data-no-turbolink`.