### PR TITLE
fix file type check

### DIFF
--- a/app/helpers/xml_view_helper.rb
+++ b/app/helpers/xml_view_helper.rb
@@ -63,7 +63,7 @@ module XmlViewHelper
   end
 
   def get_file(artifact, file_name)
-    artifact.content_type == 'text/xml' ? data_to_doc(artifact.get_file(file_name)) : data_to_doc(artifact.get_archived_file(file_name))
+    data_to_doc(artifact.get_file(file_name))
   end
 
   # used for errors popup in node partial


### PR DESCRIPTION
originally the code checked only for content_type = text/xml, but there are multiple content types for xml (notably application/xml).
more importantly the artifact.get_file method already does the check to see if it's an archive so we don't need to duplicate that here