### PR TITLE
Execution errors

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,7 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
     - 'lib/cypress/api_measure_evaluator.rb'
+    - 'app/models/product.rb'
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.

--- a/app/assets/stylesheets/cypress/_vendor.scss
+++ b/app/assets/stylesheets/cypress/_vendor.scss
@@ -1,6 +1,6 @@
 .styled-status-table {
   margin-bottom: 0;
-  
+
   > thead > tr > th,
   > thead > tr > td {
     border-bottom-color: $gray;
@@ -39,6 +39,12 @@
     color: $state-danger-text;
     background: $state-danger-bg;
     border: 1px solid darken($state-danger-bg, 20%);
+  }
+
+  .status-errored {
+    color: $state-warning-text;
+    background: $state-warning-bg;
+    border: 1px solid darken($state-warning-bg, 20%);
   }
 
   .status-not-started {

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -47,13 +47,15 @@ module ProductsHelper
 
     case test_status
     when 'passing'
-      return 5
+      return 6
     when 'failing'
+      return 5
+    when 'errored'
       return 4
     when 'incomplete'
       return 3
     else
-      return 6
+      return 7
     end
   end
 
@@ -86,6 +88,7 @@ module ProductsHelper
     return tasks.first.status if tasks.count == 0
     return 'passing' if tasks.all?(&:passing?)
     return 'failing' if tasks.any?(&:failing?)
+    return 'errored' if tasks.any?(&:errored?)
     return 'incomplete' if tasks.any?(&:incomplete?)
     'unstarted'
   end

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -85,6 +85,8 @@ module TestExecutionsHelper
       return 'info'
     when 'passing'
       return 'success'
+    when 'errored'
+      return 'warning'
     else
       return 'danger'
     end

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -8,6 +8,7 @@ module TestExecutionsResultsHelper
     case execution.status_with_sibling
     when 'passing' then msg << ' (passing)'
     when 'incomplete' then msg << ' (in progress)'
+    when 'errored' then msg << ' (internal error)'
     else # failing
       num_errors = execution.execution_errors.count
       num_errors += execution.sibling_execution.execution_errors.count if execution.sibling_execution

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -38,8 +38,8 @@ module VendorsHelper
 
   def c3_status_values(product)
     h = {}
-    cat1_status_values = product.c1_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat1Task') : [0, 0, 0, 0]
-    cat3_status_values = product.c2_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat3Task') : [0, 0, 0, 0]
+    cat1_status_values = product.c1_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat1Task') : [0, 0, 0, 0, 0]
+    cat3_status_values = product.c2_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat3Task') : [0, 0, 0, 0, 0]
     h['QRDA Category I'] = Hash[%w(passing failing errored not_started total).zip(cat1_status_values)]
     h['QRDA Category III'] = Hash[%w(passing failing errored not_started total).zip(cat3_status_values)]
     h
@@ -54,12 +54,13 @@ module VendorsHelper
 
   # returns zero for all values if test is false
   def checklist_status_values(test)
-    return [0, 0, 0, 0] unless test
+    return [0, 0, 0, 0, 0] unless test
     passing = test.num_measures_complete
     total = test.measures.count
     not_started = test.num_measures_not_started
     failing = total - not_started - passing
-    [passing, failing, not_started, total]
+    errored = 0
+    [passing, failing, errored, not_started, total]
   end
 
   def product_test_statuses(tests, task_type)

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -19,18 +19,20 @@ module VendorsHelper
 
   def c1_status_values(product)
     h = {}
-    h['Manual'] = Hash[%w(passing failing not_started total).zip(checklist_status_values(product.product_tests.checklist_tests.first))]
+    h['Manual'] = Hash[%w(passing failing errored not_started total).zip(checklist_status_values(product.product_tests.checklist_tests.first))]
     if h['Manual']['total'] == 0
       default_number = CAT1_CONFIG['number_of_checklist_measures']
       h['Manual']['not_started'] = product.measure_ids.size < default_number ? product.measure_ids.size : default_number
     end
-    h['QRDA Category I'] = Hash[%w(passing failing not_started total).zip(product_test_statuses(product.product_tests.measure_tests, 'C1Task'))]
+    h['QRDA Category I'] = Hash[%w(passing failing errored not_started total).zip(product_test_statuses(product.product_tests.measure_tests,
+                                                                                                        'C1Task'))]
     h
   end
 
   def c2_status_values(product)
     h = {}
-    h['QRDA Category III'] = Hash[%w(passing failing not_started total).zip(product_test_statuses(product.product_tests.measure_tests, 'C2Task'))]
+    h['QRDA Category III'] = Hash[%w(passing failing errored not_started total).zip(product_test_statuses(product.product_tests.measure_tests,
+                                                                                                          'C2Task'))]
     h
   end
 
@@ -38,15 +40,15 @@ module VendorsHelper
     h = {}
     cat1_status_values = product.c1_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat1Task') : [0, 0, 0, 0]
     cat3_status_values = product.c2_test ? product_test_statuses(product.product_tests.measure_tests, 'C3Cat3Task') : [0, 0, 0, 0]
-    h['QRDA Category I'] = Hash[%w(passing failing not_started total).zip(cat1_status_values)]
-    h['QRDA Category III'] = Hash[%w(passing failing not_started total).zip(cat3_status_values)]
+    h['QRDA Category I'] = Hash[%w(passing failing errored not_started total).zip(cat1_status_values)]
+    h['QRDA Category III'] = Hash[%w(passing failing errored not_started total).zip(cat3_status_values)]
     h
   end
 
   def c4_status_values(filtering_tests)
     h = {}
-    h['QRDA Category I'] = Hash[%w(passing failing not_started total).zip(product_test_statuses(filtering_tests, 'Cat1FilterTask'))]
-    h['QRDA Category III'] = Hash[%w(passing failing not_started total).zip(product_test_statuses(filtering_tests, 'Cat3FilterTask'))]
+    h['QRDA Category I'] = Hash[%w(passing failing errored not_started total).zip(product_test_statuses(filtering_tests, 'Cat1FilterTask'))]
+    h['QRDA Category III'] = Hash[%w(passing failing errored not_started total).zip(product_test_statuses(filtering_tests, 'Cat3FilterTask'))]
     h
   end
 
@@ -63,12 +65,12 @@ module VendorsHelper
   def product_test_statuses(tests, task_type)
     tasks = []
     tests.each { |test| tasks << test.tasks.where(_type: task_type) }
-    tasks.empty? ? [0, 0, 0, 0] : tasks_values(tasks)
+    tasks.empty? ? [0, 0, 0, 0, 0] : tasks_values(tasks)
   end
 
   def tasks_values(tasks)
     status_values = []
-    %w(passing failing incomplete).each { |status| status_values << tasks.count { |task| task.first.status == status } }
+    %w(passing failing errored incomplete).each { |status| status_values << tasks.count { |task| task.first.status == status } }
     status_values << tasks.count # total number of product tests
   end
 
@@ -87,6 +89,9 @@ module VendorsHelper
     when 'Incomplete'
       classes['cell'] = 'status-not-started'
       classes['icon'] = 'fa-circle-o'
+    when 'Errored'
+      classes['cell'] = 'status-errored'
+      classes['icon'] = 'fa-exclamation'
     when 'Not_started'
       classes['cell'] = 'status-not-started'
       classes['icon'] = 'fa-circle-o'
@@ -99,6 +104,7 @@ module VendorsHelper
     h = {}
     h['passing'] = vendor.products_passing.count
     h['failing'] = vendor.products_failing.count
+    h['errored'] = vendor.products_errored.count
     h['incomplete'] = vendor.products_incomplete.count
     h['total'] = vendor.products.count
     h

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -40,6 +40,7 @@ class C1Task < Task
     sibling = product_test.tasks.c3_cat1_task
     return status unless sibling
     return status if status == sibling.status
+    return 'errored' if errored? || sibling.errored?
     return 'incomplete' if incomplete? || sibling.incomplete?
     'failing'
   end

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -36,6 +36,7 @@ class C2Task < Task
     sibling = product_test.tasks.c3_cat3_task
     return status unless sibling
     return status if status == sibling.status
+    return 'errored' if errored? || sibling.errored?
     return 'incomplete' if incomplete? || sibling.incomplete?
     'failing'
   end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -64,17 +64,7 @@ class MeasureTest < ProductTest
     c1_task = tasks.c1_task
     c3_task = tasks.c3_cat1_task
     return c1_task.status unless c3_task
-    if c1_task.passing? && c3_task.passing?
-      'passing'
-    elsif c1_task.failing? || c3_task.failing?
-      'failing'
-    elsif c1_task.errored? || c3_task.errored?
-      'errored'
-    elsif c1_task.incomplete? || c3_task.incomplete?
-      'incomplete'
-    else
-      'unstarted'
-    end
+    test_status c1_task, c3_task
   end
 
   # passing only if both c2 and c3_cat3 tasks pass
@@ -84,16 +74,20 @@ class MeasureTest < ProductTest
     c2_task = tasks.c2_task
     c3_task = tasks.c3_cat3_task
     return c2_task.status unless c3_task
-    if c2_task.passing? && c3_task.passing?
-      'passing'
-    elsif c2_task.failing? || c3_task.failing?
-      'failing'
-    elsif c2_task.errored? || c3_task.errored?
-      'errored'
-    elsif c2_task.incomplete? || c3_task.incomplete?
-      'incomplete'
-    else
-      'unstarted'
-    end
+    test_status c2_task, c3_task
+  end
+end
+
+def test_status(task1, task2)
+  if task1.passing? && task2.passing?
+    'passing'
+  elsif task1.failing? || task2.failing?
+    'failing'
+  elsif task1.errored? || task2.errored?
+    'errored'
+  elsif task1.incomplete? || task2.incomplete?
+    'incomplete'
+  else
+    'unstarted'
   end
 end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -68,6 +68,8 @@ class MeasureTest < ProductTest
       'passing'
     elsif c1_task.failing? || c3_task.failing?
       'failing'
+    elsif c1_task.errored? || c3_task.errored?
+      'errored'
     elsif c1_task.incomplete? || c3_task.incomplete?
       'incomplete'
     else
@@ -86,6 +88,8 @@ class MeasureTest < ProductTest
       'passing'
     elsif c2_task.failing? || c3_task.failing?
       'failing'
+    elsif c2_task.errored? || c3_task.errored?
+      'errored'
     elsif c2_task.incomplete? || c3_task.incomplete?
       'incomplete'
     else

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -38,6 +38,8 @@ class Product
         'failing'
       elsif product_tests_for_status('passing').count == total && total > 0
         c1_test && product_tests.checklist_tests.empty? ? 'incomplete' : 'passing'
+      elsif product_tests_for_status('errored').count > 0
+        'errored'
       else
         'incomplete'
       end

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -105,6 +105,8 @@ class ProductTest
         'failing'
       elsif tasks_by_status('passing').count == total && total > 0
         'passing'
+      elsif tasks_by_status('errored').count > 0
+        'errored'
       else
         'incomplete'
       end

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -45,8 +45,7 @@ class ProductTest
   end
 
   def generate_records
-    ids = PatientCache.where('value.measure_id' => { '$in' => measure_ids },
-                             'value.IPP' => { '$gt' => 0 }).collect do |pcv|
+    ids = PatientCache.where('value.measure_id' => { '$in' => measure_ids }, 'value.IPP' => { '$gt' => 0 }).collect do |pcv|
       pcv.value['medical_record_id']
     end
     ids.uniq!
@@ -100,10 +99,9 @@ class ProductTest
 
   def status
     Rails.cache.fetch("#{cache_key}/status") do
-      total = tasks.count
       if tasks_by_status('failing').count > 0
         'failing'
-      elsif tasks_by_status('passing').count == total && total > 0
+      elsif tasks_by_status('passing').count == tasks.count && tasks.count > 0
         'passing'
       elsif tasks_by_status('errored').count > 0
         'errored'

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -64,6 +64,10 @@ class Task
     status == 'failing'
   end
 
+  def errored?
+    status == 'errored'
+  end
+
   def incomplete?
     status == 'incomplete'
   end
@@ -76,6 +80,8 @@ class Task
         'passing'
       elsif recent_execution.failing?
         'failing'
+      elsif recent_execution.errored?
+        'errored'
       else
         'incomplete'
       end

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -111,6 +111,7 @@ class TestExecution
     return status unless sibling
     return status if status == sibling.status
     return 'incomplete' if incomplete? || sibling.incomplete?
+    return 'failing' if failing? || sibling.failing?
     return 'errored' if errored? || sibling.errored?
     'failing' # failing if status's do not match
   end

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -47,7 +47,7 @@ class TestExecution
     end
     execution_errors.only_errors.count > 0 ? fail : pass
   rescue
-    error
+    errored
   end
 
   # Get the expected result for a particular measure
@@ -86,7 +86,7 @@ class TestExecution
     save
   end
 
-  def error
+  def errored
     self.state = :errored
     save
   end

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -46,6 +46,8 @@ class TestExecution
                              :msg_type => :error, :validator_type => :result_validation, :validator => :smoking_gun)
     end
     execution_errors.only_errors.count > 0 ? fail : pass
+  rescue
+    error
   end
 
   # Get the expected result for a particular measure
@@ -66,8 +68,12 @@ class TestExecution
     state == :failed
   end
 
+  def errored?
+    state == :errored
+  end
+
   def incomplete?
-    (!passing? && !failing?)
+    (!passing? && !failing? && !errored?)
   end
 
   def pass
@@ -80,6 +86,11 @@ class TestExecution
     save
   end
 
+  def error
+    self.state = :errored
+    save
+  end
+
   def sibling_execution
     TestExecution.find(sibling_execution_id)
   rescue
@@ -89,6 +100,7 @@ class TestExecution
   def status
     return 'passing' if passing?
     return 'failing' if failing?
+    return 'errored' if errored?
     'incomplete'
   end
 
@@ -99,6 +111,7 @@ class TestExecution
     return status unless sibling
     return status if status == sibling.status
     return 'incomplete' if incomplete? || sibling.incomplete?
+    return 'errored' if errored? || sibling.errored?
     'failing' # failing if status's do not match
   end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -41,6 +41,8 @@ class Vendor
         'failing'
       elsif products_passing.count == total && total > 0
         'passing'
+      elsif products_errored.count > 0
+        'errored'
       else
         'incomplete'
       end
@@ -56,6 +58,12 @@ class Vendor
   def products_failing
     Rails.cache.fetch("#{cache_key}/products_failing") do
       products.select { |product| product.status == 'failing' }
+    end
+  end
+
+  def products_errored
+    Rails.cache.fetch("#{cache_key}/products_errored") do
+      products.select { |product| product.status == 'errored' }
     end
   end
 

--- a/app/views/application/_products_status_cells.html.erb
+++ b/app/views/application/_products_status_cells.html.erb
@@ -21,7 +21,7 @@
           </tr>
         </thead>
         <tbody>
-          <% %w(passing failing not_started).each do |status| %>
+          <% %w(passing failing errored not_started).each do |status| %>
             <% classes = status_to_css_classes(status.capitalize) %>
             <tr>
               <% cert_hash.each_value do |cert_status_hash| %>

--- a/app/views/products/_product_test_link.html.erb
+++ b/app/views/products/_product_test_link.html.erb
@@ -25,9 +25,13 @@
     <i class = 'fa fa-fw fa-check-circle text-success' aria-hidden="true"></i>
     <%= link_to 'view', new_task_test_execution_path(task), :class => "label label-success" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
-  <% when 'failing' %>
+  <% when 'failing'%>
     <i class = 'fa fa-fw fa-play-circle text-danger' aria-hidden="true"></i>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-danger" %>
+    <%= render partial: '/products/product_test_upload', locals: { task: task } %>
+  <% when 'errored'%>
+    <i class = 'fa fa-fw fa-exclamation-circle text-warning' aria-hidden="true"></i>
+    <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-warning" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'incomplete' %>
     <% if should_reload_product_test_link?(tasks) %>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -14,6 +14,9 @@
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_results' }});
   </script>
 
+<% elsif execution.status_with_sibling == 'errored' %>
+  <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> An internal error occured</p>
+
 <% else %>
   <% if passing = execution.status_with_sibling == 'passing'%>
     <div class="row">

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -14,72 +14,23 @@
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_results' }});
   </script>
 
-<% elsif execution.status_with_sibling == 'passing' || execution.status_with_sibling == 'failing' %>
+<% else %>
   <% if passing = execution.status_with_sibling == 'passing'%>
-    <div class="row">
-      <div class="col-sm-7">
-        <p class="lead bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> Passed</p>
-        <div class="row">
-          <div class="col-sm-6">
-            <% if execution.task.product_test._type == 'MeasureTest' %>
-              <% cat1_task = execution.task.product_test.tasks.c1_task %>
-              <% cat3_task = execution.task.product_test.tasks.c2_task %>
-            <% else %>
-              <% cat1_task = execution.task.product_test.tasks.cat1_filter_task %>
-              <% cat3_task = execution.task.product_test.tasks.cat3_filter_task %>
-            <% end %>
-
-            <ul class="fa-ul">
-              <% if displaying_cat1?(execution.task) %>
-                <% if cat3_task && cat3_task.status != "passing" %>
-                  <li>
-                    <i class="fa-li fa fa-list" aria-hidden="true"></i>
-                    <%= link_to "Try the associated QRDA Category III Measure Test", new_task_test_execution_path(cat3_task) %>
-                  </li>
-                <% end %>
-              <% else %>
-                <% if cat1_task && cat1_task.status != "passing" %>
-                  <li>
-                    <i class="fa-li fa fa-list" aria-hidden="true"></i>
-                    <%= link_to "Try the associated QRDA Category I Measure Test", new_task_test_execution_path(cat1_task) %>
-                  </li>
-                <% end %>
-              <% end %>
-            </ul>
-          </div>
-          <div class="col-sm-6">
-            <ul class="fa-ul">
-              <% if execution.task.product_test.product.c1_test %>
-                <li>
-                  <i class="fa-li fa fa-list" aria-hidden="true"></i>
-                  <%= link_to 'Try a different Measure Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#MeasureTest" %>
-                </li>
-                <li>
-                  <i class="fa-li fa fa-eye" aria-hidden="true"></i>
-                  <%= link_to 'Try a Manual Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
-                </li>
-              <% end %>
-
-              <% if execution.task.product_test.product.c4_test %>
-                <li>
-                  <i class="fa-li fa fa-filter" aria-hidden="true"></i>
-                  <%= link_to 'Try a Filtering Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#FilteringTest" %>
-                </li>
-              <% end %>
-            </ul>
-          </div>
-        </div>
-      </div>
-      <div class="col-sm-5">
-        <div class="execution-information bg-info">
-          <ul class="list-unstyled">
-            <li><strong>Test Date:</strong> <%= local_time(execution.updated_at) %></li>
-            <li><strong>Files Uploaded:</strong> <%= execution.artifact['file'] %></li>
-            <li><strong>Total Test Executions:</strong> <%= execution.task.test_executions.count %></li>
-          </ul>
-        </div>
-      </div>
-    </div>
+    <%= render partial: 'test_executions/results/passing_result', locals: { execution: execution, execution_type: nil } %>
+  <% elsif execution.errored? || execution.sibling_execution.errored? %>
+    <% [execution, execution.sibling_execution].each do |ex| %>
+      <% ex_type = ex.task._type[0, 2] # get first two letters e.g. C1 or C3 %>
+      <% if ex.errored? %>
+        <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occured</p>
+      <% elsif ex.passing? %>
+        <%= render partial: 'test_executions/results/passing_result', locals: { execution: ex, execution_type: ex_type } %>
+      <% elsif ex.failing? %>
+        <p class="lead row bg-danger execution-status">
+          <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i> <%= ex_type %> Execution:
+          <%= execution_failure_message(ex) %>
+        </p>
+      <% end %>
+    <% end %>
   <% else %>
     <p class="lead row bg-danger execution-status">
       <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i>
@@ -193,20 +144,5 @@
         </div>
       <% end %>
     </div>
-  <% end %>
-
-<% elsif execution.status_with_sibling == 'errored' %>
-  <% [execution, execution.sibling_execution].each do |ex| %>
-    <% ex_type = ex.task._type[0, 2] %>
-    <% if ex.errored? %>
-      <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occured</p>
-    <% elsif ex.passing? %>
-      <p class="lead row bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> <%= ex_type %> Execution passed</p>
-    <% elsif ex.failing? %>
-      <p class="lead row bg-danger execution-status">
-        <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i>
-        <%= execution_failure_message(ex) %>
-      </p>
-    <% end %>
   <% end %>
 <% end %>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -14,10 +14,7 @@
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_results' }});
   </script>
 
-<% elsif execution.status_with_sibling == 'errored' %>
-  <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> An internal error occured</p>
-
-<% else %>
+<% elsif execution.status_with_sibling == 'passing' || execution.status_with_sibling == 'failing' %>
   <% if passing = execution.status_with_sibling == 'passing'%>
     <div class="row">
       <div class="col-sm-7">
@@ -196,5 +193,20 @@
         </div>
       <% end %>
     </div>
+  <% end %>
+
+<% elsif execution.status_with_sibling == 'errored' %>
+  <% [execution, execution.sibling_execution].each do |ex| %>
+    <% ex_type = ex.task._type[0, 2] %>
+    <% if ex.errored? %>
+      <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occured</p>
+    <% elsif ex.passing? %>
+      <p class="lead row bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> <%= ex_type %> Execution passed</p>
+    <% elsif ex.failing? %>
+      <p class="lead row bg-danger execution-status">
+        <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i>
+        <%= execution_failure_message(ex) %>
+      </p>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -38,7 +38,7 @@
           <% elsif task_status == 'failing' %>
             <i class = 'fa fa-times text-danger'></i><strong class = 'text-danger'> Failing</strong>
           <% elsif task_status == 'errored' %>
-            <i class = 'fa fa-exclamation text-warning'><strong class = 'text-warning'> Internal Error</strong></i>
+            <i class = 'fa fa-exclamation text-warning'></i><strong class = 'text-warning'> Internal Error</strong>
           <% else # incomplete (in progress b/c execution exists) %>
             <strong class = 'text-info'>In Progress...</strong>
           <% end %>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -29,7 +29,7 @@
       <% if execution %>
         <div class = 'col-sm-6 text-center margin-top-1'>
           <% unless current_task %>
-            <span class = 'nested-link text-primary'><%= task_status == 'passing' || task_status == 'failing' ? 'view' : 'start' unless current_task %></span>
+            <span class = 'nested-link text-primary'><%= task_status == 'passing' || task_status == 'failing' || task_status == 'errored' ? 'view' : 'start' unless current_task %></span>
           <% end %>
         </div>
         <div class = 'col-sm-6 text-left margin-top-1'>
@@ -37,6 +37,8 @@
             <i class = 'fa fa-check text-success'></i><strong class = 'text-success'> Passing</strong>
           <% elsif task_status == 'failing' %>
             <i class = 'fa fa-times text-danger'></i><strong class = 'text-danger'> Failing</strong>
+          <% elsif task_status == 'errored' %>
+            <i class = 'fa fa-exclamation text-warning'><strong class = 'text-warning'> Internal Error</strong></i>
           <% else # incomplete (in progress b/c execution exists) %>
             <strong class = 'text-info'>In Progress...</strong>
           <% end %>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -12,10 +12,12 @@
 
   <% # display provider information if the product test is a measure test %>
   <% if task.product_test.class == MeasureTest %>
-    <br/>
     <% provider = task.product_test.provider %>
-    <% { 'Name' => "#{provider.family_name}, #{provider.given_name}", 'NPI' => provider.npi, 'TIN' => provider.tin }.each do |label, value| %>
-      <strong><%= "Provider #{label}: " %></strong><span><%= value %></span><br/>
+    <% unless provider.nil? %>
+      <br/>
+      <% { 'Name' => "#{provider.family_name}, #{provider.given_name}", 'NPI' => provider.npi, 'TIN' => provider.tin }.each do |label, value| %>
+        <strong><%= "Provider #{label}: " %></strong><span><%= value %></span><br/>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/app/views/test_executions/results/_passing_result.html.erb
+++ b/app/views/test_executions/results/_passing_result.html.erb
@@ -1,0 +1,64 @@
+<div class="row">
+  <div class="col-sm-7">
+    <p class="lead bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> <%= execution_type + " Execution: " unless execution_type.nil? %>Passed</p>
+    <div class="row">
+      <div class="col-sm-6">
+        <% if execution.task.product_test._type == 'MeasureTest' %>
+          <% cat1_task = execution.task.product_test.tasks.c1_task %>
+          <% cat3_task = execution.task.product_test.tasks.c2_task %>
+        <% else %>
+          <% cat1_task = execution.task.product_test.tasks.cat1_filter_task %>
+          <% cat3_task = execution.task.product_test.tasks.cat3_filter_task %>
+        <% end %>
+
+        <ul class="fa-ul">
+          <% if displaying_cat1?(execution.task) %>
+            <% if cat3_task && cat3_task.status != "passing" %>
+              <li>
+                <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                <%= link_to "Try the associated QRDA Category III Measure Test", new_task_test_execution_path(cat3_task) %>
+              </li>
+            <% end %>
+          <% else %>
+            <% if cat1_task && cat1_task.status != "passing" %>
+              <li>
+                <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                <%= link_to "Try the associated QRDA Category I Measure Test", new_task_test_execution_path(cat1_task) %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </div>
+      <div class="col-sm-6">
+        <ul class="fa-ul">
+          <% if execution.task.product_test.product.c1_test %>
+            <li>
+              <i class="fa-li fa fa-list" aria-hidden="true"></i>
+              <%= link_to 'Try a different Measure Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#MeasureTest" %>
+            </li>
+            <li>
+              <i class="fa-li fa fa-eye" aria-hidden="true"></i>
+              <%= link_to 'Try a Manual Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
+            </li>
+          <% end %>
+
+          <% if execution.task.product_test.product.c4_test %>
+            <li>
+              <i class="fa-li fa fa-filter" aria-hidden="true"></i>
+              <%= link_to 'Try a Filtering Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#FilteringTest" %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+  <div class="col-sm-5">
+    <div class="execution-information bg-info">
+      <ul class="list-unstyled">
+        <li><strong>Test Date:</strong> <%= local_time(execution.updated_at) %></li>
+        <li><strong>Files Uploaded:</strong> <%= execution.artifact['file'] %></li>
+        <li><strong>Total Test Executions:</strong> <%= execution.task.test_executions.count %></li>
+      </ul>
+    </div>
+  </div>
+  </div>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -16,7 +16,7 @@
       <tr>
         <th scope="col">Vendor</th>
 
-        <% %w(passing failing incomplete total\ products).each do |status| %>
+        <% %w(passing failing errored incomplete total\ products).each do |status| %>
           <th scope="col" class = "vendor-status text-center"><%= status.titleize %></th>
         <% end %>
 
@@ -29,7 +29,7 @@
           <th scope="row"><div class = "abbreviated"><%= link_to vendor.name, vendor_path(vendor) %></div></th>
 
           <% vendor_hash = vendor_statuses(vendor) %>
-          <% %w(passing failing incomplete total).each do |status| %>
+          <% %w(passing failing errored incomplete total).each do |status| %>
             <%= render partial: 'status_cells', locals: { status_hash: vendor_hash, status: status } %>
           <% end %>
 


### PR DESCRIPTION
# Summary:

If an exception was thrown internally during a test execution, the execution would permanently and inaccurately show as "In progress". This adds the status of "Errored" to test executions. It follows that this adds the status of "Errored" to products as well (if any tests are failing, the "Failing" status takes precedence over "Errored").

# Views:

### vendors#index
<img width="923" alt="screen shot 2016-07-14 at 12 21 04 pm" src="https://cloud.githubusercontent.com/assets/8235974/16849159/ddd56600-49be-11e6-998b-292471c3d4e8.png">

### vendors#show
<img width="851" alt="screen shot 2016-07-14 at 12 21 34 pm" src="https://cloud.githubusercontent.com/assets/8235974/16849165/e3c7eb8c-49be-11e6-9392-89f4e7b818bc.png">

### product#show
<img width="680" alt="screen shot 2016-07-14 at 12 13 04 pm" src="https://cloud.githubusercontent.com/assets/8235974/16849179/f26ff814-49be-11e6-9570-7bac3ac4d2f1.png">
<img width="1111" alt="screen shot 2016-07-14 at 12 21 59 pm" src="https://cloud.githubusercontent.com/assets/8235974/16849172/eb006e74-49be-11e6-9f5c-f4b2ebcad2ce.png">

### test_executions#show
<img width="919" alt="screen shot 2016-07-14 at 12 17 44 pm" src="https://cloud.githubusercontent.com/assets/8235974/16849181/f51342d8-49be-11e6-8587-d5bb71865190.png">
