### PR TITLE
Made 3.0.0rc1 updates to cypress

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GIT
 
 GIT
   remote: https://github.com/projectcypress/health-data-standards.git
-  revision: 6faa02a927c772ec2d8e5f64e0e3ed63f47a80b6
+  revision: 7fdd3a4e4aa644f1ebe229d579e0b6826709012d
   branch: mongoid5
   specs:
     health-data-standards (3.6.1)
@@ -252,8 +252,9 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     modernizr-rails (2.7.1)
-    mongo (2.2.5)
+    mongo (2.2.6)
       bson (~> 4.0)
+      pry
     mongoid (5.0.2)
       activemodel (~> 4.0)
       mongo (~> 2.1)

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -3,7 +3,7 @@ effective_date:
   month: 12
   day: 31
 
-version: 3.0.0beta2
+version: 3.0.0
 
 default_bundle: "2016.0.0"
 
@@ -22,9 +22,9 @@ version_config:
   '~>2016.0.0':
       schematron: "2016.0.0"
       qrda_version: "r3_1"
-      CMSQRDA3SchematronValidator_warnings: 
-      CMSQRDA1HQRSchematronValidator_warnings: 
-      CMSQRDA1PQRSSchematronValidator_warnings: 
+      CMSQRDA3SchematronValidator_warnings:
+      CMSQRDA1HQRSchematronValidator_warnings:
+      CMSQRDA1PQRSSchematronValidator_warnings:
         - "These schematrons haven't been finalized yet"
 
 enable_logging: false

--- a/contrib/cvu.json
+++ b/contrib/cvu.json
@@ -20,7 +20,7 @@
       "subnet_id": "{{user `subnet_id`}}",
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
-      "ami_name": "cvu_3.0.0beta2",
+      "ami_name": "cvu_3.0.0rc1",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 20,
@@ -34,7 +34,7 @@
     },
     {
       "name": "cvu.v3.0.0.ovf",
-      "vm_name": "cvuv300beta2",
+      "vm_name": "cvuv300rc1",
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
       "iso_urls": [

--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -20,7 +20,7 @@
       "subnet_id": "{{user `subnet_id`}}",
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
-      "ami_name": "cypress_3.0.0beta2",
+      "ami_name": "cypress_3.0.0rc1",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 20,
@@ -34,7 +34,7 @@
     },
     {
       "name": "cypress.v3.0.0.ovf",
-      "vm_name": "cypressv300beta2",
+      "vm_name": "cypressv300rc1",
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
       "iso_urls": [


### PR DESCRIPTION
* Bumped version number in `config/cypress.yml` (note: we are deliberately skipping the 'rc1' label here, so we don't forget to remove it for the production release)
* Bumped AMI/VM names in `contrib/*.json`
* Bumped the HDS commit to the latest from `mongoid5`, after cherry-picking changes onto it from master
