### PR TITLE
Removes .first from test suite where possible

### DIFF
--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -6,7 +6,7 @@
 #   A N D   #
 
 And(/^the user has selected a measure$/) do
-  @measure = Measure.all.first
+  @measure = Measure.first
 end
 
 # # # # # # # #
@@ -54,7 +54,7 @@ And(/^the product test state is set to ready$/) do
 end
 
 And(/^the product test state is not set to ready$/) do
-  pt = ProductTest.first
+  pt = ProductTest.find_by(name: 'Asthma Assessment')
   pt.state = :garbablargblarg
   pt.save!
 end

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -178,13 +178,13 @@ When(/^all product tests have a state of ready$/) do
 end
 
 When(/^all product tests do not have a state of ready$/) do
-  pt = ProductTest.first
+  pt = ProductTest.find_by(cms_id: 'CMS155v1')
   pt.state = :nah_man_im_like_lightyears_away_from_bein_ready
   pt.save!
 end
 
 When(/^the user visits the product page$/) do
-  product = Product.first
+  product = Product.find_by(name: 'Product 1')
   visit vendor_product_path(product.vendor, product)
 end
 
@@ -195,7 +195,7 @@ end
 When(/^the user adds a product test$/) do
   # measure to add
   measure_id = '40280381-43DB-D64C-0144-5571970A2685'
-  product = Product.first
+  product = Product.find_by(name: 'Product 1')
   product.measure_ids << measure_id
   product.save!
   product_test = product.product_tests.build({ name: "measure test for measure id #{measure_id}", measure_ids: [measure_id] }, MeasureTest)
@@ -205,7 +205,7 @@ When(/^the user adds a product test$/) do
 end
 
 And(/^filtering tests are added to product$/) do
-  product = Product.first
+  product = Product.find_by(name: 'Product 1')
   product.c4_test = true
   product.save!
   product.add_filtering_tests
@@ -220,7 +220,7 @@ And(/^the user uploads a cat I document to product test (.*)$/) do |product_test
 end
 
 And(/^the user adds cat I tasks to all product tests$/) do
-  product = Product.first
+  product = Product.find_by(name: 'Product 1')
   product.c1_test = true
   product.save!
   product.product_tests.measure_tests.each do |pt|
@@ -254,25 +254,29 @@ end
 
 # product test number the number of product test (1 indexed) for upload in order of most recently created
 def td_div_id_for_cat1_task_for_product_test(product_test_number)
-  product_test = Product.first.product_tests.measure_tests.sort { |x, y| x.created_at <=> y.created_at }[product_test_number.to_i - 1]
+  product = Product.find_by(name: 'Product 1')
+  product_test = product.product_tests.measure_tests.sort { |x, y| x.created_at <=> y.created_at }[product_test_number.to_i - 1]
   task = product_test.tasks.c1_task
   "#wrapper-task-id-#{task.id.to_s}"
 end
 
 def td_div_id_for_cat3_task_for_product_test(product_test_number)
-  product_test = Product.first.product_tests.measure_tests.sort { |x, y| x.created_at <=> y.created_at }[product_test_number.to_i - 1]
+  product = Product.find_by(name: 'Product 1')
+  product_test = product.product_tests.measure_tests.sort { |x, y| x.created_at <=> y.created_at }[product_test_number.to_i - 1]
   task = product_test.tasks.c2_task
   "#wrapper-task-id-#{task.id.to_s}"
 end
 
 def td_div_id_for_cat1_task_for_filtering_test(filtering_test_number)
-  filtering_test = Product.first.product_tests.filtering_tests.sort { |x, y| x.created_at <=> y.created_at }[filtering_test_number.to_i - 1]
+  product = Product.find_by(name: 'Product 1')
+  filtering_test = product.product_tests.filtering_tests.sort { |x, y| x.created_at <=> y.created_at }[filtering_test_number.to_i - 1]
   task = filtering_test.tasks.cat1_filter_task
   "#wrapper-task-id-#{task.id.to_s}"
 end
 
 def td_div_id_for_cat3_task_for_filtering_test(filtering_test_number)
