### PR TITLE
Multi Upload on Product Page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,9 @@ gem 'sdoc', '~> 0.4.0', :group => :doc
 gem 'carrierwave'
 gem 'carrierwave-mongoid', require: 'carrierwave/mongoid'
 
+# AJAX file uploads
+gem 'remotipart', '~> 1.2'
+
 gem 'settingslogic'
 
 # bubble up errors from embedded documents in Mongoid.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -340,6 +340,7 @@ GEM
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    remotipart (1.2.1)
     representable (2.3.0)
       uber (~> 0.0.7)
     responders (2.2.0)
@@ -503,6 +504,7 @@ DEPENDENCIES
   pry-nav
   quality-measure-engine!
   rails (~> 4.2.5.2)
+  remotipart (~> 1.2)
   responders
   roar-rails
   rolify

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require turbolinks
 //= require jquery
 //= require jquery_ujs
+//= require jquery.remotipart
 //= require parsley/parsley
 //= require dataTables/jquery.dataTables
 //= require jquery-ui/autocomplete

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -14,6 +14,11 @@ ready = function() {
     stateSave: true, /* preserves order on reload */
     info: false
   });
+
+  /* submit upload when file is attached */
+  $('.multi-upload-field').on('change', function(ev) {
+    $(this).parent().siblings('.multi-upload-submit').click();
+  });
 };
 
 var reticulateSplines = function() {
@@ -29,7 +34,7 @@ var reticulateSplines = function() {
 
     if ($('#display_filtering_test_status_display').length && ($('#display_filtering_test_status_display').find('i.fa-refresh').length ||
         $('#display_filtering_test_status_display').find('span.text-muted').text().indexOf('queued') > -1) ||
-        $('#display_measure_tests_table').find('i.fa-gavel').length) {
+        $('#display_filtering_test_status_display').find('i.fa-gavel').length) {
       $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display' }});
     }
 };

--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -22,12 +22,14 @@ var reticulateSplines = function() {
     }
 
     if ($('#display_measure_tests_table').length && ($('#display_measure_tests_table').find('i.fa-refresh').length ||
-        $('#display_measure_tests_table').find('span.text-muted').text().indexOf('queued') > -1)) {
+        $('#display_measure_tests_table').find('span.text-muted').text().indexOf('queued') > -1) ||
+        $('#display_measure_tests_table').find('i.fa-gavel').length) {
       $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'measure_tests_table' }});
     }
 
     if ($('#display_filtering_test_status_display').length && ($('#display_filtering_test_status_display').find('i.fa-refresh').length ||
-        $('#display_filtering_test_status_display').find('span.text-muted').text().indexOf('queued') > -1)) {
+        $('#display_filtering_test_status_display').find('span.text-muted').text().indexOf('queued') > -1) ||
+        $('#display_measure_tests_table').find('i.fa-gavel').length) {
       $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display' }});
     }
 };

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -7,7 +7,7 @@ class TestExecutionsController < ApplicationController
   before_action :set_product_test_from_task, only: [:show, :new]
   before_action :add_breadcrumbs, only: [:show, :new]
 
-  respond_to :js, only: [:show]
+  respond_to :js, only: [:show, :create]
 
   def index
     @test_executions = @task.test_executions
@@ -72,6 +72,11 @@ class TestExecutionsController < ApplicationController
   end
 
   def results_params
-    params[:results]
+    # reqests from outside test execution page will have :results inside :test_execution in params
+    if params[:results]
+      params[:results]
+    elsif params[:test_execution]
+      params[:test_execution][:results]
+    end
   end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -41,4 +41,9 @@ module MeasuresHelper
     end
     false
   end
+
+  def type_counts(measures)
+    h = measures.map(&:type).each_with_object(Hash.new(0)) { |type, count| count[type.upcase] += 1 } # example { "EH"=> 4, "EP" => 2 }
+    h.map { |k, v| "#{v} #{k}" }.join(', ') # 4 EH, 2 EP
+  end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -29,4 +29,16 @@ module MeasuresHelper
     return false unless measure && measure.hqmf_document && measure.hqmf_document['source_data_criteria']
     measure.hqmf_document['source_data_criteria'].values.any? { |criteria| criteria['definition'] == 'diagnosis' }
   end
