### PR TITLE
Reduce AJAX Calls on Product Page

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -16,9 +16,9 @@ ready = function() {
   });
 
   /* submit upload when file is attached */
-  $('.multi-upload-field').on('change', function(ev) {
-    $(this).parent().siblings('.multi-upload-submit').click();
-  });
+  // $('.multi-upload-field').on('change', function(ev) {
+  //   $(this).parent().siblings('.multi-upload-submit').click();
+  // });
 };
 
 var reticulateSplines = function() {

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -106,4 +106,16 @@ module ProductsHelper
     end
     [task]
   end
+
+  # only yeilds tasks whose product test links need to be reloaded
+  def tasks_needing_reload(product)
+    tasks = []
+    product.product_tests.each do |test|
+      test.tasks.each do |task|
+        next unless %w(C1Task C2Task Cat1FilterTask Cat3FilterTask).include? task.class.to_s
+        tasks << task if should_reload_product_test_link?(with_c3_task(task))
+      end
+    end
+    tasks
+  end
 end

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -107,7 +107,7 @@ module ProductsHelper
     [task]
   end
 
-  # only yeilds tasks whose product test links need to be reloaded
+  # only yields tasks whose product test links need to be reloaded
   def tasks_needing_reload(product)
     tasks = []
     product.product_tests.each do |test|

--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -18,7 +18,4 @@
 <% else %>
   <p>Patient records are being built for each measure.</p>
   <p><i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i><%= " #{num_measure_tests_ready} of #{num_measure_tests} measures ready" %></p>
-  <script>
-    $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'bulk_download' }});
-  </script>
 <% end %>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -44,3 +44,9 @@
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% end %>
 <% end %>
+
+<script>
+  $('.multi-upload-field').on('change', function(ev) {
+    $(this).parent().siblings('.multi-upload-submit').click();
+  });
+</script>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -44,9 +44,3 @@
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% end %>
 <% end %>
-
-<% if should_reload_product_test_link?(tasks) %>
-  <script>
-    $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: '/products/product_test_link', task_id: "<%= task.id.to_s %>" }});
-  </script>
-<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -87,6 +87,10 @@
 <% if tasks.any? %>
   <% task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
   <script>
-    $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= task_ids %>" }});
+    var task_ids_needing_reload = [];
+    <% tasks.each do |task| %>
+      task_ids_needing_reload.push("<%= task.id %>")
+    <% end %>
+    $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script' });
   </script>
 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -82,3 +82,11 @@
     <% end %>
   <% end %>
 </div>
+
+<% tasks = tasks_needing_reload(@product) %>
+<% if tasks.any? %>
+  <% task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
+  <script>
+    $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= task_ids %>" }});
+  </script>
+<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -85,11 +85,11 @@
 
 <% tasks = tasks_needing_reload(@product) %>
 <% if tasks.any? %>
-  <% task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
+  <%# task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
   <script>
-    var task_ids_needing_reload = [];
+    var task_ids_remaining = [];
     <% tasks.each do |task| %>
-      task_ids_needing_reload.push("<%= task.id %>")
+      task_ids_remaining.push("<%= task.id.to_s %>")
     <% end %>
     $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script' });
   </script>

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -1,39 +1,48 @@
 <%# if params[:task_ids] %>
-  <% #tasks_going_to_need_reloading = Task.where(:_id.in => params[:task_ids].split(",")) %>
-  <% # itereate through any tasks that are still not ready %>
+  <%#tasks_going_to_need_reloading = Task.where(:_id.in => params[:task_ids].split(",")) %>
+  <%# itereate through any tasks that are still not ready %>
 
+  <% # see if any tasks need to be reloaded. this will happen on next AJAX call (500 ms in the future) when the product test state or %>
+  <% #   test execution state could have possibly changed %>
+  <% tasks = tasks_needing_reload(@product) %>
+
+  <% # render all product test links that were not finished 500 ms ago (any task in task_ids_needing_reload javascript variable) %>
   <% @product.product_tests.measure_tests.each do |test| %>
     <% test.tasks.each do |task| # fix to use only non-c3 tasks %>
