### PR TITLE
Shouldn't specify path when the schematrons aren't there

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -20,7 +20,7 @@ version_config:
       schematron: "bundle_2_9_9"
       qrda_version: "r3"
   '~>2016.0.0':
-      schematron: "bundle_2016_0_0"
+      schematron: false
       qrda_version: "r3_1"
 
 enable_logging: false


### PR DESCRIPTION
Fixes bug that caused UI to hang on "In progress" for measure tests that use the 2016 bundle