### PR TITLE
Point packer to RC1, dynamically set version (as allowed in new chef recipe).

### DIFF
--- a/contrib/cvu.json
+++ b/contrib/cvu.json
@@ -107,7 +107,12 @@
   {
     "type": "chef-solo",
     "cookbook_paths": ["cookbooks"],
-    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::install_cvu]" ]
+    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::install_cvu]" ],
+    "json": {
+      "cypress": {
+          "generate_secrets_on_restart": true
+      }
+    }
   },
   {
     "type": "shell",

--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -107,7 +107,13 @@
   {
     "type": "chef-solo",
     "cookbook_paths": ["cookbooks"],
-    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::install_cypress]" ]
+    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::install_cypress]" ],
+    "json": {
+      "cypress": {
+          "cypress_git_revision": "v3.0.0rc1",
+          "generate_secrets_on_restart": true
+      }
+    }
   },
   {
     "type": "shell",

--- a/contrib/cypress_cvu.json
+++ b/contrib/cypress_cvu.json
@@ -20,7 +20,7 @@
       "subnet_id": "{{user `subnet_id`}}",
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
-      "ami_name": "cypress_cvu_3.0.0beta2",
+      "ami_name": "cypress_cvu_3.0.0rc1",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 20,
@@ -34,7 +34,7 @@
     },
     {
       "name": "cypress.cvu.v3.0.0.ovf",
-      "vm_name": "cypresscvuv300beta2",
+      "vm_name": "cypresscvuv300rc1",
       "type": "virtualbox-iso",
       "guest_os_type": "Ubuntu_64",
       "iso_urls": [
@@ -107,7 +107,13 @@
   {
     "type": "chef-solo",
     "cookbook_paths": ["cookbooks"],
-    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::default]" ]
+    "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::default]" ],
+    "json": {
+      "cypress": {
+          "cypress_git_revision": "v3.0.0rc1",
+          "generate_secrets_on_restart": true
+      }
+    }
   },
   {
     "type": "shell",


### PR DESCRIPTION
This PR makes use of the new option in our chef recipe to regenerate the secret_key_base on first boot in order to remove that step from the instructions. Also it updates to rc1.