-      if (task_ids_needing_reload.includes("<%= task.id.to_s %>")) {
+      if (task_ids_remaining.includes("<%= task.id.to_s %>")) {
         $("#<%= id_for_html_wrapper_of_task(task) %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
       }
     <% end %>
   <% end %>
+
+  // console.log(string(task_ids_remaining))
+  // debugger
 
   // Object.keys(tasks_needing_reload).forEach(function (key) { 
   //   var value = tasks_needing_reload[key]
   //   $(key).html(value)
   // });
 
-  console.log("number of keys needing reload is " + Object.keys(tasks_needing_reload).length)
+  // console.log("number of keys needing reload is " + Object.keys(tasks_needing_reload).length)
 
-  if (Object.keys(tasks_needing_reload).length != 0) {
-    $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
-  }
+  // if (Object.keys(tasks_needing_reload).length != 0) {
+  //   $('#display_bulk_download').html("<%#= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+  // }
   <%# tasks_going_to_need_reloading.each do |task| %>
     // $("#<%#= id_for_html_wrapper_of_task(task) %>").html("<%#= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
   <%# end %>
 
   <%# if tasks_going_to_need_reloading.any? %>
-    <% # reload the bulk download partial %>
+    <%# reload the bulk download partial %>
     // $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
   <%# end %>
 
-  <% tasks = tasks_needing_reload(@product) %>
+  <% # add all tasks that need to be reloaded to the "task_ids_remaining" javascript variable. if there are any of these tasks, wait 500 ms %>
+  <% #   then call this show.js.erb file again %>
   <% if tasks.any? %>
-    var task_ids_needing_reload = [];
+    task_ids_remaining = []
     <% tasks.each do |task| %>
-      task_ids_needing_reload.push("<%= task.id %>")
+      task_ids_remaining.push("<%= task.id.to_s %>")
     <% end %>
     setTimeout(function() {
       $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script' });
@@ -44,5 +53,13 @@
     // setTimeout(function() {
     //   $.ajax({url: "<%#= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%#= task_ids %>" }});
     // }, 2000);
+  <% end %>
+
+  <% if params[:task_id] %>
+    $("#<%= id_for_html_wrapper_of_task(task) %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
+    if ()
+    setTimeout(function() {
+      $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= params[:task_id] %>" }});
+    }, 500);
   <% end %>
 <%# end %>

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -1,19 +1,18 @@
-
-<% if params[:partial] == 'bulk_download' %>
-  <% if @product.product_tests.measure_tests.where(:state.nin => [:ready]).count > 0 %>
-    <% # wait 2 seconds. then reload the page %>
-    setTimeout(function(){
-      $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
-    }, 2000);
-  <% else %>
-    <% # don't wait. just load the bulk download %>
-    $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+<% if params[:task_ids] %>
+  <% tasks_going_to_need_reloading = Task.where(:_id.in => params[:task_ids].split(",")) %>
+  <% # itereate through any tasks that are still not ready %>
+  <% tasks_going_to_need_reloading.each do |task| %>
+    $("#<%= id_for_html_wrapper_of_task(task) %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
   <% end %>
 
-<% elsif params[:partial] == '/products/product_test_link' %>
-  <% task = Task.find(params[:task_id]) %>
-  <% wrapper_id = id_for_html_wrapper_of_task(task) %>
-  setTimeout(function() {
-    $("#<%= wrapper_id %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
-  }, 500);
+  <% tasks = tasks_needing_reload(@product) %>
+  <% if tasks.any? %>
+    <% task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
+    setTimeout(function() {
+      $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= task_ids %>" }});
+    }, 500);
+  <% else %>
+    <% # reload the bulk download partial %>
+    $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+  <% end %>
 <% end %>

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -1,18 +1,48 @@
-<% if params[:task_ids] %>
-  <% tasks_going_to_need_reloading = Task.where(:_id.in => params[:task_ids].split(",")) %>
+<%# if params[:task_ids] %>
+  <% #tasks_going_to_need_reloading = Task.where(:_id.in => params[:task_ids].split(",")) %>
   <% # itereate through any tasks that are still not ready %>
-  <% tasks_going_to_need_reloading.each do |task| %>
-    $("#<%= id_for_html_wrapper_of_task(task) %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
+
+  <% @product.product_tests.measure_tests.each do |test| %>
+    <% test.tasks.each do |task| # fix to use only non-c3 tasks %>
+      if (task_ids_needing_reload.includes("<%= task.id.to_s %>")) {
+        $("#<%= id_for_html_wrapper_of_task(task) %>").html("<%= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
+      }
+    <% end %>
   <% end %>
+
+  // Object.keys(tasks_needing_reload).forEach(function (key) { 
+  //   var value = tasks_needing_reload[key]
+  //   $(key).html(value)
+  // });
+
+  console.log("number of keys needing reload is " + Object.keys(tasks_needing_reload).length)
+
+  if (Object.keys(tasks_needing_reload).length != 0) {
+    $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+  }
+  <%# tasks_going_to_need_reloading.each do |task| %>
+    // $("#<%#= id_for_html_wrapper_of_task(task) %>").html("<%#= escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>");
+  <%# end %>
+
+  <%# if tasks_going_to_need_reloading.any? %>
+    <% # reload the bulk download partial %>
+    // $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+  <%# end %>
 
   <% tasks = tasks_needing_reload(@product) %>
   <% if tasks.any? %>
-    <% task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
+    var task_ids_needing_reload = [];
+    <% tasks.each do |task| %>
+      task_ids_needing_reload.push("<%= task.id %>")
+    <% end %>
     setTimeout(function() {
-      $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= task_ids %>" }});
+      $.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script' });
     }, 500);
-  <% else %>
-    <% # reload the bulk download partial %>
-    $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
+    <%# key = id_for_html_wrapper_of_task(task) %>
+    <%# val = escape_javascript render partial: '/products/product_test_link', locals: { test: task.product_test, task: task } %>
+    <%# task_ids = tasks.collect { |task| task.id.to_s }.join(',') %>
+    // setTimeout(function() {
+    //   $.ajax({url: "<%#= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%#= task_ids %>" }});
+    // }, 2000);
   <% end %>
-<% end %>
+<%# end %>

--- a/app/views/test_executions/create.js.erb
+++ b/app/views/test_executions/create.js.erb
@@ -6,4 +6,4 @@
 <% # set PATH_INFO so AJAX call can be made in /products/measure_tests_table partial. this AJAX call is for reloading each product_test_link %>
 <% request.env['PATH_INFO'] = vendor_product_path(@product.vendor, @product) %>
 
-$.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: '/products/product_test_link', task_id: "<%= params[:task_id] %>" }});
+$.ajax({url: "<%= vendor_product_path(@product.vendor, @product) %>", type: "GET", dataType: 'script', data: { task_ids: "<%= params[:task_id] %>" }});

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -31,6 +31,29 @@ Scenario: AJAX Reload Product Test Links with Statuses
   When a task for the product test has failed
   Then the user should see a product test that has failed
 
+Scenario: Can See Progress for Bulk Download
+  When two product tests are created for product
+  And all measure tests for product have state of building
+  And the user visits the product page
+  Then the user should see 0 of 3 measure tests ready in bulk download
+  When a building measure test becomes ready
+  Then the user should see 1 of 3 measure tests ready in bulk download
+  When a building measure test becomes ready
+  Then the user should see 2 of 3 measure tests ready in bulk download
+  When a building measure test becomes ready
+  Then the user should see the bulk download
+
+Scenario: Can See Ready Product Test Links
+  When two product tests are created for product
+  And all measure tests for product have state of building
+  And the user visits the product page
+  When a building measure test becomes ready
+  Then the user should see product test links for all ready measure tests
+  When a building measure test becomes ready
+  Then the user should see product test links for all ready measure tests
+  When a building measure test becomes ready
+  Then the user should see product test links for all ready measure tests
+
 Scenario: Can Download Report in ATL Mode
   When all product tests have a state of ready
   And the application is in ATL mode

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -18,6 +18,19 @@ Scenario: Cannot View Download All Patients
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
+Scenario: AJAX Reload Product Test Links with Statuses
+  When all product tests have a state of ready
+  And the product test is queued
+  And the user visits the product page
+  Then the user should see a queued product test
+  When the product test is building
+  Then the user should see a building product test
+  When a task for the product test is testing
+  When all product tests have a state of ready
+  Then the user should see a testing product test
+  When a task for the product test has failed
+  Then the user should see a product test that has failed
+
 Scenario: Can Download Report in ATL Mode
   When all product tests have a state of ready
   And the application is in ATL mode

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -170,6 +170,26 @@ When(/^the user views the product$/) do
   page.click_link @product.name
 end
 
+When(/^the product test is (.*)$/) do |state|
+  test = ProductTest.first # should only be one product test
+  test.state = state.to_sym
+  test.save!
+end
+
+When(/^a task for the product test is testing$/) do
+  test = ProductTest.first
+  test.tasks.first.test_executions.create!(:state => :pending)
+end
+
+When(/^a task for the product test has failed$/) do
+  test = ProductTest.first
+  task = test.tasks.first
+  test.tasks.first.test_executions.create!(:state => :failed) unless task.most_recent_execution
+  execution = task.most_recent_execution
+  execution.state = :failed
+  execution.save!
+end
+
 When(/^all product tests have a state of ready$/) do
   ProductTest.all.each do |pt|
     pt.state = :ready
@@ -379,6 +399,14 @@ end
 
 Then(/^the user should not be able to download the report$/) do
   page.assert_no_text 'Download Report'
+end
+
+Then(/^the user should see a (.*) product test$/) do |product_test_link_status|
+  page.assert_text product_test_link_status
+end
+
+Then(/^the user should see a product test that has failed$/) do
+  page.assert_text 'retry'
 end
 
 Then(/^the user should see a cat I test testing for product test (.*)$/) do |product_test_number|


### PR DESCRIPTION
- reduced the number of ajax requests on product show page by making single ajax request every 500ms from show.js.erb
- show.js.erb now only reloads partials if a task's product is not ready or a task has a test execution that is pending
- added integration test for AJAX reloading the product test links