### PR TITLE
q, y, g, j, and p are no longer cut off in vendor and product show pages

### DIFF
--- a/app/assets/stylesheets/cypress/_text.scss
+++ b/app/assets/stylesheets/cypress/_text.scss
@@ -3,6 +3,7 @@ a.label {
 }
 
 .summary-title {
+  line-height: normal;
   margin-top: 10px;
   max-width: 30em;
   white-space: nowrap;


### PR DESCRIPTION
![screen shot 2016-07-14 at 1 46 29 pm](https://cloud.githubusercontent.com/assets/19916148/16849623/54909ea4-49c9-11e6-984c-cb1ea73ed180.png)
