### PR TITLE
Test links

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'jasny-bootstrap-rails'
 
 gem 'jquery-datatables-rails', '~> 3.3.0'
 
+gem 'local_time'
+
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'therubyracer', platforms: :ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -235,6 +235,8 @@ GEM
       railties (>= 3.2.16)
     json (1.8.3)
     kgio (2.10.0)
+    local_time (1.0.3)
+      coffee-rails
     log4r (1.1.10)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
@@ -486,6 +488,7 @@ DEPENDENCIES
   jquery-datatables-rails (~> 3.3.0)
   jquery-rails (~> 4.0.4)
   jquery-ui-rails (~> 5.0.5)
+  local_time
   minitest
   minitest-rails
   minitest-reporters

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require assets_framework/breadcrumb
 //= require jquery_nested_form
 //= require jasny-bootstrap.min
+//= require local_time
 //= require_tree .
 
 $(function() {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
  *= require jquery-ui/tabs
  *= require rails_bootstrap_forms
  *= require jasny-bootstrap.min
+ *= require dataTables/jquery.dataTables
 */
 
 @import 'globals';

--- a/app/assets/stylesheets/cypress/_tables.scss
+++ b/app/assets/stylesheets/cypress/_tables.scss
@@ -13,13 +13,13 @@
 
   .abbreviated-multiline {
     overflow: hidden;
-    position: relative; 
+    position: relative;
     line-height: 1.2em;
-    max-height: 6em; 
-    text-align: justify;  
+    max-height: 6em;
+    text-align: justify;
     margin-right: -1em;
     padding-right: 1em;
-    
+
     &:hover {
       white-space: normal;
       max-height: 10.9em;
@@ -33,7 +33,7 @@
     right: 0;
     bottom: 0;
   }
-  
+
   .abbreviated-multiline:after {
     content: '';
     position: absolute;
@@ -66,4 +66,8 @@
 .table > tfoot > tr > th,
 .table > tfoot > tr > td {
   vertical-align: middle;
+}
+
+.dataTable thead th {
+  padding-right: 1.5em; // make sure the sorting icon is visible
 }

--- a/app/assets/stylesheets/cypress/_text.scss
+++ b/app/assets/stylesheets/cypress/_text.scss
@@ -1,5 +1,5 @@
-main a:not(.btn):not(.task-switch-link) {
-  font-weight: bold;
+a.label {
+  color: $brand-white;
 }
 
 .summary-title {
@@ -10,8 +10,8 @@ main a:not(.btn):not(.task-switch-link) {
   text-overflow: ellipsis;
 
   &:hover {
-      white-space: normal;
-      overflow: hidden;
+    white-space: normal;
+    overflow: hidden;
   }
 }
 
@@ -60,4 +60,8 @@ main:focus { outline: none; }
   }
 
   dd { font-weight: bold; }
+}
+
+.no-wrap {
+  white-space: nowrap;
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,4 +23,12 @@ module ApplicationHelper
              end
     @title.titleize
   end
+
+  def cms_int(cms_id)
+    # this is here because sometimes we only have the cms_id string and not the measure
+    return 0 unless cms_id
+    start_marker = 'CMS'
+    end_marker = 'v'
+    cms_id[/#{start_marker}(.*?)#{end_marker}/m, 1].to_i
+  end
 end

--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -48,4 +48,25 @@ module FilteringTestsHelper
 
     arr
   end
+
+  def generate_filter_records(filter_tests)
+    return unless filter_tests
+    test = filter_tests.pop
+    test.generate_records
+    test.save
+    test.queued
+    ProductTestSetupJob.perform_later(test)
+    records = test.records
+    filter_tests.each do |ft|
+      records.collect do |r|
+        r2 = r.clone
+        r2.test_id = ft.id
+        r2.save
+        r2
+      end
+      ft.save
+      ft.queued
+      ProductTestSetupJob.perform_later(ft)
+    end
+  end
 end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -61,8 +61,10 @@ class MeasureTest < ProductTest
       'passing'
     elsif c1_task.failing? || c3_task.failing?
       'failing'
-    else
+    elsif c1_task.incomplete? || c3_task.incomplete?
       'incomplete'
+    else
+      'unstarted'
     end
   end
 
@@ -77,8 +79,10 @@ class MeasureTest < ProductTest
       'passing'
     elsif c2_task.failing? || c3_task.failing?
       'failing'
-    else
+    elsif c2_task.incomplete? || c3_task.incomplete?
       'incomplete'
+    else
+      'unstarted'
     end
   end
 end

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -8,14 +8,14 @@
 
 <table class = 'table table-hover table-condensed'>
   <thead>
-    <td class = 'col-sm-10'></td>
-    <td class = 'col-sm-2'></td>
+    <th class="no-wrap" scope="col">Manual Entry Test</th>
+    <th class="no-wrap" scope="col">Status</th>
   </thead>
   <tbody>
     <% checklist_test.measures.sort_by(&:cms_int).each do |measure| %>
       <tr>
         <td><%= link_to "#{measure.cms_id} #{measure.name}", product_checklist_test_path(product, checklist_test, anchor: measure.cms_id) %></td>
-        <td class = 'text-right'>
+        <td class="no-wrap">
           <% case checklist_test.measure_status(measure.id) %>
           <% when 'passed' %>
             <strong class = 'text-success'>Passing</strong>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -4,28 +4,24 @@
 
 %>
 
-<table class = 'table table-hover table-condensed'>
+<table class = 'table'>
   <thead>
-    <td class = 'col-sm-1'></td>
-    <td class = 'col-sm-5'></td>
-    <th class = 'col-sm-3'><strong>CAT I</strong></th>
-    <th class = 'col-sm-3'><strong>CAT III</strong></th>
+    <th class="no-wrap" scope="col">Filtering Criteria</th>
+    <th class="no-wrap" scope="col">CAT I</th>
+    <th class="no-wrap" scope="col">CAT III</th>
   </thead>
   <tbody>
     <% tests.each do |test| %>
       <tr>
-        <td></td>
-        <td>
-          <% visibility = test.task_status('Cat1FilterTask') == 'passing' && test.task_status('Cat3FilterTask') == 'passing' ? '' : 'invisible' %>
-          <i class = 'fa fa-fw fa-check text-success <%= visibility %>'></i>
+        <td class="no-wrap">
           <% if test.display_name.to_s == '' %>
             <%= test.options.filters.keys.join('/').titleize %>
           <% else %>
             <%= test.display_name %>
           <% end %>
         </td>
-        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task, status: test.cat1_task.status } %></td>
-        <td><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task, status: test.cat3_task.status } %></td>
+        <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task, status: test.cat1_task.status } %></td>
+        <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task, status: test.cat3_task.status } %></td>
       </tr>
     <% end %>
     <% if tests.any? { |test| test.state != :ready } %>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -9,6 +9,7 @@
     <th class="no-wrap" scope="col">Filtering Criteria</th>
     <th class="no-wrap" scope="col">CAT I</th>
     <th class="no-wrap" scope="col">CAT III</th>
+    <th class="no-wrap" scope="col">Last Updated</th>
   </thead>
   <tbody>
     <% tests.each do |test| %>
@@ -22,6 +23,8 @@
         </td>
         <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task, status: test.cat1_task.status } %></td>
         <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task, status: test.cat3_task.status } %></td>