+
+  # used in _measure_tests_table.html.erb view
+  # returns true if measure test is not ready (not built yet) or if measure test has a test execution that is running
+  def should_reload_measure_test?(test)
+    return true if test.state != :ready
+    test.tasks.each do |task|
+      task.test_executions.each do |execution|
+        return true if execution.state == :pending
+      end
+    end
+    false
+  end
 end

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -50,6 +50,28 @@ module VendorsHelper
     h
   end
 
+  # returns zero for all values if test is false
+  def checklist_status_values(test)
+    return [0, 0, 0, 0] unless test
+    passing = test.num_measures_complete
+    total = test.measures.count
+    not_started = test.num_measures_not_started
+    failing = total - not_started - passing
+    [passing, failing, not_started, total]
+  end
+
+  def product_test_statuses(tests, task_type)
+    tasks = []
+    tests.each { |test| tasks << test.tasks.where(_type: task_type) }
+    tasks.empty? ? [0, 0, 0, 0] : tasks_values(tasks)
+  end
+
+  def tasks_values(tasks)
+    status_values = []
+    %w(passing failing incomplete).each { |status| status_values << tasks.count { |task| task.first.status == status } }
+    status_values << tasks.count # total number of product tests
+  end
+
   # status should be 'Passing', 'Failing', or 'Not Complete'
   # used for each certification status on vendor show page
   def status_to_css_classes(status)

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -21,16 +21,15 @@
             <%= test.display_name %>
           <% end %>
         </td>
-        <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat1_task, status: test.cat1_task.status } %></td>
-        <td class="no-wrap"><%= render partial: 'product_test_link', locals: { test: test, task: test.cat3_task, status: test.cat3_task.status } %></td>
+        <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(test.cat1_task) %>">
+          <%= render partial: '/products/product_test_link', locals: { test: test, task: test.cat1_task } %>
+        </td>
+        <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(test.cat3_task) %>">
+          <%= render partial: '/products/product_test_link', locals: { test: test, task: test.cat3_task } %>
+        </td>
         <td class="no-wrap"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
           <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
-    <% if tests.any? { |test| should_reload_measure_test?(test) } %>
-      <script>
-        $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display' }});
-      </script>
-    <% end%>
   </tbody>
 </table>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -27,7 +27,7 @@
           <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
-    <% if tests.any? { |test| test.state != :ready } %>
+    <% if tests.any? { |test| should_reload_measure_test?(test) } %>
       <script>
         $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display' }});
       </script>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -44,19 +44,14 @@
         <td data-sort="<%= cms_int(test.cms_id) %>"><%= test.cms_id %></td>
         <td><%= test.name %></td>
         <% if @product.c1_test %>
-          <td class="no-wrap" data-order="<%= set_sorting(test, test.cat1_status) %>"><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c1_task, status: test.cat1_status } %></td>
+          <td id = "<%= id_for_html_wrapper_of_task(test.tasks.c1_task) %>" class="no-wrap" data-order="<%= set_sorting(test, test.cat1_status) %>"><%= render partial: '/products/product_test_link', locals: { test: test, task: test.tasks.c1_task } %></td>
         <% end %>
         <% if @product.c2_test %>
-          <td class="no-wrap" data-order="<%= set_sorting(test, test.cat3_status) %>"><%= render partial: 'product_test_link', locals: { test: test, task: test.tasks.c2_task, status: test.cat3_status } %></td>
+          <td id = "<%= id_for_html_wrapper_of_task(test.tasks.c2_task) %>" class="no-wrap" data-order="<%= set_sorting(test, test.cat3_status) %>"><%= render partial: '/products/product_test_link', locals: { test: test, task: test.tasks.c2_task } %></td>
         <% end %>
         <td class="no-wrap" data-order="<%= test.updated_at %>"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
           <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
-    <% if tests.any? { |test| should_reload_measure_test?(test) } %>
-      <script>
-        $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table' }});
-      </script>
-    <% end%>
   </tbody>
 </table>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -53,7 +53,7 @@
           <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
-    <% if tests.any? { |test| test.state != :ready } %>
+    <% if tests.any? { |test| should_reload_measure_test?(test) } %>
       <script>
         $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table' }});
       </script>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -2,11 +2,15 @@
 
 # local variables
 #
