### PR TITLE
allows symbols (e.g. ) in file names for QRDA uploads

### DIFF
--- a/app/helpers/xml_view_helper.rb
+++ b/app/helpers/xml_view_helper.rb
@@ -45,20 +45,16 @@ module XmlViewHelper
     collected_errors = { nonfile: get_nonfile_errors(execution), files: {} }
     execution.artifact.file_names.each do |this_name|
       file_error_hash = {}
-      all_errs = execution.execution_errors.by_file(this_name)
+      all_errs = execution.execution_errors.by_file(this_name.force_encoding('UTF-8'))
       related_errs = execution.sibling_execution ? execution.sibling_execution.execution_errors.by_file(this_name) : [] # c3
-
       next unless (all_errs.count + related_errs.count) > 0
       doc = get_file(execution.artifact, this_name)
-
       file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
       file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
       file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : { execution_errors: [] }
       file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : { execution_errors: [] }
-
       collected_errors[:files][this_name] = file_error_hash
     end
-
     collected_errors
   end
 

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -71,9 +71,11 @@ class Artifact
   #
   def get_archived_file(name)
     data = nil
+    encoding = name.encoding
     Zip::ZipFile.open(file.path) do |zipfile|
-      data = zipfile.read(name)
+      data = zipfile.read(name.force_encoding('ASCII-8BIT'))
     end
+    name.force_encoding(encoding)
     data
   end
 


### PR DESCRIPTION
some symbols caused problems with ASCII-8BIT versus UTF-8 in string comparisons.
previously these files just didn't show up in the list, even when there were errors