### PR TITLE
Provider for Measure Test Records

### DIFF
--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -3,6 +3,7 @@ class ProductTestSetupJob < ActiveJob::Base
   include Job::Status
   def perform(product_test)
     product_test.building
+    product_test.generate_provider if product_test.is_a? MeasureTest
     product_test.generate_records if product_test.records.count == 0
     product_test.pick_filter_criteria if product_test.is_a? FilteringTest
     if product_test.respond_to? :patient_cache_filter

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -1,4 +1,6 @@
 class MeasureTest < ProductTest
+  belongs_to :provider, index: true
+
   validate :at_most_one_measure?
 
   def at_most_one_measure?
@@ -23,6 +25,11 @@ class MeasureTest < ProductTest
       C2Task.new(product_test: self).save!
       C3Cat3Task.new(product_test: self).save! if product.c3_test
     end
+  end
+
+  def generate_provider
+    self.provider = Provider.generate_provider(measure_type: measures.first.type)
+    save!
   end
 
   def archive_records
@@ -84,9 +91,5 @@ class MeasureTest < ProductTest
     else
       'unstarted'
     end
-  end
-
-  def provider
-    Provider.find(records.first.provider_performances.first.provider_id)
   end
 end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -85,4 +85,8 @@ class MeasureTest < ProductTest
       'unstarted'
     end
   end
+
+  def provider
+    Provider.find(records.first.provider_performances.first.provider_id)
+  end
 end

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -10,6 +10,15 @@
   <strong>HQMF ID: </strong><span><%= @task.product_test.measure_ids.join(',') %></span><br/>
   <strong>CMS ID: </strong><span><%= @task.product_test.cms_id %></span><br/>
 
+  <% # display provider information if the product test is a measure test %>
+  <% if task.product_test.class == MeasureTest %>
+    <br/>
+    <% provider = task.product_test.provider %>
+    <% { 'Name' => "#{provider.family_name}, #{provider.given_name}", 'NPI' => provider.npi, 'TIN' => provider.tin }.each do |label, value| %>
+      <strong><%= "Provider #{label}: " %></strong><span><%= value %></span><br/>
+    <% end %>
+  <% end %>
+
   <br/>
   <% unless @task._type == 'C1ManualTask' %>
   <%= link_to 'View Patients', { controller: 'records', task_id: @task.id}, method: :get %>

--- a/features/filtering_tests/show.feature
+++ b/features/filtering_tests/show.feature
@@ -9,11 +9,13 @@ Background:
 Scenario: Successful View CAT 1 Filtering Test
   When the user views the CAT 1 test for the first filter task
   Then the user should see the CAT 1 test
+  Then the user should not see provider information
 
 Scenario: Successful View CAT 3 Filtering Test After Viewing CAT 1
   When the user views the CAT 1 test for the first filter task
   And the user views the CAT 3 test from the CAT 1 page
   Then the user should see the CAT 3 test
+  Then the user should not see provider information
 
 Scenario: Successful Download CAT 1 Zip File From Filter Task
   When the user views the CAT 1 test for the first filter task

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -9,6 +9,7 @@ Scenario: Successfully View a Measure Test
   When the user creates a product with tasks c1
   And the user views task c1
   Then the user should see the upload functionality for that product test
+  Then the user should see provider information
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
@@ -16,6 +17,7 @@ Scenario: View Only C1 Execution Page
   When the user creates a product with tasks c1
   And the user views task c1
   Then the user should only see the c1 execution page
+  Then the user should see provider information
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
@@ -23,6 +25,7 @@ Scenario: View Only C2 Execution Page
   When the user creates a product with tasks c2
   And the user views task c2
   Then the user should only see the c2 execution page
+  Then the user should see provider information
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -64,6 +64,12 @@ Then(/^the user should see the CAT 3 test$/) do
   assert page.has_content?('a QRDA Category III XML document')
 end
 
+Then(/^the user should not see provider information$/) do
+  page.assert_no_text 'Provider Name'
+  page.assert_no_text 'Provider NPI'
+  page.assert_no_text 'Provider TIN'
+end
+
 # 'Then the user should be able to download a CAT 1 zip file' included in step_definitions/measure_test.rb
 
 # 'Then the user should see test results' included in step_definitions/measure_test.rb

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -24,6 +24,8 @@ When(/^the user creates a product with tasks (.*)$/) do |tasks|
 
   # create record and assign provider for product test
   provider = Provider.find('53b2c4414d4d32139c730000')
+  @product_test.provider = provider
+  @product_test.save!
   provider_performance = ProviderPerformance.new(provider: provider, provider_id: provider.id)
   Record.create!(test_id: @product_test.id, provider_performances: [provider_performance])
 end

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -21,6 +21,11 @@ When(/^the user creates a product with tasks (.*)$/) do |tasks|
   @product.product_tests.build({ name: @measure.name, measure_ids: [@measure.hqmf_id] }, MeasureTest)
   @product_test = @product.product_tests.first
   @product.save!
