### PR TITLE
Bundle messages

### DIFF
--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -41,6 +41,10 @@
 
 </div>
 
+<% if config_for_version(@product.bundle.version).schematron_banner%>
+  <%=render partial: 'alert', locals: {alert_type: 'danger', messages: [config_for_version(@product.bundle.version).schematron_banner]} %>
+<% end %>
+
 <div class="product-test-tabs">
   <ul>
     <% APP_CONFIG.tests.each do |c, certification_test| %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -41,7 +41,7 @@
 
 </div>
 
-<% if config_for_version(@product.bundle.version).schematron_banner%>
+<% if config_for_version(@product.bundle.version)["schematron_banner"]%>
   <%=render partial: 'alert', locals: {alert_type: 'danger', messages: [config_for_version(@product.bundle.version).schematron_banner]} %>
 <% end %>
 

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -45,7 +45,7 @@
   <% end %>
 </div>
 
-<% if config_for_version(@task.product_test.bundle.version).schematron_banner%>
+<% if config_for_version(@task.product_test.bundle.version)["schematron_banner"]%>
   <%=render partial: 'alert', locals: {alert_type: 'danger', messages: [config_for_version(@task.product_test.bundle.version).schematron_banner]} %>
 <% end %>
 

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -45,6 +45,10 @@
   <% end %>
 </div>
 
+<% if config_for_version(@task.product_test.bundle.version).schematron_banner%>
+  <%=render partial: 'alert', locals: {alert_type: 'danger', messages: [config_for_version(@task.product_test.bundle.version).schematron_banner]} %>
+<% end %>
+
 <% if @task.most_recent_execution %>
   <div class = 'panel panel-<%= execution_status_class(@test_execution) %>' id = 'results_panel'>
     <div class = 'panel-heading'>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -22,6 +22,7 @@ version_config:
   '~>2016.0.0':
       schematron: false
       qrda_version: "r3_1"
+      schematron_banner: "The EH schematrons haven't been finalized for this year yet and results here should be considered preliminary."
 
 enable_logging: false
 


### PR DESCRIPTION
Add messages to Product and Test Execution pages if there is a `schematron_banner` key in the config for that bundle version. 