### PR TITLE
fix NoMethodError on test execution result

### DIFF
--- a/app/helpers/xml_view_helper.rb
+++ b/app/helpers/xml_view_helper.rb
@@ -54,8 +54,8 @@ module XmlViewHelper
 
       file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
       file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
-      file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : []
-      file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : []
+      file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : { execution_errors: [] }
+      file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : { execution_errors: [] }
 
       collected_errors[:files][this_name] = file_error_hash
     end


### PR DESCRIPTION
Fixes the NoMethodError on viewing a test execution result. The error occurred when a file had a QRDA or Reporting error, and no Submission errors or warnings.