-#   test   (MeasureTest)
-#   task   (C1Task or C2Task)
-#   status (String)
+#   test  (MeasureTest)
+#   task  (Task)        for   MeasureTest: should be C1Task or C2Task. should NOT be C3Cat1Task or C3Cat3Task since c3 test executions are executed
+#                                          when c1 or c2 test executions are created
+#                       for FilteringTest: should be Cat1FilterTask or Cat3FilterTask
 
 %>
+
+<% tasks = with_c3_task(task) %>
+
 <% if test.state != :ready %>
   <% if test.state == :queued %>
     <i class="fa fa-fw fa-circle text-muted" aria-hidden="true"></i>
@@ -16,23 +20,33 @@
     <span class="label label-default">building</span>
   <% end %>
 <% else %>
-  <% case status %>
+  <% case tasks_status(tasks) %>
   <% when 'passing' %>
-    <i class = 'fa fa-fw fa-check-circle text-success' aria-hidden="true"></i>
+    <i class = 'fa fa-fw fa-check-circle text-success invisible' aria-hidden="true"></i>
     <%= link_to 'view', new_task_test_execution_path(task), :class => "label label-success" %>
+    <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'failing' %>
-    <i class = 'fa fa-fw fa-play-circle text-danger' aria-hidden="true"></i>
+    <i class = 'fa fa-fw fa-play-circle text-danger invisible' aria-hidden="true"></i>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-danger" %>
+    <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'incomplete' %>
-    <% if task.most_recent_execution %>
+    <% if should_reload_product_test_link?(tasks) %>
       <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
-      <%= link_to 'testing', new_task_test_execution_path(task), :class => 'label label-default' %>
+      <%= link_to 'testing...', new_task_test_execution_path(task), :class => 'label label-default' %>
     <% else %>
-      <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
+      <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
       <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
+      <%= render partial: '/products/product_test_upload', locals: { task: task } %>
     <% end %>
   <% else %>
     <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
     <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
+    <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% end %>
+<% end %>
+
+<% if should_reload_product_test_link?(tasks) %>
+  <script>
+    $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: '/products/product_test_link', task_id: "<%= task.id.to_s %>" }});
+  </script>
 <% end %>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -24,8 +24,13 @@
     <i class = 'fa fa-fw fa-play-circle text-danger' aria-hidden="true"></i>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-danger" %>
   <% when 'incomplete' %>
-    <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
-    <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
+    <% if task.most_recent_execution %>
+      <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
+      <%= link_to 'testing', new_task_test_execution_path(task), :class => 'label label-default' %>
+    <% else %>
+      <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
+      <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
+    <% end %>
   <% else %>
     <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
     <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>

--- a/app/views/products/_product_test_upload.html.erb
+++ b/app/views/products/_product_test_upload.html.erb
@@ -1,0 +1,17 @@
+<%
+
+# local variables:
+#
+#   task
+
+%>
+
+<% accept_type = displaying_cat1?(task) ? 'application/zip' : 'text/xml' %>
+<% unique_id = task.id # value unique to this form %>
+
+<%= form_for(TestExecution.new, html: { method: :post, multipart: true, id: "multi-upload-form-#{unique_id}", class: 'inline' }, :authenticity_token => true, remote: true, url: task_test_executions_path(task)) do |f| %>
+  <%= f.label :results, 'upload', class: 'inline label label-default', for: "multi-upload-field-#{unique_id}" do %>
+     upload<%= f.file_field :results, class: 'hidden multi-upload-field', accept: accept_type, id: "multi-upload-field-#{unique_id}" %>
+  <% end %>
+  <%= f.submit 'my submit button', class: 'hidden multi-upload-submit', id: "multi-upload-submit-#{unique_id}" %>
+<% end %>

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -11,7 +11,7 @@
   <% end %>
 
 <% elsif params[:partial] == 'measure_tests_table' %>
-  <% if @product.product_tests.measure_tests.any? { |test| test.state != :ready } %>
+  <% if @product.product_tests.measure_tests.any? { |test| should_reload_measure_test?(test) } %>
     setTimeout(function(){
     $('#display_measure_tests_table').html("<%= escape_javascript render partial: 'measure_tests_table', locals: { tests: @product.product_tests.measure_tests } %>");
     }, 2000);
@@ -20,7 +20,7 @@
   <% end %>
 
 <% elsif params[:partial] == 'filtering_test_status_display' %>
