### PR TITLE
add navbar link to CVU in demo and internal modes

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -34,6 +34,14 @@
             Master Patient List
             <% end %>
           </li>
+          <% if mode_internal? || mode_demo? %>
+          <li>
+          <%= link_to '/cvu', class: 'navbar-item', target: '_blank'   do %>
+              <i class="fa fa-fw fa-check-square-o" aria-hidden="true"></i>
+              Validation Utility
+              <% end %>
+          </li>
+          <% end %>
           <li <% if curr_page == :account %>class="active"<% end %>>
             <%= link_to edit_user_registration_path, class: 'navbar-item'   do %>
             <i class="fa fa-fw fa-user" aria-hidden="true"></i>


### PR DESCRIPTION
Adds a link to /cvu , which redirects to the CVU on the preconfigured VM and demo server

![cvu_link](https://cloud.githubusercontent.com/assets/13512036/16270254/b396a050-3863-11e6-936c-c40589a24af6.JPG)

