### PR TITLE
Allow devise to use application wide secret token

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,11 +4,6 @@ Devise.setup do |config|
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in DeviseMailer.
   config.mailer_sender = 'registration@projectcypress.org'
-  config.secret_key = if Rails.env.development? || Rails.env.test?
-                        ('x' * 30) # meets minimum requirement of 30 chars long
-                      else
-                        ENV['DEVISE_SECRET_KEY']
-                      end
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"


### PR DESCRIPTION
This makes deployment to production a lot easier as we do not have to worry about both the devise secret key and the application secret key.