### PR TITLE
Add button to clear measures on add product page

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -26,7 +26,6 @@ function ToggleCustomSelection(task) {
   }
 }
 
-
 function UpdateGroupSelections(event) {
   var measure_category = $(event.currentTarget).attr('data-category');
   var $groupChecks = $('.measure-group .measure-checkbox[data-category='+ measure_category +']');
@@ -72,7 +71,6 @@ function UpdateMeasureSet(bundle_id) {
       });
 }
 
-
 // these pieces need to run every time the bundle is changed
 // (they act on the measures which have been reloaded by ajax,
 //  not the controls which are fixed)
@@ -99,8 +97,6 @@ ready_run_on_refresh_bundle = function() {
   // Trigger change events for already-checked inputs
   $('.measure-group .measure-checkbox:checked').trigger('change');
   $('input[name="product[measure_selection]"]:checked').trigger('change');
-
-
 };
 
 // these pieces should run only once, at page load
@@ -134,7 +130,6 @@ ready_run_once = function() {
     }
   });
 
-
   // Enable changing measures
   $('#measures_options').find('button.confirm').on('click', function (event) {
     event.preventDefault();
@@ -143,6 +138,13 @@ ready_run_once = function() {
     $('input[name="product[measure_selection]"]').closest('.radio').removeClass('disabled');
     $(event.currentTarget).closest('alert').find('.close').click();
   });
+
+  $('.clear-measures-btn').on('click', function(event) {
+    $('.measure-group .measure-checkbox').prop('checked', false).change();
+    this.blur();
+    // $('clear-measures-btn').setAttribute("aria-pressed", false);
+  });
+
 
   // Changing the bundle
   $('.btn-checkbox input[name="product[bundle_id]"]').on('change', function() {

--- a/app/assets/stylesheets/cypress/_products.scss
+++ b/app/assets/stylesheets/cypress/_products.scss
@@ -5,3 +5,9 @@
 .pointer-on-hover:hover {
   cursor: pointer;
 }
+
+.measures-title-panel {
+  display: inline;
+  vertical-align: middle;
+  line-height: 28px;
+}

--- a/app/views/products/_measure_selection.html.erb
+++ b/app/views/products/_measure_selection.html.erb
@@ -1,6 +1,8 @@
 <div class="panel panel-primary select-measures hidden">
-  <div class="panel-heading">
-    <h1 id="select_custom_measures" class='panel-title'>Select Custom Measures <span class='selected-number'>(0)</span><span class='sr-only'>selected</span></h1>
+  <div class="panel-heading clearfix">
+    <h1 id="select_custom_measures" class='panel-title measures-title-panel'>Select Custom Measures <span class='selected-number'>(0)</span><span class='sr-only'>selected</span>
+      <button type="button" class="btn btn-default btn-sm pull-right clear-measures-btn">Clear all</button>
+    </h1>
   </div>
   <div class="panel-body">
     <div class="col-md-12" id="measures_errors_container"><!--%= f.errors_on :measure_tests, hide_attribute_name: true % --></div>


### PR DESCRIPTION
If you (accidentally) clicked one of the measure options like All eCQMs or EH or EP, but then decide you want custom, the only way to clear all the measures was uncheck them all or refresh the page. So this adds a button to uncheck all measures.

![screen shot 2016-06-28 at 1 49 03 pm](https://cloud.githubusercontent.com/assets/8235974/16427742/b49cf5fc-3d3c-11e6-97a6-f4c574be99f5.png)
