### PR TITLE
Added missing closing div tag for the edit product panel body

### DIFF
--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -80,8 +80,9 @@
         </div>
       </div>
 
-    <div class="row" id="measure_selection_section">
-       <%= render partial: 'measure_selection' %>
+      <div class="row" id="measure_selection_section">
+         <%= render partial: 'measure_selection' %>
+      </div>
     </div>
 
     <div class="panel-footer">


### PR DESCRIPTION
Now the delete product panel is not weirdly inside the preceding panel.

### Before
![image](https://cloud.githubusercontent.com/assets/2136286/16267891/021e1514-385a-11e6-8a16-de6f863acb78.png)

### After
![image](https://cloud.githubusercontent.com/assets/2136286/16267897/09e4d896-385a-11e6-9a41-31d742e58a2c.png)
