### PR TITLE
Added load_library_functions to some setup/teardown methods

### DIFF
--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -8,6 +8,10 @@ class Admin::BundlesControllerTest < ActionController::TestCase
     FileUtils.rm_rf(APP_CONFIG.bundle_file_path)
   end
 
+  teardown do
+    load_library_functions
+  end
+
   test 'should get index' do
     for_each_logged_in_user([ADMIN]) do
       get :index

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -10,6 +10,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     collection_fixtures('vendors', 'products', 'product_tests', 'tasks', 'test_executions', 'users', 'roles',
                         'bundles', 'measures', 'health_data_standards_svs_value_sets', 'artifacts',
                         'records', 'patient_populations')
+    load_library_functions
     @vendor = Vendor.find(EHR1)
     @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').first
     @first_product.bundle = Bundle.default


### PR DESCRIPTION
This should help to keep them in sync with the bundles that are installed in the testing environment, and maybe eliminate a few of the errors we're seeing.