+        <td class="no-wrap"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
+          <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
     <% if tests.any? { |test| test.state != :ready } %>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -10,33 +10,28 @@
 <% c2_label += ' and C3' if @product.c3_test %>
 <% c1_and_c2 = @product.c1_test && @product.c2_test %>
 
-<table class = 'table table-hover table-condensed' id = 'measure_tests_table'>
+<table class = 'table' id = 'measure_tests_table'>
   <thead>
-    <th scope="col" class = 'col-sm-2 pointer-on-hover'>
+    <th scope="col" class = 'no-wrap pointer-on-hover'>
       CMS ID
-      <a>[sort]</a>
     </th>
     <% if c1_and_c2 %>
-      <th scope="col" class = 'col-sm-6 pointer-on-hover'>
+      <th scope="col" class = 'no-wrap pointer-on-hover'>
         Measure Name
-        <a>[sort]</a>
       </th>
     <% else %>
-      <th scope="col" class = 'col-sm-8 pointer-on-hover'>
+      <th scope="col" class = 'no-wrap pointer-on-hover'>
         Measure Name
-        <a>[sort]</a>
       </th>
     <% end %>
     <% if @product.c1_test %>
-      <th scope="col" class = 'col-sm-2 pointer-on-hover'>
+      <th scope="col" class = 'no-wrap pointer-on-hover'>
         <%= c1_label %>
