### PR TITLE
adds footer with link to cypress website and to user guide

### DIFF
--- a/app/assets/stylesheets/cypress/_footer.scss
+++ b/app/assets/stylesheets/cypress/_footer.scss
@@ -1,0 +1,21 @@
+html {
+  position: relative;
+  min-height: 100%;
+}
+
+main {
+  margin-bottom: 5em;
+}
+
+.footer {
+  position: absolute;
+  bottom: 0;
+  width: 100%;
+  height: 5em;
+  border: 1px solid $navbar-default-border;
+
+  .container {
+    padding: 1em;
+  }
+  
+}

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer role="contentinfo" class="footer">
+  <div class="container">
+    Learn more about <a href="http://projectcypress.org">Project Cypress</a>, an open source project sponsored by CMS and ONC.<br> Need help? <a href="http://projectcypress.org/documents/cypress_user_guide_prs_12_5071.pdf">Cypress User Guide</a>.
+  </div>
+</footer>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,6 +48,8 @@
     </div>
   </main>
 
+<%= render "footer" %>
+
 </body>
 
 </html>


### PR DESCRIPTION
I couldn't find a link to the 3.0 user guide on the internet, currently links to 2.4 user guide, the guide on the Cypress website currently.
![screen shot 2016-06-29 at 9 41 21 am](https://cloud.githubusercontent.com/assets/19916148/16454184/a9880e3a-3ddd-11e6-9a59-12eb1dc3493c.png)
