### PR TITLE
Add logging functionality for Delayed::Job

### DIFF
--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,0 +1,3 @@
+Delayed::Worker.logger = Logger.new(Rails.root.join('log', 'delayed_job.log'))
+Delayed::Worker.logger.level = Logger::WARN
+Delayed::Worker.destroy_failed_jobs = false


### PR DESCRIPTION
Delayed::Job now logs `:warn` and higher to `log/delayed_job.log`

Also, don't delete broken Delayed::Job jobs on failure, so they can be investigated.