### PR TITLE
Manual Checklist Creation and Status

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,7 @@ class ProductsController < ApplicationController
     @product.save!
     flash_comment(@product.name, 'success', 'created')
     respond_with(@product) do |f|
-      f.html { add_checklist_test_and_redirect(product_params, @vendor) }
+      f.html { redirect_to vendor_path(@vendor) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with_errors(@product) do |f|
@@ -55,7 +55,7 @@ class ProductsController < ApplicationController
     @product.save!
     flash_comment(@product.name, 'info', 'edited')
     respond_with(@product) do |f|
-      f.html { add_checklist_test_and_redirect(edit_product_params, @product.vendor) }
+      f.html { redirect_to vendor_path(@product.vendor) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with(@product) do |f|
@@ -111,10 +111,5 @@ class ProductsController < ApplicationController
 
   def edit_product_params
     params.require(:product).permit(:name, :version, :description, :measure_selection, measure_ids: [])
-  end
-
-  def add_checklist_test_and_redirect(params, vendor)
-    @product.add_checklist_test if @product.c1_test
-    redirect_to vendor_path(vendor)
   end
 end

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -2,6 +2,11 @@ class ChecklistTest < ProductTest
   embeds_many :checked_criteria, class_name: 'ChecklistSourceDataCriteria'
   accepts_nested_attributes_for :checked_criteria, allow_destroy: true
 
+  def status
+    return 'incomplete' if measures.empty?
+    num_measures_complete == measures.count ? 'passing' : 'incomplete'
+  end
+
   def num_measures_complete
     return 0 if checked_criteria.count == 0
     num_complete = 0
@@ -24,13 +29,11 @@ class ChecklistTest < ProductTest
   def measures
     # measure list is changed once checklist is created, measures are based on checklist criteria
     if !checked_criteria.empty?
-      measure_ids = []
+      m_ids = []
       checked_criteria.each do |critiera|
-        unless measure_ids.include? critiera.measure_id
-          measure_ids << critiera.measure_id
-        end
+        m_ids << critiera.measure_id unless m_ids.include? critiera.measure_id
       end
-      Measure.where(:_id.in => measure_ids)
+      Measure.where(:_id.in => m_ids)
     else
       super
     end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -37,7 +37,7 @@ class Product
       if product_tests_for_status('failing').count > 0
         'failing'
       elsif product_tests_for_status('passing').count == total && total > 0
-        'passing'
+        c1_test && product_tests.checklist_tests.empty? ? 'incomplete' : 'passing'
       else
         'incomplete'
       end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -80,7 +80,9 @@ class Product
     end
     # remove measure and checklist tests if their measure ids have been removed
     product_tests.in(measure_ids: (old_ids - new_ids)).destroy
+    save!
     add_filtering_tests if c4_test
+    add_checklist_test if c1_test
   end
 
   # builds a checklist test if product does not have a checklist test
@@ -103,24 +105,22 @@ class Product
 
   def add_filtering_tests
     measure = ApplicationController.helpers.pick_measure_for_filtering_test(measure_ids, bundle)
-    save!
     reload_relations
 
-    if product_tests.filtering_tests.count == 0
-      criteria = %w(races ethnicities genders payers age).shuffle
-      filter_tests = []
-      filter_tests << build_filtering_test(measure, criteria[0, 2])
-      filter_tests << build_filtering_test(measure, criteria[2, 2])
-      filter_tests << build_filtering_test(measure, ['providers'], 'NPI, TIN & Provider Location')
-      filter_tests << build_filtering_test(measure, ['providers'], 'NPI & TIN', false)
-      filter_tests << if ApplicationController.helpers.measure_has_diagnosis_criteria?(measure)
-                        build_filtering_test(measure, ['problems'])
-                      else
-                        # the measure doesn't have a diagnosis so instead create a new demographics task
-                        build_filtering_test(measure, criteria.values_at(4, (0..3).to_a.sample))
-                      end
-      ApplicationController.helpers.generate_filter_records(filter_tests)
-    end
+    return if product_tests.filtering_tests.any?
+    criteria = %w(races ethnicities genders payers age).shuffle
+    filter_tests = []
+    filter_tests << build_filtering_test(measure, criteria[0, 2])
+    filter_tests << build_filtering_test(measure, criteria[2, 2])
+    filter_tests << build_filtering_test(measure, ['providers'], 'NPI, TIN & Provider Location')
+    filter_tests << build_filtering_test(measure, ['providers'], 'NPI & TIN', false)
+    filter_tests << if ApplicationController.helpers.measure_has_diagnosis_criteria?(measure)
+                      build_filtering_test(measure, ['problems'])
+                    else
+                      # the measure doesn't have a diagnosis so instead create a new demographics task
+                      build_filtering_test(measure, criteria.values_at(4, (0..3).to_a.sample))
+                    end
+    ApplicationController.helpers.generate_filter_records(filter_tests)
   end
 
   def build_filtering_test(measure, criteria, display_name = '', incl_addr = true)

--- a/app/views/application/_products_status_cells.html.erb
+++ b/app/views/application/_products_status_cells.html.erb
@@ -14,7 +14,7 @@
         <thead>
           <tr>
             <% cert_hash.each_key do |cert_key| %>
-              <th scope="col" class="text-center col-xs-6">
+              <th scope="col" class="text-center col-xs-6 text-nowrap">
                 <%= cert_key %>
               </th>
             <% end %>

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -289,7 +289,7 @@ class ProductsControllerTest < ActionController::TestCase
     vendor = Vendor.first
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
       post :create, :format => :json, :vendor_id => vendor.id, :product => { name: "Product JSON post #{rand}", c1_test: true,
-                                                                             measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
+                                                                             measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'],
                                                                              bundle_id: '4fdb62e01d41c820f6000001' }
       assert_response 201, 'response should be Created on product create'
       assert response.location.end_with?(product_path(vendor.products.order_by(created_at: 'desc').first)),
@@ -299,7 +299,7 @@ class ProductsControllerTest < ActionController::TestCase
 
   test 'should get destroy with json request' do
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
-      pd = Product.new(vendor: @vendor.id, name: "p_#{rand}", c1_test: true, measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
+      pd = Product.new(vendor: @vendor.id, name: "p_#{rand}", c1_test: true, measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'],
                        bundle_id: '4fdb62e01d41c820f6000001')
       pd.save!
       delete :destroy, :format => :json, :id => pd.id
@@ -307,6 +307,17 @@ class ProductsControllerTest < ActionController::TestCase
       assert_equal '', response.body
       get :show, :format => :json, :id => pd.id
       assert_response 404, 'response should be Not Found because product should be destroyed'
+    end
+  end
+
+  test 'should create manual checklist on product create when c1 is selected' do
+    for_each_logged_in_user([ADMIN, ATL, OWNER]) do
+      product_name = "my product name #{rand}"
+      post :create, :format => :json, :vendor_id => Vendor.first.id, :product => { name: product_name, c1_test: true,
+                                                                                   measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'],
+                                                                                   bundle_id: '4fdb62e01d41c820f6000001' }
+      product = Product.where(name: product_name).first
+      assert product.product_tests.checklist_tests.any?
     end
   end
 
@@ -336,7 +347,7 @@ class ProductsControllerTest < ActionController::TestCase
     vendor = Vendor.first
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
       post :create, :format => :xml, :vendor_id => vendor.id, :product => { name: "Product JSON post #{rand}", c1_test: true,
-                                                                            measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
+                                                                            measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'],
                                                                             bundle_id: '4fdb62e01d41c820f6000001' }
       assert_response 201, 'response should be Created on product create'
       assert response.location.end_with?(product_path(vendor.products.order_by(created_at: 'desc').first)),
@@ -346,7 +357,7 @@ class ProductsControllerTest < ActionController::TestCase
 
   test 'should get destroy with xml request' do
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
-      pd = Product.new(vendor: @vendor.id, name: "p_#{rand}", c1_test: true, measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
+      pd = Product.new(vendor: @vendor.id, name: "p_#{rand}", c1_test: true, measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'],
                        bundle_id: '4fdb62e01d41c820f6000001')
       pd.save!
       delete :destroy, :format => :xml, :id => pd.id

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -114,6 +114,7 @@ class ProducTest < ActiveSupport::TestCase
   def test_add_filtering_tests
     pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, c4_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
                      bundle_id: '4fdb62e01d41c820f6000001')
+    pt.save!
     pt.add_filtering_tests
     assert pt.product_tests.filtering_tests.count == 5
   end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -156,19 +156,43 @@ class ProducTest < ActiveSupport::TestCase
   #   S T A T U S   T E S T S   #
   # # # # # # # # # # # # # # # #
 
-  def test_product_status_incomplete_for_all_passing_product_tests_but_no_manual_checklist_test_exists
-    measure_id = '40280381-4BE2-53B3-014C-0F589C1A1C39'
-    product = Product.new(vendor: @vendor, name: 'my product', c1_test: true, measure_ids: [measure_id])
+  def test_product_status
+    product = Product.new(vendor: @vendor, name: 'my product', c1_test: true, measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'])
     product.save!
-    product_test = product.product_tests.build({ name: "my product test for measure id #{measure_id}", measure_ids: [measure_id] }, MeasureTest)
+    product_test = product.product_tests.build({ name: 'my product test 1', measure_ids: ['40280381-4BE2-53B3-014C-0F589C1A1C39'] }, MeasureTest)
     product_test.save!
-    test_execution = product_test.tasks.first.test_executions.build(:state => :passed)
-    test_execution.save!
+
+    # status should be incomplete if all product tests passing but no manual checklist test exists
+    product_test.tasks.first.test_executions.create!(:state => :passed)
     assert_equal 'incomplete', product.status
+
+    # if product does not need to certify for c1, than product should pass
+    product.c1_test = nil
+    product.c2_test = true
+    product.save!
+    assert_equal 'passing', product.status
+    product.c1_test = true
+    product.c2_test = nil
+    product.save!
 
     # adding a complete checklist test will make product pass
     create_complete_checklist_test_for_product(product, product.measure_ids.first)
     assert_equal 'passing', product.status
+
+    # one failing product test will fail the product
+    product_test = product.product_tests.build({ name: 'my product test 2', measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'] }, MeasureTest)
+    product_test.save!
+    product_test.tasks.first.test_executions.create!(:state => :failed)
+    assert_equal 'failing', product.status
+  end
+
+  def test_product_status_failing_if_one_product_test_are_fails
+    measure_id = '40280381-4BE2-53B3-014C-0F589C1A1C39'
+    product = Product.new(vendor: @vendor, name: 'my product', c1_test: true, measure_ids: [measure_id])
+    product_test = product.product_tests.build({ name: "my product test for measure id #{measure_id}", measure_ids: [measure_id] }, MeasureTest)
+    product_test.save!
+    test_execution = product_test.tasks.first.test_executions.build(:state => :passed)
+    product.save!
   end
 
   def create_complete_checklist_test_for_product(product, measure_id)
@@ -179,13 +203,6 @@ class ProducTest < ActiveSupport::TestCase
     checklist_test = product.product_tests.build({ name: 'my checklist test', checked_criteria: criterias,
                                                    measure_ids: [measure_id] }, ChecklistTest)
     checklist_test.save!
-  end
-
-  # come back and write tests for status
-
-  # statuses should be array of strings where strings can be 'passing', 'failing', or 'incomplete'
-  def create_product_tests_with_statuses(statuses)
-    # write function here
   end
 end
 

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -22,4 +22,37 @@ class ProductTestTest < ActiveJob::TestCase
     assert errors.key?(:name)
     assert errors.key?(:measure_ids)
   end
+
+  def test_status_passing
+    measure_id = '40280381-4BE2-53B3-014C-0F589C1A1C39'
+    vendor = Vendor.create!(name: 'my vendor')
+    product = vendor.products.build(name: 'my product', bundle_id: '4fdb62e01d41c820f6000001', c1_test: true, c2_test: true,
+                                    measure_ids: [measure_id])
+    product.save!
+    measure_test = product.product_tests.build({ name: "my measure test for measure id #{measure_id}", measure_ids: [measure_id] }, MeasureTest)
+    measure_test.save!
+    create_test_executions_with_state(measure_test, :passed)
+    assert_equal 'passing', measure_test.status
+
+    # measure test should be incomplete if at least one test execution is incomplete
+    te = measure_test.tasks[0].test_executions.build(:state => :incomplete)
+    te.save!
+    assert_equal 'incomplete', measure_test.status
+
+    # measure test should be failing if at least one test execution is failing
+    te = measure_test.tasks[1].test_executions.build(:state => :failed)
+    te.save!
+    assert_equal 'failing', measure_test.status
+  end
+
+  # # # # # # # # # # # # # # # # # # # #
+  #   H E L P E R   F U N C T I O N S   #
+  # # # # # # # # # # # # # # # # # # # #
+
+  def create_test_executions_with_state(product_test, state)
+    product_test.tasks.each do |task|
+      test_execution = task.test_executions.build(state: state)
+      test_execution.save!
+    end
+  end
 end


### PR DESCRIPTION
- API request for create product now also create c1 manual checklist (just like using web interface)
- status of product is `incomplete` instead of `passing` if product checked `c1_test` and no checklist test exists
- fixed visual issue with header text wrapping to new line in `product_status_cells.html.erb` partial
- added custom `status()` function to `checklist_test` class
- added unit tests for `status()` function in `checklist_test`, `product_test`, and `product` classes

below is the old product status cell
<img width="1133" alt="screen shot 2016-06-22 at 2 57 27 pm" src="https://cloud.githubusercontent.com/assets/14349011/16285667/7b687b58-38a5-11e6-9d5d-558a76f12370.png">



below is the new product status cell
<img width="1127" alt="screen shot 2016-06-22 at 6 01 35 pm" src="https://cloud.githubusercontent.com/assets/14349011/16285675/89757732-38a5-11e6-9e2e-8f1ee4aa819b.png">