-        <a>[sort]</a>
       </th>
     <% end %>
     <% if @product.c2_test %>
-      <th scope="col" class = 'col-sm-2 pointer-on-hover'>
+      <th scope="col" class = 'no-wrap pointer-on-hover'>
         <%= c2_label %>
-        <a>[sort]</a>
       </th>
     <% end %>
   </thead>
@@ -46,10 +41,10 @@
         <td data-sort="<%= cms_int(test.cms_id) %>"><%= test.cms_id %></td>
         <td><%= test.name %></td>
         <% if @product.c1_test %>
-          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>
+          <td class="no-wrap" data-order="<%= set_sorting(test, test.cat1_status) %>"><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>
         <% end %>
         <% if @product.c2_test %>
-          <td><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task, status: test.cat3_status } %></td>
+          <td class="no-wrap" data-order="<%= set_sorting(test, test.cat3_status) %>"><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task, status: test.cat3_status } %></td>
         <% end %>
       </tr>
     <% end %>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -34,6 +34,9 @@
         <%= c2_label %>
       </th>
     <% end %>
+    <th scope="col" class="no-wrap">
+      Last Updated
+    </th>
   </thead>
   <tbody>
     <% tests.each do |test| %>
@@ -46,6 +49,8 @@
         <% if @product.c2_test %>
           <td class="no-wrap" data-order="<%= set_sorting(test, test.cat3_status) %>"><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task, status: test.cat3_status } %></td>
         <% end %>
+        <td class="no-wrap" data-order="<%= test.updated_at %>"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
+          <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
     <% if tests.any? { |test| test.state != :ready } %>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -9,20 +9,25 @@
 %>
 <% if test.state != :ready %>
   <% if test.state == :queued %>
-    <i class="fa fa-fw fa-play-circle text-info invisible" aria-hidden="true"></i> <span class="text-muted">queued</span>
+    <i class="fa fa-fw fa-circle text-muted" aria-hidden="true"></i>
+    <span class="label label-default">queued</span>
   <% else test.state == :building %>
-    <i class="fa fa-fw fa-refresh fa-spin" aria-hidden="true"></i> building
+    <i class="fa fa-fw fa-cog fa-spin" aria-hidden="true"></i>
+    <span class="label label-default">building</span>
   <% end %>
 <% else %>
   <% case status %>
   <% when 'passing' %>
-    <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-    <%= link_to 'view', new_task_test_execution_path(task) %>
+    <i class = 'fa fa-fw fa-check-circle text-success' aria-hidden="true"></i>
+    <%= link_to 'view', new_task_test_execution_path(task), :class => "label label-success" %>
   <% when 'failing' %>
-    <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
-    <%= link_to 'retry', new_task_test_execution_path(task) %>
+    <i class = 'fa fa-fw fa-play-circle text-danger' aria-hidden="true"></i>
+    <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-danger" %>
+  <% when 'incomplete' %>
+    <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
+    <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
   <% else %>
-    <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-    <%= link_to 'start', new_task_test_execution_path(task) %>
+    <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
+    <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
   <% end %>
 <% end %>


### PR DESCRIPTION
# Before
![image](https://cloud.githubusercontent.com/assets/2136286/15895827/52938466-2d5b-11e6-9adc-a77d01ad9781.png)

# After
![image](https://cloud.githubusercontent.com/assets/2136286/15895828/56161126-2d5b-11e6-8728-656ad3b5bb7a.png)

![image](https://cloud.githubusercontent.com/assets/2136286/15895980/13f42ef8-2d5c-11e6-8cdf-52fd5ee0c176.png)

## Notes
* Adds new icons/labels for test states. Not visible: building icon spinning.
* Removed **[sort]** link in favor of using the icon that comes with dataTables.
* Added a new column to show last updated date, via the `local_time` gem.

