### PR TITLE
Some ui changes

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -1,6 +1,6 @@
 class RegistrationsController < Devise::RegistrationsController
-  add_breadcrumb 'New Account',  :new_user_registration_path,  only: [:new, :create]
-  add_breadcrumb 'Edit Account', :edit_user_registration_path, only: [:edit, :update]
+  add_breadcrumb 'New Account', :new_user_registration_path, only: [:new, :create]
+  add_breadcrumb 'Edit User', :edit_user_registration_path, only: [:edit, :update]
   add_breadcrumb 'Cancel Account', :cancel_user_registration_path, only: [:cancel]
 
   before_action :configure_permitted_parameters
@@ -11,7 +11,7 @@ class RegistrationsController < Devise::RegistrationsController
   end
 
   def edit
-    @title = 'Edit Account'
+    @title = 'Edit User'
     super
   end
 

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,7 +15,7 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h1 class='panel-title'>Edit <%= resource_name.to_s.humanize %></h1>
+    <h1 class='panel-title'>Edit Account</h1>
   </div>
   <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <div class="panel-body">
@@ -30,7 +30,7 @@
       <%= f.password_field :password_confirmation, label: 'Confirm New Password', autocomplete: "off", autocapitalize: 'off', autocorrect: 'off' %>
     </div>
     <div class="panel-footer">
-      <%= f.primary "Update" %>
+      <%= f.primary "Edit Account"%>
       <%= link_to "Back", :back, class: 'btn btn-default' %>
     </div>
   <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -15,7 +15,7 @@
 
 <div class="panel panel-default">
   <div class="panel-heading">
-    <h1 class='panel-title'>Edit Account</h1>
+    <h1 class='panel-title'>Edit <%= resource_name.to_s.humanize %></h1>
   </div>
   <%= bootstrap_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
     <div class="panel-body">
@@ -30,7 +30,7 @@
       <%= f.password_field :password_confirmation, label: 'Confirm New Password', autocomplete: "off", autocapitalize: 'off', autocorrect: 'off' %>
     </div>
     <div class="panel-footer">
-      <%= f.primary "Edit Account"%>
+      <%= f.primary "Edit " + resource_name.to_s.humanize %>
       <%= link_to "Back", :back, class: 'btn btn-default' %>
     </div>
   <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,5 +1,5 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Sign in", new_session_path(resource_name) %><br />
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'remove_modal' %>
 
-<%= render :partial => 'product_form', locals: { submit_text: "Update Product" } %>
+<%= render :partial => 'product_form', locals: { submit_text: "Edit Product" } %>
 
 <%= render partial: 'remove_panel', locals: { name: @product.name, type: 'product', message: 'Removing a product will also delete all associated product tests and test execution results. Be sure you want to do this.', delete_path: vendor_product_path(@product.vendor, @product) } %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -2,7 +2,7 @@
 
 <div class="row">
 
-  <div class = 'col-sm-8'>
+  <div class = 'col-sm-9'>
     <div class = 'panel panel-default'>
       <div class = 'panel-heading'><h1 class = 'panel-title'>Product Status</h1></div>
       <div class = 'panel-body'>
@@ -26,7 +26,7 @@
     </div>
   </div>
 
-  <div class = 'col-sm-4'>
+  <div class = 'col-sm-3'>
     <% unless @product.product_tests.empty? %>
       <div class = 'panel panel-default'>
         <div class = 'panel-heading'>

--- a/app/views/static_pages/terms_and_conditions.html.erb
+++ b/app/views/static_pages/terms_and_conditions.html.erb
@@ -12,5 +12,5 @@
           <p>NOT A CONTRIBUTION - The Measures, including specifications and coding, as used in the Cypress Tool, are not a contribution under the Apache license. Coding in the Measures is provided for convenience only and necessary licenses for use should be obtained from the copyright owners. Current Procedural Terminology (CPT®) © 2004-2010 American Medical Association. LOINC® © 2004 Regenstrief Institute, Inc. SNOMED Clinical Terms® (SNOMED CT®) © 2004-2010 International Health Terminology Standards Development Organization.</p>
         </div>
       </div>
-  <%= link_to "Back", :back %>
+  <%= link_to "Back", :back, class: 'btn btn-default' %>
 </body>

--- a/app/views/vendors/edit.html.erb
+++ b/app/views/vendors/edit.html.erb
@@ -3,7 +3,7 @@
 
   <%= render partial: 'remove_modal' %>
 
-  <%= render :partial => 'vendor_form', locals: {submit_text: 'Submit Changes'} %>
+  <%= render :partial => 'vendor_form', locals: {submit_text: 'Edit Vendor'} %>
 
   <%= render partial: 'remove_panel', locals: { name: @vendor.name, type: 'vendor', message: 'Removing a vendor will also delete all associated products, product tests, and test execution results. Be sure you want to do this.', delete_path: vendor_path(@vendor) } %>
 

--- a/app/views/vendors/new.html.erb
+++ b/app/views/vendors/new.html.erb
@@ -1,5 +1,5 @@
 <div class="vendors new_vendor_page">
 
-  <%= render :partial => 'vendor_form', locals: {submit_text: "Create Vendor"} %>
+  <%= render :partial => 'vendor_form', locals: {submit_text: "Add Vendor"} %>
 
 </div>

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -139,7 +139,7 @@ When(/^the user changes the name of the product$/) do
   page.click_button 'Edit Product'
   @product_other = FactoryGirl.build(:product)
   page.fill_in 'Name', with: @product_other.name
-  page.click_button 'Update Product'
+  page.click_button 'Edit Product'
 end
 
 When(/^the user removes the product$/) do

--- a/features/step_definitions/vendor.rb
+++ b/features/step_definitions/vendor.rb
@@ -44,7 +44,7 @@ end
 When(/^the user creates a vendor with a name of (.*)$/) do |name|
   steps %( When the user visits the create vendor page )
   page.fill_in 'Vendor Name', with: name
-  page.click_button 'Create Vendor'
+  page.click_button 'Add Vendor'
 end
 
 When(/^the user cancels creating a vendor$/) do
@@ -57,7 +57,7 @@ When(/^the user edits the vendor$/) do
   visit '/'
   page.click_button 'Edit Vendor'
   page.fill_in 'URL', with: 'www.example.com'
-  page.click_button 'Submit Changes'
+  page.click_button 'Edit Vendor'
 end
 
 When(/^the user removes the vendor$/) do


### PR DESCRIPTION
fixes overlapping columns in product show page
fixes differences between action buttons breadcrumbs and panels e.g. "create vendor" changed to "add vendor" to match action button and format of "add product" page.  
![screen shot 2016-06-23 at 10 28 44 am](https://cloud.githubusercontent.com/assets/19916148/16306888/4aa6999a-392d-11e6-863b-276b75e7279c.png)
