### PR TITLE
fixes for errors on download report

### DIFF
--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -1,5 +1,6 @@
 module FilteringTestsHelper
   def display_filter_val(filter_name, vals)
+    return [] if vals == [] # ie, the filter values haven't been chosen yet
     return providers_val(vals) if filter_name == 'providers'
     return problems_val(vals) if filter_name == 'problems'
     return age_val(vals) if filter_name == 'age'

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -112,7 +112,7 @@
           <% check_test.checked_criteria.all(measure_id: measure.id).each do |check_crit| %>
             <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == check_crit.source_data_criteria }.values.first %>
             <tr>
-              <td><%= render partial: 'products/report/status_icon', locals: { passing: check_crit.completed } %></td>
+              <td><%= render partial: 'products/report/status_icon', locals: { passing: check_crit.complete? } %></td>
               <td><%= criteria[:description].chomp(': ' + criteria[:title]) %></td>
               <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
             </tr>


### PR DESCRIPTION
1. Before the job runs for C4 tests their filter criteria are set to empty lists, which breaks our helper. This adds a base case for that scenario

2. ChecklistDataSourceCriteria no longer has a `.completed`, it has a `.complete?`