-  filtering_test = Product.first.product_tests.filtering_tests.sort { |x, y| x.created_at <=> y.created_at }[filtering_test_number.to_i - 1]
+  product = Product.find_by(name: 'Product 1')
+  filtering_test = product.product_tests.filtering_tests.sort { |x, y| x.created_at <=> y.created_at }[filtering_test_number.to_i - 1]
   task = filtering_test.tasks.cat3_filter_task
   "#wrapper-task-id-#{task.id.to_s}"
 end

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -5,7 +5,7 @@ When(/^the user visits the records page$/) do
   visit '/records/'
   @bundle = Bundle.default
   @other_bundle = Bundle.where('$or' => [{ 'active' => false }, { :active.exists => false }]).sample
-  @measure = @bundle.measures.where(hqmf_id: '8A4D92B2-3946-CDAE-0139-7944ACB700BD').first
+  @measure = @bundle.measures.find_by(hqmf_id: '8A4D92B2-3946-CDAE-0139-7944ACB700BD')
 end
 
 And(/^there is only 1 bundle installed$/) do
@@ -71,7 +71,7 @@ end
 
 When(/^the user visits a record$/) do
   @bundle = Bundle.default
-  @record = @bundle.records.where(_id: '4efa05ada9ffcce9010000dc').first
+  @record = @bundle.records.find_by(_id: '4efa05ada9ffcce9010000dc')
   visit "/records/#{@record.id}"
 end
 

--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -19,7 +19,7 @@ When(/^I fill in the form with correct information$/) do
 end
 
 Then(/^I should have a new account$/) do
-  assert_not_nil User.where(email: @email).first
+  assert_not_nil User.find_by(email: @email)
   assert_equal vendors_path, page.current_path
 end
 

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -43,7 +43,7 @@ class Admin::BundlesControllerTest < ActionController::TestCase
     end
   end
 
-  test 'shoud deny access to import for non admin users ' do
+  test 'should deny access to import for non admin users ' do
     for_each_logged_in_user([USER, OWNER, VENDOR]) do
       upload = Rack::Test::UploadedFile.new(Rails.root.join('test/fixtures/bundles/minimal_bundle.zip'), 'application/zip')
       post :create, file: upload

--- a/test/controllers/admin/user_controller_test.rb
+++ b/test/controllers/admin/user_controller_test.rb
@@ -4,7 +4,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
   def setup
     collection_fixtures 'users', 'roles', 'vendors'
-    @user = User.first
+    @user = User.find('4def93dd4f85cf8968000001')
   end
 
   test 'Admin can view index ' do
@@ -37,7 +37,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   end
 
   test 'Admin can update user' do
-    v = Vendor.first
+    v = Vendor.find('4f57a8791d41c851eb000002')
     Settings[:default_role] = nil
     u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
 

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -10,7 +10,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'should get index with logged in user' do
     collection_fixtures('users')
-    sign_in User.first
+    sign_in User.find('4def93dd4f85cf8968000001')
 
     get :index
     assert_response :redirect

--- a/test/controllers/measures_controller_test.rb
+++ b/test/controllers/measures_controller_test.rb
@@ -4,7 +4,7 @@ class MeasuresControllerTest < ActionController::TestCase
 
   setup do
     collection_fixtures('bundles', 'measures', 'users')
-    sign_in User.first
+    sign_in User.find('4def93dd4f85cf8968000001')
   end
 
   # json

--- a/test/controllers/product_tests_controller_test.rb
+++ b/test/controllers/product_tests_controller_test.rb
@@ -9,8 +9,8 @@ class ProductTestsControllerTest < ActionController::TestCase
   setup do
     collection_fixtures('vendors', 'products', 'product_tests', 'users', 'roles', 'bundles', 'measures')
     @vendor = Vendor.find(EHR1)
-    @product = @vendor.products.first
-    @test = @product.product_tests.first
+    @product = @vendor.products.find('4f57a88a1d41c851eb000004')
+    @test = @product.product_tests.find('4f58f8de1d41c851eb000478')
     @test['_type'] = MeasureTest # each measure test should have a _type of MeasureTest and cms_id
     @test['cms_id'] = 'CMS001'
     @test.save!

