### PR TITLE
effective date for age filter should not show time

### DIFF
--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -20,7 +20,7 @@ module FilteringTestsHelper
 
   def display_filter_title(filter_name, task)
     if filter_name == 'age'
-      display_time_to_minutes(eff_date = task.product_test.created_at.in_time_zone('Eastern Time (US & Canada)'))
+      eff_date = display_time(task.product_test.created_at.in_time_zone('Eastern Time (US & Canada)'))
       return "Age As Of #{eff_date}"
     end
 


### PR DESCRIPTION
Removes the time from the effective date for age c4 filter

Before:
![before](https://cloud.githubusercontent.com/assets/13512036/16963953/f85ed04a-4dc6-11e6-8f1f-1ef808399442.JPG)


After:
![after](https://cloud.githubusercontent.com/assets/13512036/16963950/f6c409a8-4dc6-11e6-9e6f-84eb93199de7.JPG)
