### PR TITLE
Example Patient Finder uses MSRPOPL instead of DENOM as appropriate

### DIFF
--- a/lib/cypress/example_patient_finder.rb
+++ b/lib/cypress/example_patient_finder.rb
@@ -2,21 +2,26 @@ module Cypress
   class ExamplePatientFinder
     def self.find_example_patient(measure)
       measure = Measure.find_by name: measure.name
-      records = Bundle.default.records
-      lowest = 100
-      example = nil
-      records.each do |patient|
-        result_value = patient.calculation_results.where('value.measure_id' => measure.hqmf_id).where('value.sub_id' => measure.sub_id)
-        match_ipp = get_result_value(result_value, 'DENOM')
-        next unless match_ipp && match_ipp > 0
+      populations = measure.continuous_variable ? %w(IPP MSRPOPL MSRPOPLEX OBSERV) : %w(IPP DENOM NUMER DENEX DENEXCEP)
+      example_patient = example_patient_by_pop(measure, populations, populations[1])
+      !example_patient.nil? ? example_patient : example_patient_by_pop(measure, populations, 'IPP')
+    end
+
+    def self.example_patient_by_pop(measure, populations, pop)
+      simplest = 100
+      example_patient = nil
+      Bundle.default.records.each do |record|
+        result_value = record.calculation_results.where('value.measure_id' => measure.hqmf_id).where('value.sub_id' => measure.sub_id)
+        match = get_result_value(result_value, pop)
+        next unless match && match > 0
         count = population_matches_for_patient(result_value, measure)
-        return patient if count == 1
-        if count < lowest
-          lowest = count
-          example = patient
+        return record if count == 1 || count == 2
+        if count < simplest
+          simplest = count
+          example_patient = record
         end
       end
-      example
+      example_patient
     end
 
     def self.get_result_value(result_value, population)


### PR DESCRIPTION
and defaults to IPP