### PR TITLE
Add a page:load event and remove a data-no-turbolink

### DIFF
--- a/app/assets/javascripts/admin.js
+++ b/app/assets/javascripts/admin.js
@@ -24,7 +24,8 @@ var assignmentsReady = function(){
 
 }
 
-$(document).ready(assignmentsReady)
+$(document).ready(assignmentsReady);
+$(document).on('page:load', assignmentsReady);
 
 // Place all the behaviors and hooks related to the matching controller here.
 // All this logic will automatically be available in application.js.

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -4,8 +4,8 @@
   #   banner_message, smtp_settings, mode, mode_settings, debug_features
 %>
 
-<div data-no-turbolink class="settings-tabs">
-  <ul data-no-turbolink>
+<div class="settings-tabs">
+  <ul>
     <% ['application_settings', 'user_management', 'bundles', 'application_status'].each do |target_id| %>
       <li><a href = '#<%= target_id %>'><%= target_id.humanize.titleize %></a></li>
     <% end %>


### PR DESCRIPTION
- For admin, add a `page:load` event
- Also in admin, remove `data-no-turbolink`

These changes were made while removing `(document).ready` events throughout the app, but then we realized we actually need them, as per [this stack overflow post](http://stackoverflow.com/questions/18770517/rails-4-how-to-use-document-ready-with-turbo-links).