### PR TITLE
Create Checklist Test on Product Create

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,7 +25,7 @@ Metrics/AbcSize:
   # a Float.
   Max: 32
   Exclude:
-    - 'test/models/measure_test_test.rb'
+    - 'test/**/*.rb'
 # Avoid complex methods.
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -4,7 +4,7 @@ class ChecklistTestsController < ProductTestsController
   before_action :set_measures, only: [:show]
 
   def create
-    @product_test = @product.product_tests.build({ name: 'c1 visual', measure_ids: interesting_measure_ids }, ChecklistTest)
+    @product_test = @product.product_tests.build({ name: 'c1 visual', measure_ids: @product.interesting_measure_ids }, ChecklistTest)
     @product_test.save!
     @product_test.create_checked_criteria
     redirect_to vendor_product_path(@product.vendor, @product, anchor: 'ChecklistTest')
@@ -46,13 +46,6 @@ class ChecklistTestsController < ProductTestsController
   def set_measures
     @measures = @product_test.measures.sort_by(&:cms_int)
   end
-
-  # CHOOSE INTERESTING CRITERIA HERE - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - #
-  def interesting_measure_ids
-    @product.product_tests.measure_tests.map { |test| test.measure_ids.first } # Probably not the way we want to choose measures ~ Jaebird
-  end
-
-  # CHOOSE INTERESTING CRITERIA HERE - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - #
 
   def checklist_test_params
     params[:product_test].permit(checked_criteria_attributes: [:id, :_destroy, :completed, :code, :attribute_code])

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,7 @@ class ProductsController < ApplicationController
     @product.save!
     flash_comment(@product.name, 'success', 'created')
     respond_with(@product) do |f|
-      f.html { redirect_to vendor_path(@vendor) }
+      f.html { add_checklist_test_and_redirect(product_params, @vendor) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with_errors(@product) do |f|
@@ -54,7 +54,7 @@ class ProductsController < ApplicationController
     @product.save!
     flash_comment(@product.name, 'info', 'edited')
     respond_with(@product) do |f|
-      f.html { redirect_to vendor_path(@product.vendor) }
+      f.html { add_checklist_test_and_redirect(edit_product_params, @product.vendor) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with(@product) do |f|
@@ -110,5 +110,10 @@ class ProductsController < ApplicationController
 
   def edit_product_params
     params.require(:product).permit(:name, :version, :description, :measure_selection, measure_ids: [])
+  end
+
+  def add_checklist_test_and_redirect(params, vendor)
+    @product.add_checklist_test if @product.c1_test
+    redirect_to vendor_path(vendor)
   end
 end

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -4,7 +4,7 @@
 # # # # # # # # # # #
 
 def build_product
-  Product.new(name: 'Product 1', measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'], bundle_id: '4fdb62e01d41c820f6000001')
+  Product.new(name: 'Product 1', measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'], bundle_id: '4fdb62e01d41c820f6000001')
 end
 
 # # # # # # # # #
@@ -32,7 +32,7 @@ end
 When(/^the user creates a product with name (.*) for vendor (.*)$/) do |product_name, vendor_name|
   steps %( When the user navigates to the create product page for vendor #{vendor_name} )
   page.fill_in 'Name', with: product_name
-  page.find('#product_c1_test').click
+  page.find('#product_c2_test').click
   page.find('#product_measure_selection_custom').click
   page.all('.sidebar a')[2].click
   page.all('input.measure-checkbox')[0].click
@@ -83,7 +83,7 @@ When(/^the user fills out all product information but measures$/) do
   @product = FactoryGirl.build(:product)
   page.fill_in 'Name', with: @product.name
   page.find('#product_measure_selection_custom').click
-  page.find('#product_c1_test').click
+  page.find('#product_c2_test').click
 end
 
 # V V V Measure Selection V V V


### PR DESCRIPTION
- creates c1 checklist test when user creates product (does not happenfor api request)
- deletes and makes new c1 checklist test if user removes a measure used in checklist test
- added tests for these
- fixed issue where only changing product name would remove all measures