+
+  # create record and assign provider for product test
+  provider = Provider.find('53b2c4414d4d32139c730000')
+  provider_performance = ProviderPerformance.new(provider: provider, provider_id: provider.id)
+  Record.create!(test_id: @product_test.id, provider_performances: [provider_performance])
 end
 
 #   A N D   #
@@ -77,6 +82,12 @@ end
 Then(/^the user should see the upload functionality for that product test$/) do
   page.assert_text @measure.name
   page.assert_text 'Download Test Deck'
+end
+
+Then(/^the user should see provider information$/) do
+  page.assert_text 'Provider Name'
+  page.assert_text 'Provider NPI'
+  page.assert_text 'Provider TIN'
 end
 
 Then(/^the user should only see the c1 execution page$/) do

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -12,6 +12,8 @@ require 'capybara/accessible'
 
 require 'axe/cucumber/step_definitions'
 
+include HealthDataStandards::CQM
+
 Mongoid.logger.level = Logger::INFO
 Mongo::Logger.logger.level = Logger::INFO
 
@@ -153,5 +155,5 @@ Before do
   Mongoid.default_client['products'].drop
   Mongoid.default_client['product_tests'].drop
 
-  collection_fixtures('patient_cache', 'records', 'bundles', 'measures')
+  collection_fixtures('patient_cache', 'records', 'bundles', 'measures', 'providers')
 end

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -33,11 +33,9 @@ module Cypress
 
       # get single provider if @test is a measure test. measure tests have a single provider for each record while filtering tests can have different
       # providers for each record
-      provider = @test.class == MeasureTest ? Provider.generate_provider(measure_type: @test.measures.first.type) : nil
+      provider = @test.provider if @test.class == MeasureTest
 
-      patients.each do |patient|
-        clone_and_save_record(patient, provider)
-      end
+      patients.each { |patient| clone_and_save_record(patient, provider) }
     end
 
     def find_patients_to_clone
@@ -49,7 +47,6 @@ module Cypress
                  else
                    @test.bundle.records.where(test_id: nil).to_a
                  end
-      patients
     end
 
     def randomize_ids(patients)

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -31,8 +31,12 @@ module Cypress
       # grab a random number of records and then randomize the dates between +- 10 days
       randomize_ids patients if options['randomization_ids']
 
+      # get single provider if @test is a measure test. measure tests have a single provider for each record while filtering tests can have different
+      # providers for each record
+      provider = @test.class == MeasureTest ? Provider.generate_provider(measure_type: @test.measures.first.type) : nil
+
       patients.each do |patient|
-        clone_and_save_record(patient)
+        clone_and_save_record(patient, provider)
       end
     end
 
@@ -62,16 +66,17 @@ module Cypress
       end
     end
 
-    def clone_and_save_record(record, date_shift = nil)
+    # if provider argument is nil, this function will assign a new provider based on the @option['providers'] and @option['generate_provider'] options
+    def clone_and_save_record(record, provider = nil)
       cloned_patient = record.clone
       cloned_patient[:original_medical_record_number] = cloned_patient.medical_record_number
       cloned_patient.medical_record_number = next_medical_record_number unless options['disable_randomization']
       DemographicsRandomizer.randomize(cloned_patient) if options['randomize_demographics']
-      cloned_patient.shift_dates(date_shift) if date_shift
       cloned_patient.test_id = options['test_id']
       patch_insurance_provider(record)
       randomize_entry_ids(cloned_patient) unless options['disable_randomization']
-      assign_provider(cloned_patient)
+      # assign existing provider if provider argument is not nil (should be when @test is a measure test)
+      provider ? assign_existing_provider(cloned_patient, provider) : assign_provider(cloned_patient)
       cloned_patient.save!
     end
 
@@ -127,8 +132,12 @@ module Cypress
     end
 
     def generate_provider
-      measure = @test.measures.first
-      @generated_providers << Provider.generate_provider(measure_type: measure.type)
+      @generated_providers << Provider.generate_provider(measure_type: @test.measures.first.type)
+    end
+
+    def assign_existing_provider(patient, provider)
+      patient.provider_performances.each(&:destroy)
+      patient.provider_performances.build(provider: provider)
     end
   end
 end

--- a/lib/ext/provider.rb
+++ b/lib/ext/provider.rb
@@ -1,4 +1,6 @@
 class Provider
+  has_many :measure_tests
+
   def self.default_provider(options = {})
     prov = where(default: true, specialty: default_specialty(options[:measure_type])).first
     if prov.nil?

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -47,6 +47,8 @@ class TestExecutionsControllerTest < ActionController::TestCase
 
     # add provider performance to each record associated with the measure test
     provider = Provider.find('53b2c4414d4d32139c730000')