--- a/test/controllers/records_controller_test.rb
+++ b/test/controllers/records_controller_test.rb
@@ -5,7 +5,7 @@ class RecordsControllerTest < ActionController::TestCase
   setup do
     collection_fixtures('bundles', 'records', 'vendors', 'products', 'product_tests', 'tasks', 'users', 'measures', 'roles')
     @vendor = Vendor.find(EHR1)
-    @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').first
+    @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').find('4f57a88a1d41c851eb000004')
   end
 
   test 'should redirect from index to default bundle' do
@@ -27,7 +27,7 @@ class RecordsControllerTest < ActionController::TestCase
   test 'should get index scoped to bundle' do
     # do this for all users
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR, OTHER_VENDOR]) do
-      get :index, bundle_id: Bundle.where(:records.exists => true).first
+      get :index, bundle_id: Bundle.where(:records.exists => true).find('4fdb62e01d41c820f6000001')
       assert_response :success, "#{@user.email} should have access "
       assert assigns(:records)
       assert assigns(:source)
@@ -38,7 +38,7 @@ class RecordsControllerTest < ActionController::TestCase
   test 'should get show' do
     # do this for all users
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR, OTHER_VENDOR]) do
-      get :show, id: Bundle.where(:records.exists => true).first.records.first
+      get :show, id: Bundle.where(:records.exists => true).find('4fdb62e01d41c820f6000001').records.find('4f5bb2ef1d41c841b3000589')
       assert_response :success, "#{@user.email} should have access "
       assert assigns(:record)
     end
@@ -47,7 +47,7 @@ class RecordsControllerTest < ActionController::TestCase
   # need negative tests for user that does not have owner or vendor access
   test 'should be able to restrict access to product test records unauthorized users ' do
     for_each_logged_in_user([OTHER_VENDOR]) do
-      task_id = @first_product.product_tests.where(name: 'vendor1 product1 test1').first.tasks.first.id
+      task_id = @first_product.product_tests.where(name: 'vendor1 product1 test1').find('4f58f8de1d41c851eb000478').tasks.find('4f57a88a1d41c851eb000010')
       get :index, task_id: task_id
       assert_response 401
     end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -7,9 +7,9 @@ class TasksControllerTest < ActionController::TestCase
   setup do
     collection_fixtures('vendors', 'bundles', 'measures', 'products', 'product_tests', 'tasks', 'users', 'roles')
     @vendor = Vendor.find(EHR1)
-    @product = @vendor.products.where(name: 'Vendor 1 Product 1').first
-    @test = @product.product_tests.where(name: 'vendor1 product1 test1').first
-    @task = @test.tasks.first
+    @product = @vendor.products.where(name: 'Vendor 1 Product 1').find('4f57a88a1d41c851eb000004')
+    @test = @product.product_tests.where(name: 'vendor1 product1 test1').find('4f58f8de1d41c851eb000478')
+    @task = @test.tasks.find('4f57a88a1d41c851eb000010')
   end
 
   # need negative tests for user that does not have owner or vendor access

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -12,11 +12,11 @@ class TestExecutionsControllerTest < ActionController::TestCase
                         'records', 'patient_populations', 'providers')
     load_library_functions
     @vendor = Vendor.find(EHR1)
-    @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').first
+    @first_product = @vendor.products.where(name: 'Vendor 1 Product 1').find('4f57a88a1d41c851eb000004')
     @first_product.bundle = Bundle.default
     @first_product.save
-    @first_test = @first_product.product_tests.where(name: 'vendor1 product1 test1').first
-    @first_task = @first_test.tasks.first
+    @first_test = @first_product.product_tests.where(name: 'vendor1 product1 test1').find('4f58f8de1d41c851eb000478')
+    @first_task = @first_test.tasks.find('4f57a88a1d41c851eb000010')
     @first_execution = @first_task.test_executions.first
   end
 
@@ -25,8 +25,8 @@ class TestExecutionsControllerTest < ActionController::TestCase
     product.product_tests.build({ name: 'my filtering test', measure_ids: ['8A4D92B2-35FB-4AA7-0136-5A26000D30BD'],
                                   bundle_id: '4fdb62e01d41c820f6000001' }, FilteringTest)
     product.save!
