### PR TITLE
Handle no selected default bundle

### DIFF
--- a/app/controllers/admin/bundles_controller.rb
+++ b/app/controllers/admin/bundles_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class BundlesController < AdminController
+    include CypressYaml
     respond_to :html
 
     before_action :find_bundle, only: [:set_default, :destroy]

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,5 +1,6 @@
 module Admin
   class SettingsController < AdminController
+    include CypressYaml
     add_breadcrumb 'Admin', :admin_path
 
     def show

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -21,17 +21,4 @@ class AdminController < ApplicationController
   def require_admin
     raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.has_role? :admin
   end
-
-  def sub_yml_setting(key, val)
-    yml_text = File.read("#{Rails.root}/config/cypress.yml")
-    sub_string = /#{key}:(.*?)\n/
-    if val.is_a? String
-      yml_text.sub!(sub_string, "#{key}: \"#{val}\"\n")
-    elsif val.is_a? Symbol
-      yml_text.sub!(sub_string, "#{key}: :#{val}\n")
-    else
-      yml_text.sub!(sub_string, "#{key}: #{val}\n")
-    end
-    File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts yml_text }
-  end
 end

--- a/app/jobs/bundle_upload_job.rb
+++ b/app/jobs/bundle_upload_job.rb
@@ -1,5 +1,6 @@
 class BundleUploadJob < ActiveJob::Base
   include Job::Status
+  include CypressYaml
   DEFAULT_OPTIONS = { delete_existing: false, update_measures: false, exclude_results: false }.freeze
   after_enqueue do |job|
     tracker = job.tracker
@@ -23,6 +24,9 @@ class BundleUploadJob < ActiveJob::Base
     if already_have_default
       @bundle.active = false
       @bundle.save!
+    else
+      Settings[:default_bundle] = @bundle.version
+      sub_yml_setting('default_bundle', Settings[:default_bundle])
     end
   end
 end

--- a/lib/cypress_yaml.rb
+++ b/lib/cypress_yaml.rb
@@ -1,0 +1,14 @@
+module CypressYaml
+  def sub_yml_setting(key, val)
+    yml_text = File.read("#{Rails.root}/config/cypress.yml")
+    sub_string = /#{key}:(.*?)\n/
+    if val.is_a? String
+      yml_text.sub!(sub_string, "#{key}: \"#{val}\"\n")
+    elsif val.is_a? Symbol
+      yml_text.sub!(sub_string, "#{key}: :#{val}\n")
+    else
+      yml_text.sub!(sub_string, "#{key}: #{val}\n")
+    end
+    File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts yml_text }
+  end
+end

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -25,7 +25,11 @@ class Bundle
   def self.default
     find_by(active: true)
   rescue
-    nil
+    most_recent
+  end
+
+  def self.most_recent
+    where(version: pluck(:version).max).first
   end
 
   def self.first


### PR DESCRIPTION
When no default bundle is set, use the one with the highest version number.

The user can get into this state if they change the `default_bundle` version number in cypress.yml to a version that none of the bundles they have imported match, and then restart the app.

Before, having no default bundle selected would break the app on visiting the add product page and on the master patient list page.