### PR TITLE
add links to passing test execution

### DIFF
--- a/app/assets/stylesheets/_bootstrap-variables.scss
+++ b/app/assets/stylesheets/_bootstrap-variables.scss
@@ -506,7 +506,7 @@ $jumbotron-heading-font-size:    ceil(($font-size-base * 4.5)) !default;
 //## Define colors for form feedback states and, by default, alerts.
 
 $state-success-text:             darken($brand-success, 10%) !default;
-$state-success-bg:               lighten(desaturate($brand-success, 30%), 65%) !default;
+$state-success-bg:               lighten(desaturate($brand-success, 30%), 62%) !default;
 $state-success-border:           darken($state-success-bg, 5%) !default;
 
 $state-info-text:                darken($brand-info, 10%) !default;

--- a/app/assets/stylesheets/cypress/_panels.scss
+++ b/app/assets/stylesheets/cypress/_panels.scss
@@ -39,3 +39,7 @@
     display: block;
   }
 }
+
+.execution-information {
+  padding: 1em;
+}

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -16,7 +16,70 @@
 
 <% else %>
   <% if passing = execution.status_with_sibling == 'passing'%>
-    <p class="lead row bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> Passed</p>
+    <div class="row">
+      <div class="col-sm-7">
+        <p class="lead bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> Passed</p>
+        <div class="row">
+          <div class="col-sm-6">
+            <% if execution.task.product_test._type == 'MeasureTest' %>
+              <% cat1_task = execution.task.product_test.tasks.c1_task %>
+              <% cat3_task = execution.task.product_test.tasks.c2_task %>
+            <% else %>
+              <% cat1_task = execution.task.product_test.tasks.cat1_filter_task %>
+              <% cat3_task = execution.task.product_test.tasks.cat3_filter_task %>
+            <% end %>
+
+            <ul class="fa-ul">
+              <% if displaying_cat1?(execution.task) %>
+                <% if cat3_task && cat3_task.status != "passing" %>
+                  <li>
+                    <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                    <%= link_to "Try the associated QRDA Category III Measure Test", new_task_test_execution_path(cat3_task) %>
+                  </li>
+                <% end %>
+              <% else %>
+                <% if cat1_task && cat1_task.status != "passing" %>
+                  <li>
+                    <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                    <%= link_to "Try the associated QRDA Category I Measure Test", new_task_test_execution_path(cat1_task) %>
+                  </li>
+                <% end %>
+              <% end %>
+            </ul>
+          </div>
+          <div class="col-sm-6">
+            <ul class="fa-ul">
+              <% if execution.task.product_test.product.c1_test %>
+                <li>
+                  <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                  <%= link_to 'Try a different Measure Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#MeasureTest" %>
+                </li>
+                <li>
+                  <i class="fa-li fa fa-eye" aria-hidden="true"></i>
+                  <%= link_to 'Try a Manual Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
+                </li>
+              <% end %>
+
+              <% if execution.task.product_test.product.c4_test %>
+                <li>
+                  <i class="fa-li fa fa-filter" aria-hidden="true"></i>
+                  <%= link_to 'Try a Filtering Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#FilteringTest" %>
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      </div>
+      <div class="col-sm-5">
+        <div class="execution-information bg-info">
+          <ul class="list-unstyled">
+            <li><strong>Test Date:</strong> <%= local_time(execution.updated_at) %></li>
+            <li><strong>Files Uploaded:</strong> <%= execution.artifact['file'] %></li>
+            <li><strong>Total Test Executions:</strong> <%= execution.task.test_executions.count %></li>
+          </ul>
+        </div>
+      </div>
+    </div>
   <% else %>
     <p class="lead row bg-danger execution-status">
       <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i>


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/2136286/16812763/9200dbe6-48fc-11e6-890d-de741df2eced.png)

If you're on the C1/C3 page, you'll see a link to the C2/C3 page if it's available and if it's not already passing.
You'll also see links to other tests - these all just lead to the relevant tab in the Product page for now.