-    @task_cat1 = product.product_tests.first.tasks.where(_type: 'Cat1FilterTask').first
-    @task_cat3 = product.product_tests.first.tasks.where(_type: 'Cat3FilterTask').first
+    @task_cat1 = product.product_tests.find_by(name: 'my filtering test').tasks.where(_type: 'Cat1FilterTask').first
+    @task_cat3 = product.product_tests.find_by(name: 'my filtering test').tasks.where(_type: 'Cat3FilterTask').first
   end
 
   test 'should get show' do
@@ -162,7 +162,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     # only need to do this for admin -- its checking error in file and the
     # access is already tested
     sign_in User.find(ADMIN)
-    task = C1Task.first
+    task = C1Task.find('4f57a88a1d41c851eb000004')
     old_count = task.test_executions.count
     file = File.new(File.join(Rails.root, 'app/assets/images/icon.svg'))
     upload = Rack::Test::UploadedFile.new(file, 'image/svg')
@@ -175,7 +175,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     # only need to do this for admin -- its checking error in file and the
     # access is already tested
     sign_in User.find(ADMIN)
-    task = C1Task.first
+    task = C1Task.find('4f57a88a1d41c851eb000004')
     task._type = 'C2Task'
     task.save!
     old_count = task.test_executions.count

--- a/test/controllers/vendors_controller_test.rb
+++ b/test/controllers/vendors_controller_test.rb
@@ -63,7 +63,7 @@ class VendorsControllerTest < ActionController::TestCase
 
   test 'should get show with json request' do
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
-      get :show, :format => :json, :id => Vendor.first.id
+      get :show, :format => :json, :id => Vendor.find('4f57a8791d41c851eb000002').id
       assert_response :success, 'response should be OK on vendor show'
       assert assigns(:vendor)
       assert_not_nil JSON.parse(response.body)
@@ -95,7 +95,7 @@ class VendorsControllerTest < ActionController::TestCase
 
   test 'should get error on invalid create vendor with json request' do
     for_each_logged_in_user([ADMIN, ATL, USER]) do
-      post :create, :format => :json, :vendor => { name: Vendor.first.name, poc_attributes: { name: 'test poc' } }
+      post :create, :format => :json, :vendor => { name: Vendor.find('4f57a8791d41c851eb000002').name, poc_attributes: { name: 'test poc' } }
       assert_response :unprocessable_entity, 'response should be Unprocessable Entity'
       assert_has_json_errors JSON.parse(response.body), 'name' => ['Vendor name was already taken. Please choose another.']
     end
@@ -170,7 +170,7 @@ class VendorsControllerTest < ActionController::TestCase
 
   test 'should get show with xml request' do
     for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
-      get :show, :format => :xml, :id => Vendor.first.id
+      get :show, :format => :xml, :id => Vendor.find('4f57a8791d41c851eb000002').id
       assert_response :success, 'response should be OK on vendor show'
       assert assigns(:vendor)
       assert_not_equal '', response.body
@@ -194,7 +194,7 @@ class VendorsControllerTest < ActionController::TestCase
 
   test 'should get error on invalid create vendor with xml request' do
     for_each_logged_in_user([ADMIN, ATL, USER]) do
-      post :create, :format => :xml, :vendor => { name: Vendor.first.name, poc_attributes: { name: 'test poc' } }
+      post :create, :format => :xml, :vendor => { name: Vendor.find('4f57a8791d41c851eb000002').name, poc_attributes: { name: 'test poc' } }
       assert_response :unprocessable_entity, 'response should be Unprocessable Entity'
       assert_has_xml_errors Hash.from_trusted_xml(response.body), 'name' => ['Vendor name was already taken. Please choose another.']
     end

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -8,7 +8,7 @@ class ProductsHelperTest < ActiveJob::TestCase
     drop_database
     collection_fixtures('records', 'measures', 'vendors', 'products', 'product_tests', 'bundles')
 
