### PR TITLE
population_errors should check if its an empty array

### DIFF
--- a/app/views/test_executions/results/_supplemental_data_error_table.html.erb
+++ b/app/views/test_executions/results/_supplemental_data_error_table.html.erb
@@ -15,7 +15,7 @@
       <tr>
         <th colspan = '5' scope = 'col' class = 'col-sm-2'>
           <% if pop_error_value %>
-            <% unless population_errors.empty? %>
+            <% unless population_errors.blank? %>
               <%= population_errors.first.message %>. The following errors were also identified for this population.
             <% end %>
           <% else %>

--- a/app/views/test_executions/results/_supplemental_data_error_table.html.erb
+++ b/app/views/test_executions/results/_supplemental_data_error_table.html.erb
@@ -15,7 +15,7 @@
       <tr>
         <th colspan = '5' scope = 'col' class = 'col-sm-2'>
           <% if pop_error_value %>
-            <% if population_errors %>
+            <% unless population_errors.empty? %>
               <%= population_errors.first.message %>. The following errors were also identified for this population.
             <% end %>
           <% else %>


### PR DESCRIPTION
population_errors.first.message was giving a 500 error when the array was empty

Fix for #493
