### PR TITLE
Download report zip

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -74,8 +74,12 @@ class ProductsController < ApplicationController
     end
   end
 
-  # always responds with a pdf file containing information on the certification status of the product
+  # always responds with a zip file containing information on the certification status of the product
+  # includes an html report plus all the test records and files
   def report
+    report_content = render_to_string layout: 'report'
+    file = Cypress::CreateDownloadZip.create_combined_report_zip(@product, report_content)
+    send_data file.read, type: 'application/zip', disposition: 'attachment', filename: "#{@product.name}_#{@product.id}_report.zip".tr(' ', '_')
   end
 
   # always responds with a zip file of (.qrda.zip files of (qrda category I documents))

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -52,6 +52,12 @@ class FilteringTest < ProductTest
     save!
   end
 
+  def name_slug
+    return options['filters'].keys.join('_') if display_name == ''
+
+    display_name.gsub(/[^0-9A-Za-z.\-]+/, '_').downcase
+  end
+
   # Final Rule defines 9 different criteria that can be filtered:
   #
   # (A) TIN .................... (F) Age

--- a/app/views/application/_header_product.html.erb
+++ b/app/views/application/_header_product.html.erb
@@ -4,8 +4,10 @@
       <%= button_to edit_vendor_product_path(@product.vendor, @product), :method => :get, :class => "btn btn-default" do %>
         <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Product
       <% end %>
-      <%= button_to report_vendor_product_path(@product.vendor, @product), :method => :get, :class => "btn btn-default" do %>
-        <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Report
+      <% if mode_atl? %>
+        <%= button_to report_vendor_product_path(@product.vendor, @product), :method => :get, :class => "btn btn-default" do %>
+          <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Report
+        <% end %>
       <% end %>
     </div>
     <h1 class="summary-title"><%= @product.name %> <% if @product.version? %>(Version: <%= @product.version %>)<% end %></h1>

--- a/app/views/layouts/report.html.erb
+++ b/app/views/layouts/report.html.erb
@@ -1,0 +1,25 @@
+<!DOCTYPE HTML>
+<!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
+<!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress3" lang="en-US" class="no-js not-ie"><!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= make_title %></title>
+  <meta name="description" content="" />
+  <meta name="keywords" content="" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <style type="text/css">
+    <%= Rails.application.assets.find_asset('application.css').to_s.html_safe %>
+  </style>
+</head>
+<body>
+  <main aria-label="main section" id="main-content" class="container" role="main" tabindex="-1">
+    <div class="col-sm-12">
+      <%= yield %>
+    </div>
+  </main>
+</body>
+
+</html>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -1,7 +1,7 @@
 <div class="product-report">
-<% add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor) %>
-<% add_breadcrumb 'Product: ' + @product.name, product_path(@product) %>
-<% add_breadcrumb 'Report' %>
+<%# add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor) %>
+<%# add_breadcrumb 'Product: ' + @product.name, product_path(@product) %>
+<%# add_breadcrumb 'Report' %>
 <section>
   <h1>Report Summary</h1>
   <dl class="dl-horizontal">
@@ -14,7 +14,7 @@
     <dt>Bundle</dt>
     <dd><%= "#{@bundle.title} v#{@bundle.version}" %></dd>
     <dt>Cypress Version</dt>
-    <dd>3.0</dd>
+    <dd><%= APP_CONFIG.version %></dd>
   </dl>
 
   <h2>Measure Tests</h2>

--- a/app/views/products/report/_status_icon.html.erb
+++ b/app/views/products/report/_status_icon.html.erb
@@ -4,8 +4,5 @@
 
 %>
 
-<% icon_image_class = passing ? 'fa-check' : 'fa-times' %>
-<% icon_color_class = passing ? 'text-success' : 'text-danger' %>
-
-<i aria-hidden="true" class = '<%= "fa fa-lg #{icon_image_class} #{icon_color_class}" %>'></i>
+<span aria-hidden="true" class='<%= passing ? 'text-success' : 'text-danger' %>'><%= passing ? '✓' : 'X' %></span>
 <span class="sr-only"><%= passing ? 'passing' : 'failing' %></span>

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -18,10 +18,17 @@ Scenario: Cannot View Download All Patients
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: Can Download Report
+Scenario: Can Download Report in ATL Mode
   When all product tests have a state of ready
+  And the application is in ATL mode
   And the user visits the product page
-  Then the user should be able to view the report
+  Then the user should be able to download the report
+
+Scenario: Cannot Download Report
+  When all product tests have a state of ready
+  And the application is not in ATL mode
+  And the user visits the product page
+  Then the user should not be able to download the report
 
 Scenario: Can Multi Upload Cat I
   When all product tests have a state of ready

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -229,6 +229,14 @@ And(/^the user adds cat I tasks to all product tests$/) do
   end
 end
 
+And(/^the application is in ATL mode$/) do
+  ApplicationController.helpers.mode_atl
+end
+
+And(/^the application is not in ATL mode$/) do
+  ApplicationController.helpers.mode_internal
+end
+
 And(/^the user uploads a cat III document to product test (.*)$/) do |product_test_number|
   html_id = td_div_id_for_cat3_task_for_product_test(product_test_number)
   attach_xml_to_multi_upload(html_id)
@@ -365,9 +373,12 @@ Then(/^the user should not be able to download all patients$/) do
   page.assert_text 'records are being built'
 end
 
-Then(/^the user should be able to view the report$/) do
-  page.click_button 'Download Report'
-  page.assert_text 'Report Summary'
+Then(/^the user should be able to download the report$/) do
+  page.assert_text 'Download Report'
+end
+
+Then(/^the user should not be able to download the report$/) do
+  page.assert_no_text 'Download Report'
 end
 
 Then(/^the user should see a cat I test testing for product test (.*)$/) do |product_test_number|

--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -22,5 +22,30 @@ module Cypress
       end
       file
     end
+
+    def self.create_combined_report_zip(product, report_content)
+      measure_tests = MeasureTest.where(product_id: product.id)
+      file = Tempfile.new("combined-report-#{Time.now.to_i}")
+      Zip::ZipOutputStream.open(file.path) do |z|
+        z.put_next_entry('product_report.html')
+        z << report_content
+
+        measure_tests.each do |m|
+          z.put_next_entry("#{m.cms_id}/#{m.cms_id}_#{m.id}_records.qrda.zip".tr(' ', '_'))
+          z << m.patient_archive.read
+
+          # most recent test executions
+
+          m.tasks.each do |t|
+            most_recent_execution = t.most_recent_execution
+            if most_recent_execution
+              z.put_next_entry("#{m.cms_id}/#{most_recent_execution.artifact.file.uploaded_filename}")
+              z << most_recent_execution.artifact.file.read
+            end
+          end
+        end
+      end
+      file
+    end
   end
 end


### PR DESCRIPTION
Replaces the Report page with a ZIP download, including: standalone HTML report, all product test records, and the most recent execution for each test

The Download Report button is now only available in ATL mode

sample standalone HTML report:

![sample_html_report](https://cloud.githubusercontent.com/assets/13512036/16596040/16437dca-42c0-11e6-8d5a-79e99714d5e8.JPG)