-    @product = Product.new(vendor: Vendor.all.first, name: 'test_product', c1_test: true, c2_test: true, c3_test: true, c4_test: true,
+    @product = Product.new(vendor: Vendor.find('4f57a8791d41c851eb000002'), name: 'test_product', c1_test: true, c2_test: true, c3_test: true, c4_test: true,
                            bundle_id: '4fdb62e01d41c820f6000001', measure_ids: ['40280381-43DB-D64C-0144-5571970A2685'])
     setup_checklist_test
     setup_measure_tests
@@ -22,7 +22,7 @@ class ProductsHelperTest < ActiveJob::TestCase
     measures = Measure.top_level.where(:hqmf_id.in => checklist_test.measure_ids)
     measures.each do |measure|
       # chose criteria randomly
-      criterias = measure['hqmf_document']['source_data_criteria'].sort_by { rand }.first(5)
+      criterias = measure['hqmf_document']['source_data_criteria'].sort_by { rand }[0..4]
       criterias.each do |criteria_key, _criteria_value|
         checked_criterias.push(measure_id: measure.id.to_s, source_data_criteria: criteria_key, completed: false)
       end
@@ -61,7 +61,7 @@ class ProductsHelperTest < ActiveJob::TestCase
   def test_generate_filter_records
     @product.product_tests = nil
     @product.add_filtering_tests
-    records = @product.product_tests.filtering_tests.first.records
+    records = @product.product_tests.filtering_tests.find_by(cms_id: 'CMS31v3').records
     @product.product_tests.filtering_tests.each { |ft| assert ft.records == records }
   end
 
@@ -127,7 +127,7 @@ class ProductsHelperTest < ActiveJob::TestCase
 
   def test_with_c3_task
     measure_ids = ['8A4D92B2-397A-48D2-0139-B0DC53B034A7']
-    product = Product.new(vendor: Vendor.all.first, name: 'my product', c1_test: true, c2_test: true, bundle_id: '4fdb62e01d41c820f6000001',
+    product = Product.new(vendor: Vendor.find('4f57a8791d41c851eb000002'), name: 'my product', c1_test: true, c2_test: true, bundle_id: '4fdb62e01d41c820f6000001',
                           measure_ids: measure_ids)
     product.save!
     pt = ProductTest.new(name: 'my product test name 1', measure_ids: measure_ids, product: product)

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -43,22 +43,22 @@ class TestExecutionHelper < ActiveSupport::TestCase
   def test_get_title_message_cat1_singlular
     setup_product_tests(true, false, false, true, filt1: 'val1')
 
-    assert_equal get_title_message(@m_test, @m_test.tasks.first), 'C1 certification for TEST_CMSID test_measure_test_name'
-    assert_equal get_title_message(@f_test, @f_test.tasks.first), 'CQM Filter Filt1 for TEST_CMSID test_filtering_test_name'
+    assert_equal get_title_message(@m_test, @m_test.tasks.find_by(_type: 'C1Task')), 'C1 certification for TEST_CMSID test_measure_test_name'
+    assert_equal get_title_message(@f_test, @f_test.tasks.find_by(_type: 'Cat1FilterTask')), 'CQM Filter Filt1 for TEST_CMSID test_filtering_test_name'
   end
 
   def test_get_title_message_cat1_plural
     setup_product_tests(true, false, true, true, filt1: 'val1', filt2: 'val2')
 
-    assert_equal get_title_message(@m_test, @m_test.tasks.first), 'C1 and C3 certifications for TEST_CMSID test_measure_test_name'
-    assert_equal get_title_message(@f_test, @f_test.tasks.first), 'CQM Filters Filt1/Filt2 for TEST_CMSID test_filtering_test_name'
+    assert_equal get_title_message(@m_test, @m_test.tasks.find_by(_type: 'C1Task')), 'C1 and C3 certifications for TEST_CMSID test_measure_test_name'
+    assert_equal get_title_message(@f_test, @f_test.tasks.find_by(_type: 'Cat1FilterTask')), 'CQM Filters Filt1/Filt2 for TEST_CMSID test_filtering_test_name'
   end
 
   def test_get_title_message_cat3
     setup_product_tests(false, true, false, true, filt1: 'val1')
 
-    assert_equal get_title_message(@m_test, @m_test.tasks.first), 'C2 certification for TEST_CMSID test_measure_test_name'
-    assert_equal get_title_message(@f_test, @f_test.tasks.first), 'CQM Filter Filt1 for TEST_CMSID test_filtering_test_name'
+    assert_equal get_title_message(@m_test, @m_test.tasks.find_by(_type: 'C2Task')), 'C2 certification for TEST_CMSID test_measure_test_name'
+    assert_equal get_title_message(@f_test, @f_test.tasks.find_by(_type: 'Cat1FilterTask')), 'CQM Filter Filt1 for TEST_CMSID test_filtering_test_name'
   end
 
   def test_get_upload_type

--- a/test/helpers/vendors_helper_test.rb
+++ b/test/helpers/vendors_helper_test.rb
@@ -8,7 +8,7 @@ class VendorsHelperTest < ActiveJob::TestCase
     drop_database
     collection_fixtures('records', 'measures', 'vendors', 'products', 'product_tests', 'bundles')
 
-    @product = Product.new(vendor: Vendor.all.first, name: 'test_product', c1_test: true, c2_test: true, c3_test: true, c4_test: true,
+    @product = Product.new(vendor: Vendor.find('4f57a8791d41c851eb000002'), name: 'test_product', c1_test: true, c2_test: true, c3_test: true, c4_test: true,
                            bundle_id: '4fdb62e01d41c820f6000001', measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'])
     setup_checklist_test
     setup_measure_tests
@@ -23,7 +23,7 @@ class VendorsHelperTest < ActiveJob::TestCase
     measures = Measure.top_level.where(:hqmf_id.in => checklist_test.measure_ids)
     measures.each do |measure|
       # chose criteria randomly
-      criterias = measure['hqmf_document']['source_data_criteria'].sort_by { rand }.first(5)
+      criterias = measure['hqmf_document']['source_data_criteria'].sort_by { rand }[0..4]
       criterias.each do |criteria_key, _criteria_value|
         checked_criterias.push(measure_id: measure.id.to_s, source_data_criteria: criteria_key, completed: false)
       end
@@ -49,8 +49,8 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   # one C1 failing test, one C3 passing test
   def setup_cat1_measure_executions
-    c1_cat1_execution = @product.product_tests.measure_tests.first.tasks.c1_task.test_executions.build(:state => :failed)
-    c3_cat1_execution = @product.product_tests.measure_tests.first.tasks.c3_cat1_task.test_executions.build(:state => :passed)
+    c1_cat1_execution = @product.product_tests.measure_tests.find_by(name: 'test_product_test_name_2').tasks.c1_task.test_executions.build(:state => :failed)
+    c3_cat1_execution = @product.product_tests.measure_tests.find_by(name: 'test_product_test_name_2').tasks.c3_cat1_task.test_executions.build(:state => :passed)
     c1_cat1_execution.sibling_execution_id = c3_cat1_execution.id
     c1_cat1_execution.save
     c3_cat1_execution.save
@@ -58,8 +58,8 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   # one C2 passing test, one C3 failing test
   def setup_cat3_measure_executions
-    c2_cat3_execution = @product.product_tests.measure_tests.first.tasks.c2_task.test_executions.build(:state => :passed)
-    c3_cat3_execution = @product.product_tests.measure_tests.first.tasks.c3_cat3_task.test_executions.build(:state => :failed)
+    c2_cat3_execution = @product.product_tests.measure_tests.find_by(name: 'test_product_test_name_2').tasks.c2_task.test_executions.build(:state => :passed)
+    c3_cat3_execution = @product.product_tests.measure_tests.find_by(name: 'test_product_test_name_2').tasks.c3_cat3_task.test_executions.build(:state => :failed)
     c2_cat3_execution.sibling_execution_id = c3_cat3_execution.id
     c2_cat3_execution.save
     c3_cat3_execution.save
@@ -75,8 +75,8 @@ class VendorsHelperTest < ActiveJob::TestCase
     end
 
     # one cat1 passing execution, one cat3 failing execution
-    @product.product_tests.filtering_tests.first.cat1_task.test_executions.create(:state => :passed)
-    @product.product_tests.filtering_tests.first.cat3_task.test_executions.create(:state => :passed)
+    @product.product_tests.filtering_tests.find_by(name: 'Filter Test 1').cat1_task.test_executions.create(:state => :passed)
+    @product.product_tests.filtering_tests.find_by(name: 'Filter Test 1').cat3_task.test_executions.create(:state => :passed)
   end
 
   # # # # # # # # #
@@ -159,7 +159,7 @@ class VendorsHelperTest < ActiveJob::TestCase
   end
 
   def test_checklist_status_values_not_started
-    test = @product.product_tests.checklist_tests.first
+    test = @product.product_tests.checklist_tests.find_by(name: 'c1 visual')
     passing, failing, errored, not_started, total = checklist_status_values(test)
 
     assert_equal 0, passing
@@ -184,7 +184,7 @@ class VendorsHelperTest < ActiveJob::TestCase
   end
 
   def test_checklist_status_values_passing
-    test = @product.product_tests.checklist_tests.first
+    test = @product.product_tests.checklist_tests.find_by(name: 'c1 visual')
     test.checked_criteria.each do |criteria|
       criteria.code_complete = true
       criteria.code = '123'
@@ -210,7 +210,7 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   def test_product_test_statuses_passing
     tests = @product.product_tests.measure_tests
-    tests.first.tasks.where(_type: 'C1Task').first.test_executions.build(:state => :passed).save
+    tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C1Task').first.test_executions.build(:state => :passed).save
     passing, failing, errored, not_started, total = product_test_statuses(tests, 'C1Task')
 
     assert_equal 1, passing
@@ -222,7 +222,7 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   def test_product_test_statuses_failing
     tests = @product.product_tests.measure_tests
-    tests.first.tasks.where(_type: 'C1Task').first.test_executions.build(:state => :failed).save
+    tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C1Task').first.test_executions.build(:state => :failed).save
     passing, failing, errored, not_started, total = product_test_statuses(tests, 'C1Task')
 
     assert_equal 0, passing
@@ -246,8 +246,8 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   def test_product_test_statuses_cat1
     tests = @product.product_tests.measure_tests
-    c1_execution = tests.first.tasks.where(_type: 'C1Task').first.test_executions.build(:state => :failed)
-    c3_execution = tests.first.tasks.where(_type: 'C3Cat1Task').first.test_executions.build(:state => :passed)
+    c1_execution = tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C1Task').first.test_executions.build(:state => :failed)
+    c3_execution = tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C3Cat1Task').first.test_executions.build(:state => :passed)
     c1_execution.sibling_execution_id = c3_execution.id
     c1_execution.save
     c3_execution.save
@@ -277,8 +277,8 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   def test_product_test_statuses_cat3
     tests = @product.product_tests.measure_tests
-    c2_execution = tests.first.tasks.where(_type: 'C2Task').first.test_executions.build(:state => :failed)
-    c3_execution = tests.first.tasks.where(_type: 'C3Cat3Task').first.test_executions.build(:state => :passed)
+    c2_execution = tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C2Task').first.test_executions.build(:state => :failed)
+    c3_execution = tests.find_by(name: 'test_product_test_name_2').tasks.where(_type: 'C3Cat3Task').first.test_executions.build(:state => :passed)
     c2_execution.sibling_execution_id = c3_execution.id
     c2_execution.save
     c3_execution.save
@@ -317,12 +317,12 @@ class VendorsHelperTest < ActiveJob::TestCase
   def test_cache_key_changes_after_tests
     get_product_status_values(@product)
     assert_changes_cache_key do |product|
-      checklist_test = product.product_tests.checklist_tests.first
+      checklist_test = product.product_tests.checklist_tests.find_by(name: 'c1 visual')
       checklist_test.checked_criteria.first.completed = true
       checklist_test.save
     end
-    assert_changes_cache_key { |product| product.product_tests.measure_tests.first.tasks.c1_task.test_executions.create({}) }
-    assert_changes_cache_key { |product| product.product_tests.filtering_tests.first.tasks.cat1_filter_task.test_executions.create({}) }
+    assert_changes_cache_key { |product| product.product_tests.measure_tests.find_by(name: 'test_product_test_name_2').tasks.c1_task.test_executions.create({}) }
+    assert_changes_cache_key { |product| product.product_tests.filtering_tests.find_by(name: 'Filter Test 1').tasks.cat1_filter_task.test_executions.create({}) }
   end
 
   def assert_changes_cache_key

--- a/test/jobs/measure_evaluation_job_test.rb
+++ b/test/jobs/measure_evaluation_job_test.rb
@@ -26,7 +26,7 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
     QME::QualityReport.any_instance.stubs(:result).returns(@result)
     QME::QualityReport.any_instance.stubs(:calculated?).returns(true)
     assert_enqueued_jobs 0
-    prod = Product.first
+    prod = Product.find('4f57a88a1d41c851eb000004')
     perform_enqueued_jobs do
       ptest = prod.product_tests.create({ name: 'test_for_measure_job_calculation',
                                           measure_ids: ['8A4D92B2-3887-5DF3-0139-0C4E41594C98'] }, MeasureTest)
@@ -44,7 +44,7 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
     QME::QualityReport.any_instance.stubs(:result).returns(@result)
     QME::QualityReport.any_instance.stubs(:calculated?).returns(true)
     assert_enqueued_jobs 0
-    prod = Product.first
+    prod = Product.find('4f57a88a1d41c851eb000004')
     perform_enqueued_jobs do
       ptest = prod.product_tests.create({ name: 'test_for_measure_job_calculation',
                                           measure_ids: ['8A4D92B2-3887-5DF3-0139-0C4E41594C98'] }, MeasureTest)

--- a/test/jobs/test_execution_job_test.rb
+++ b/test/jobs/test_execution_job_test.rb
@@ -9,7 +9,7 @@ class TestExecutionJobTest < ActiveJob::TestCase
   def test_can_queue_job
     assert_enqueued_jobs 0
 
-    ptest = ProductTest.first
+    ptest = ProductTest.find('51703a4e3054cf8439000004')
     task = ptest.tasks.create({}, C2Task)
     te = task.test_executions.create({})
 

--- a/test/models/filtering_test_test.rb
+++ b/test/models/filtering_test_test.rb
@@ -57,7 +57,7 @@ class FilteringTestTest < ActiveJob::TestCase
     test = @product.product_tests.create!({ name: 'test_for_measure_1a',
                                             measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'],
                                             options: { 'filters' => {} } }, FilteringTest)
-    test.tasks.first.test_executions.build(:state => :passed).save!
+    test.tasks.find_by(_type: 'Cat1FilterTask').test_executions.build(:state => :passed).save!
 
     assert_equal 'passing', test.task_status('Cat1FilterTask')
     assert_equal 'incomplete', test.task_status('Cat3FilterTask')

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -61,7 +61,7 @@ class MeasureTestTest < ActiveJob::TestCase
       assert pt.save, 'should be able to save valid product test'
       assert_performed_jobs 1
       assert_equal 1, pt.records.count, 'product test creation should have created specific number of test records'
-      patient = pt.records.first
+      patient = pt.records.find_by(first: 'Selena')
       assert_equal 'Selena', patient.first, 'Patient name should not be randomized'
       assert_equal 'Lotherberg', patient.last, 'Patient name should not be randomized'
       assert_equal '19', patient.medical_record_number, 'Patient record # should not be randomized'

--- a/test/unit/lib/record_filter_test.rb
+++ b/test/unit/lib/record_filter_test.rb
@@ -240,7 +240,7 @@ class RecordFilterTest < ActiveSupport::TestCase
     filters = { 'providers' => prov_filters }
 
     # assign the provider and make sure we can find it
-    patient = Record.first
+    patient = Record.find('4f5bb2ef1d41c841b3000502')
 
     patient.provider_performances.build(provider: prov)
     patient.save!


### PR DESCRIPTION
In some cases .first was used with a set of randomized elements, in which case find() or find_by wouldn't work as each element has unknown characteristics
I ran all the tests a few times, but they had been breaking some times but not others, if that happens it's probably my fault and I can fix it