-  <% if @product.product_tests.filtering_tests.any? { |test| test.state != :ready } %>
+  <% if @product.product_tests.filtering_tests.any? { |test| should_reload_measure_test?(test) } %>
     setTimeout(function(){
     $('#display_filtering_test_status_display').html("<%= escape_javascript render partial: 'filtering_test_status_display', locals: { tests: @product.product_tests.filtering_tests } %>");
     }, 2000);

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -10,21 +10,10 @@
     $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
   <% end %>
 
-<% elsif params[:partial] == 'measure_tests_table' %>
-  <% if @product.product_tests.measure_tests.any? { |test| should_reload_measure_test?(test) } %>
-    setTimeout(function(){
-    $('#display_measure_tests_table').html("<%= escape_javascript render partial: 'measure_tests_table', locals: { tests: @product.product_tests.measure_tests } %>");
-    }, 2000);
-  <% else %>
-    $('#display_measure_tests_table').html("<%= escape_javascript render partial: 'measure_tests_table', locals: { tests: @product.product_tests.measure_tests } %>");
-  <% end %>
-
-<% elsif params[:partial] == 'filtering_test_status_display' %>
-  <% if @product.product_tests.filtering_tests.any? { |test| should_reload_measure_test?(test) } %>
-    setTimeout(function(){
-    $('#display_filtering_test_status_display').html("<%= escape_javascript render partial: 'filtering_test_status_display', locals: { tests: @product.product_tests.filtering_tests } %>");
-    }, 2000);
-  <% else %>
-    $('#display_filtering_test_status_display').html("<%= escape_javascript render partial: 'filtering_test_status_display', locals: { tests: @product.product_tests.filtering_tests } %>");
-  <% end %>
+<% elsif params[:partial] == '/products/product_test_link' %>
+  <% task = Task.find(params[:task_id]) %>
+  <% wrapper_id = id_for_html_wrapper_of_task(task) %>
+  setTimeout(function() {
+    $("#<%= wrapper_id %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
+  }, 500);
 <% end %>

--- a/app/views/test_executions/create.js.erb
+++ b/app/views/test_executions/create.js.erb
@@ -1,0 +1,9 @@
+<% # currently only used by product show page for ajax call to create test execution %>
+
+<% # set product for /products/measure_tests_table partial %>
+<% @product = @test_execution.task.product_test.product %>
+
+<% # set PATH_INFO so AJAX call can be made in /products/measure_tests_table partial. this AJAX call is for reloading each product_test_link %>
+<% request.env['PATH_INFO'] = vendor_product_path(@product.vendor, @product) %>
+
+$.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: '/products/product_test_link', task_id: "<%= params[:task_id] %>" }});

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -22,3 +22,26 @@ Scenario: Can Download Report
   When all measure tests have a state of ready
   And the user visits the product page
   Then the user should be able to view the report
+
+Scenario: Can Multi Upload Cat I
+  When all measure tests have a state of ready
+  And the user adds cat I tasks to all product tests
+  And the user visits the product page
+  And the user uploads a cat I document to product test 1
+  Then the user should see a cat I test testing for product test 1
+
+Scenario: Can Multi Upload Cat III
+  When all measure tests have a state of ready
+  And the user visits the product page
+  And the user uploads a cat III document to product test 1
+  Then the user should see a cat III test testing for product test 1
+
+Scenario: Can Multi Upload Multiple Times
+  When the user adds a product test
+  And all measure tests have a state of ready
+  And the user adds cat I tasks to all product tests
+  And the user visits the product page
+  And the user uploads a cat I document to product test 1
+  And the user uploads a cat III document to product test 2
+  Then the user should see a cat I test testing for product test 1
+  And the user should see a cat III test testing for product test 2

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -55,6 +55,7 @@ end
 # # # # # # # #
 
 Then(/^the user should see the CAT 1 test$/) do
+  sleep(0.5)
   assert page.has_content?('a zip file of QRDA Category I documents')
 end
 


### PR DESCRIPTION
- added a `testing` state for measure and filtering tests
- added AJAX upload for CAT I and CAT III documents on product show page
- added gem `remotipart` (for AJAX upload)
- moved helper functions from product helper to vendor helper because these functions were only used by other vendor helper functions

![screen shot 2016-06-21 at 10 05 26 am](https://cloud.githubusercontent.com/assets/14349011/16232266/d4b74d2e-3797-11e6-8e43-004de89307f1.png)
