### PR TITLE
Add ability for cypress.yml values to be pulled from environment.

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -24,12 +24,13 @@ class AdminController < ApplicationController
 
   def sub_yml_setting(key, val)
     yml_text = File.read("#{Rails.root}/config/cypress.yml")
+    sub_string = /#{key}:(.*?)\n/
     if val.is_a? String
-      yml_text.sub!(/^\s*#{key}: "(.*)"/, "#{key}: \"#{val}\"")
+      yml_text.sub!(sub_string, "#{key}: \"#{val}\"\n")
     elsif val.is_a? Symbol
-      yml_text.sub!(/^\s*#{key}: (.*)/, "#{key}: :#{val}")
+      yml_text.sub!(sub_string, "#{key}: :#{val}\n")
     else
-      yml_text.sub!(/^\s*#{key}: (.*)/, "#{key}: #{val}")
+      yml_text.sub!(sub_string, "#{key}: #{val}\n")
     end
     File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts yml_text }
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -7,7 +7,7 @@ class Ability
     # if user.atl?
     #   can :manage, :all
     # end
-    if APP_CONFIG.ignore_roles || user.has_role?('admin')
+    if Settings[:ignore_roles] || user.has_role?('admin')
       can :manage, :all
     else
       can :manage, Vendor if user.has_role?('atl')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User
   index(invitation_token: 1)
   index(invitation_by_id: 1)
 
-  field :approved, type: Boolean, default: APP_CONFIG.auto_approve || false
+  field :approved, type: Boolean, default: Settings[:auto_approve] || false
 
   validates :terms_and_conditions, :acceptance => true, :on => :create, :allow_nil => false
 
@@ -101,7 +101,7 @@ class User
   end
 
   def assign_default_role
-    dr = APP_CONFIG.default_role
+    dr = Settings[:default_role]
     add_role dr if dr
   end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -23,7 +23,7 @@ class Vendor
   def self.accessible_by(user)
     # if admin or atl or ignore_roles get them all
     # else get all vendors that the user is a owner or vendor on
-    if user.has_role?(:admin) || user.has_role?(:atl) || APP_CONFIG.ignore_roles
+    if user.has_role?(:admin) || user.has_role?(:atl) || Settings[:ignore_roles]
       Vendor.all
     else
       vids = []

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -12,9 +12,9 @@ default_bundle: 2016.0.0
   # EP_CAT_1.sch
   # EP_CAT_3.sch
   # EH_CAT_1.sch
-# Inside the specified folder. 
-# The highest matching version will be used. Ie if bundle version is 3.0.0  the schematrons would be 3.0.0 
-# In the case of none of them being valid it will default to the first one 
+# Inside the specified folder.
+# The highest matching version will be used. Ie if bundle version is 3.0.0  the schematrons would be 3.0.0
+# In the case of none of them being valid it will default to the first one
 version_config:
   '>2.9.0':
       schematron: "bundle_2_9_9"
@@ -41,18 +41,18 @@ mailer_authentication: :plain
 
 bundle_file_path: "temp/bundles"
 
-# ignore roles completely -- this is essientially the same as everyone in the system being an admin
-ignore_roles: true
+# ignore roles completely -- this is essientially the same as everyone in the system being an admin, default true
+ignore_roles: <%= if ENV['IGNORE_ROLES'].nil? then true else ENV['IGNORE_ROLES'] end %>
 
-# enable the "debug features" such as allowing QA testers to produce known good results for a task
-enable_debug_features: true
+# enable the "debug features" such as allowing QA testers to produce known good results for a task, default true
+enable_debug_features: <%= if ENV['ENABLE_DEBUG_FEATURES'].nil? then true else ENV['ENABLE_DEBUG_FEATURES'] end %>
 
 # the default role to assign to a user upon at creation -- this should be either admin,atl, user or nil
 # a user without a role will not be able to create or view any vendors .  You may want to set this to nil
-# when an admin is required to approve new users and have the admin set the role there
-default_role: :user
-# wheather or not users are automatically approved without admin intervention
-auto_approve: true
+# when an admin is required to approve new users and have the admin set the role there, default :user
+default_role: <%= if !ENV["DEFAULT_ROLE"].nil? && ENV["DEFAULT_ROLE"].empty? then nil else (ENV["DEFAULT_ROLE"] || ":user") end %>
+# wheather or not users are automatically approved without admin intervention, default true
+auto_approve: <%= if ENV['AUTO_APPROVE'].nil? then true else ENV['AUTO_APPROVE'] end %>
 # sets whether or not Users are automatically linked to a Vendor based off the vendors points of contacts. Setting to true will
 # auto associate a User to a vendor when a user is created and a vendor point of contanct contains the same email address as the
 # user.  Likewise if a point of contact is added to a vendor and a User in the system has the same email address then the user

--- a/test/controllers/admin/user_controller_test.rb
+++ b/test/controllers/admin/user_controller_test.rb
@@ -38,7 +38,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
   test 'Admin can update user' do
     v = Vendor.first
-    APP_CONFIG['default_role'] = nil
+    Settings[:default_role] = nil
     u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
 
     for_each_logged_in_user([ADMIN]) do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -30,12 +30,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_assign_default_role
-    APP_CONFIG['default_role'] = :user
+    Settings[:default_role] = :user
     u = User.create(email: 'vendor@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
     assert u.has_role? :user
     assert u.has_role? 'user'
 
-    APP_CONFIG['default_role'] = nil
+    Settings[:default_role] = nil
     u = User.create(email: 'vendor2@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
     assert_equal 0, u.roles.length, 'user should not have any roles assigned '
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,6 @@ SimpleCov.start 'rails'
 # We dropped the value to 77 to be able to get pull requests pulled in. Needs to be brought back up as coverage goes back up.
 SimpleCov.minimum_coverage 77
 Mongo::Logger.logger.level = Logger::WARN
-APP_CONFIG['ignore_roles'] = false
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
@@ -25,6 +24,10 @@ Warden.test_mode!
 Mongoid.logger.level = Logger::INFO
 
 class ActiveSupport::TestCase
+  def setup
+    Settings[:ignore_roles] = false
+  end
+
   def teardown
     drop_database
   end


### PR DESCRIPTION
This checks to see if a user has set different configuration variables in their environment before falling back to defaults directly defined in the cypress.yml.