### PR TITLE
Add links to remove failed bundle job trackers

### DIFF
--- a/app/controllers/admin/trackers_controller.rb
+++ b/app/controllers/admin/trackers_controller.rb
@@ -1,0 +1,16 @@
+module Admin
+  class TrackersController < AdminController
+    before_action :find_tracker
+
+    def destroy
+      @tracker.destroy if @tracker.status == :failed
+      redirect_to admin_path(anchor: 'bundles')
+    end
+
+    private
+
+    def find_tracker
+      @tracker = Tracker.find(params['id'])
+    end
+  end
+end

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -57,11 +57,14 @@
     </tr>
   </thead>
   <tbody>
-    <% BundleUploadJob.trackers.each do |tracker| %>
+    <% BundleUploadJob.trackers.reverse_each do |tracker| %>
     <tr>
       <td><%= tracker.options["original_filename"]%></td>
       <td><%= tracker.status%></td>
       <td><%= tracker.log_message.last%></td>
+      <td>
+        <%= link_to "", admin_tracker_path(tracker), :method => :delete, :class => "close fa fa-fw fa-close" if tracker.status == :failed %>
+      </td>
     </tr>
     <% end %>
   </tbody>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,7 @@ Rails.application.routes.draw do
         post :set_default
       end
     end
+    resources :trackers, only: [:destroy]
   end
 
   get 'terms_and_conditions' => 'static_pages#terms_and_conditions'


### PR DESCRIPTION
**Summary:**
- Add links to remove failed bundle job trackers (create a trackers controller to handle this)
- Reverse order of job trackers in the view so most recent is first now

**View:**

![screen shot 2016-07-01 at 1 34 59 pm](https://cloud.githubusercontent.com/assets/8235974/16529400/ac723bb6-3f90-11e6-8e19-c3910db5d3c2.png)