+    test.provider = provider
+    test.save!
     test.records.each do |record|
       pp = record.provider_performances.build(provider: provider)
       pp.save!

--- a/test/jobs/product_test_setup_job_test.rb
+++ b/test/jobs/product_test_setup_job_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class ProductTestSetupJobTest < ActiveJob::TestCase
+  def setup
+    collection_fixtures('bundles', 'measures')
+    vendor = Vendor.new(name: "my vendor #{rand}")
+    vendor.save!
+    @product = vendor.products.build(name: "my product #{rand}", measure_ids: ['8A4D92B2-397A-48D2-0139-C648B33D5582'],
+                                     bundle_id: '4fdb62e01d41c820f6000001')
+  end
+
+  def test_perform_with_measure_test_creates_provider
+    test = @product.product_tests.build({ name: "my measure test #{rand}", measure_ids: @product.measure_ids }, MeasureTest)
+    test.save!
+    ProductTestSetupJob.perform_now(test)
+    test.reload
+
+    assert_not_equal nil, test.provider
+  end
+end

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -136,4 +136,12 @@ class MeasureTestTest < ActiveJob::TestCase
     assert pt.tasks.c3_cat1_task, 'product test should have a c3_cat1_task'
     assert pt.tasks.c3_cat3_task, 'product test should have a c3_cat3_task'
   end
+
+  def test_generate_provider
+    test = @product.product_tests.build({ name: "my measure test #{rand}", measure_ids: @product.measure_ids }, MeasureTest)
+    test.generate_provider
+
+    test.reload
+    assert_not_equal nil, test.provider
+  end
 end

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -2,8 +2,10 @@ require 'test_helper'
 require 'fileutils'
 
 class PopulationCloneJobTest < ActiveSupport::TestCase
+  include HealthDataStandards::CQM
+
   def setup
-    collection_fixtures('records', 'products', 'product_tests', 'bundles', 'measures')
+    collection_fixtures('records', 'products', 'product_tests', 'bundles', 'measures', 'patient_cache', 'providers')
   end
 
   def test_perform_full_deck
@@ -42,6 +44,7 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
   end
 
   def test_assigns_generated_provider
+    Provider.all.each(&:destroy)
     # 0 providers to start
     assert_equal 0, Provider.count
     # ids passed in should clone just the 2 records
@@ -183,6 +186,49 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
     assert found_random == true, 'Did not find any evidence that payer was randomized.  Since there are only three ' \
       'possible payers there is some mathematical chance that this might happen, but it is slim (1/10,000)!'
   end
-end
 
-# rubocop:enable Metrics/ClassLength
+  def test_clone_and_save_record_with_provider
+    test = ProductTest.find('4f5a606b1d41c851eb000484')
+    record = test.bundle.records.where(test_id: nil).sample
+    provider = Provider.generate_provider(measure_type: test.measures.first.type)
+
+    pcj = Cypress::PopulationCloneJob.new({ 'test_id' => test.id }.stringify_keys!)
+    pcj.clone_and_save_record(record, provider)
+    cloned_record = Record.find_by(test_id: test.id)
+
+    cloned_record.provider_performances.each do |provider_performance|
+      assert_equal provider.id, provider_performance.provider_id
+    end
+  end
+
+  def test_perform_on_measure_test_creates_patients_with_same_provider
+    # change product test to measure test
+    test = ProductTest.find('4f5a606b1d41c851eb000484')
+    test._type = 'MeasureTest'
+    test.save!
+
+    # make one record (pre-cloned record) have a provider performance. PopulationCloneJob should take care of this
+    Record.where(test_id: nil).sample.provider_performances << ProviderPerformance.new(provider: Provider.find(BSON::ObjectId('53b2c4414d4d32139c730000')))
+
+    # create cloned record for measure test
+    records = clone_records(test)
+
+    assert_equal 8, records.count
+    assert records.all { |record| record.provider_performances.any? }
+
+    # assert provider for each record on the measure test are the same
+    first_provider = records.first.provider_performances.first.provider
+    records.each do |record|
+      assert_equal first_provider, record.provider_performances.first.provider
+    end
+  end
+
+  def clone_records(product_test, options = {})
+    options['test_id'] = product_test.id unless options['test_id']
+    options['subset_id'] = 'all'
+    options['randomize_demographics'] = true
+    pcj = Cypress::PopulationCloneJob.new(options.stringify_keys!)
+    pcj.perform
+    Record.where(test_id: product_test.id)
+  end
+end


### PR DESCRIPTION
- added same provider for all records within a single measure test
- displayed provider information on test execution show page (only for measure tests)
- added integration and unit tests for this

<img width="1012" alt="screen shot 2016-07-01 at 9 03 20 am" src="https://cloud.githubusercontent.com/assets/14349011/16623510/4c52871a-436c-11e6-9456-866bd11deaae.png">
