### PR TITLE
Refactor Manual Entry with Many Measures

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -17,7 +17,7 @@ module Admin
       @user = User.find(params[:id])
       @user.roles = []
       @user.add_role params[:role]
-      @user.email = params[:user][:email] if params[:user][:email]
+      @user.email = params[:user][:email] if params[:user] && params[:user][:email]
       assignments = params[:assignments].values if params[:assignments]
       (assignments || []).each do |ass|
         @user.add_role(ass[:role], Vendor.find(ass[:vendor_id]))

--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -2,6 +2,7 @@ class ChecklistTestsController < ProductTestsController
   include HealthDataStandards::Export::Helper::ScoopedViewHelper
 
   before_action :set_measures, only: [:show]
+  before_action :set_measure, only: [:measure]
   respond_to :js, only: [:show]
 
   def create
@@ -39,6 +40,12 @@ class ChecklistTestsController < ProductTestsController
     end
   end
 
+  def measure
+    @product = @product_test.product
+    set_breadcrumbs
+    add_breadcrumb "Measure: #{@measure.cms_id}", measure_checklist_test_path(@product_test, @measure)
+  end
+
   def print_criteria
     criteria_list = render_to_string layout: 'report'
     zip = Cypress::CreateDownloadZip.create_c1_criteria_zip(@product.product_tests.checklist_tests.first, criteria_list).read
@@ -56,6 +63,10 @@ class ChecklistTestsController < ProductTestsController
 
   def set_measures
     @measures = @product_test.measures.sort_by(&:cms_int)
+  end
+
+  def set_measure
+    @measure = Measure.find_by(_id: params[:measure_id])
   end
 
   def checklist_test_params

--- a/app/controllers/product_tests_controller.rb
+++ b/app/controllers/product_tests_controller.rb
@@ -1,8 +1,8 @@
 class ProductTestsController < ApplicationController
   include API::Controller
 
-  before_action :set_product, except: [:show, :patients]
-  before_action :set_product_test, only: [:show, :update, :destroy, :patients]
+  before_action :set_product, except: [:show, :patients, :measure]
+  before_action :set_product_test, only: [:show, :update, :destroy, :patients, :measure]
   before_action :authorize_vendor
 
   def index

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -1,8 +1,13 @@
 <%
 
-# local variable 'product'
+# local variables:
+#
+#   product           (Product)
+#   has_many_measures (bool)    [optional]
 
 %>
+
+<% has_many_measures ||= false %>
 
 <% checklist_test = product.product_tests.checklist_tests.first %>
 <% return unless checklist_test %>
@@ -21,8 +26,9 @@
   </thead>
   <tbody>
     <% checklist_test.measures.sort_by(&:cms_int).each do |measure| %>
+      <% link_path = has_many_measures ? measure_checklist_test_path(checklist_test, measure) : product_checklist_test_path(@product, checklist_test, anchor: "#{measure.cms_id}") %>
       <tr>
-        <td><%= link_to "#{measure.cms_id} #{measure.name}", product_checklist_test_path(@product, checklist_test, anchor: "#{measure.cms_id}") %></td>
+        <td><%= link_to "#{measure.cms_id} #{measure.name}", link_path %></td>
         <td class="no-wrap">
           <% case checklist_test.measure_status(measure.id) %>
           <% when 'passed' %>

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -1,0 +1,128 @@
+<%
+
+# local variables:
+#
+#   product      (Product)
+#   product_test (ChecklistTest)
+#   measure      (Measure)       should be a measure that belongs to the checklist test
+
+%>
+
+<%= bootstrap_nested_form_for([product, product_test], :url => { :controller => 'checklist_tests', :action => 'update' }) do |f| %>
+  <div class = 'panel-group' id = '<%= measure.cms_id %>' disabled = true>
+    <div class = 'panel panel-default'>
+      <div class = 'panel-heading'>
+        <h1 class='panel-title'>
+          <%= "#{measure.cms_id} #{measure.name}" %>
+        </h1>
+      </div>
+      <div class = 'panel-body'>
+        <div class = 'checklist-panel'>
+          <table class = 'table table-condensed'>
+            <thead>
+              <tr>
+                <th class = 'col-sm-1' scope = 'col'>Validated in QRDA</th>
+                <th class = 'col-sm-2' scope = 'col'>Data Criteria</th>
+                <th class = 'col-sm-1' scope = 'col'>Section</th>
+                <th class = 'col-sm-1' scope = 'col'>Required Attributes</th>
+                <th class = 'col-sm-3' scope = 'col'>Value Set(s)</th>
+                <th class = 'col-sm-3' scope = 'col'>Recorded Code/Attribute Value</th>
+                <th>
+              </tr>
+            </thead>
+            <tbody>
+              <%= f.fields_for :checked_criteria, product_test.checked_criteria.all(measure_id: measure.id) do |criteria_field| %>
+                <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
+                <% if criteria.has_key?('description') %>
+                  <tr>
+                    <td rowspan="3">
+                      <% if criteria_field.object.passed_qrda %>
+                        <span class="sr-only">Passes QRDA</span>
+                        <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                      <% else %>
+                        <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                      <% end %>
+                    </td>
+                    <% valuessets = criteria_field.object.get_all_valuesets_for_dc(measure) %>
+                    <% if valuessets.empty? %>
+                      <td rowspan="3"/>
+                      <tr>
+                        <td/>
+                      <td/>
+                      <td/>
+                    </tr>
+                    <% else %>
+                      <td rowspan="3"><%= criteria[:description].chomp(': ' + criteria[:title]) %></td>
+                      <tr>
+                      <td> <strong>Valuesets</strong> </td>
+                      <td/>
+                      <td><span>
+                        <ul class='list-unstyled'>
+                        <% valuessets.each do |vs| %>
+                        <li class="valueset-listitem"><%= "#{lookup_valueset_name(vs)}" %></li>
+                        <% end %>
+                        </ul>
+                      </span></td>
+                      <td>
+                        <% if criteria_field.object.complete?.nil? %>
+                          <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                        <% elsif criteria_field.object.code_complete %>
+                          <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                        <% else %>
+                          <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                        <% end %>
+                        <%= criteria_field.text_field :code, hide_label: false %>
+                      </td>
+                    </tr>
+                    <% end %>
+                    <tr>
+                      <td> <strong> Attributes </strong> </td>
+                    <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
+                    <td><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value']} if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %></td>
+                    <% if coded_attribute?(criteria) %>
+                      <td>
+                        <% if criteria_field.object.complete?.nil? %>
+                          <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                        <% elsif criteria_field.object.attribute_complete %>
+                          <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                        <% else %>
+                          <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                        <% end %>
+                        <%= criteria_field.text_field :attribute_code, hide_label: false %>
+                      </td>
+                    <% elsif criteria['value'] && criteria['value'].type != 'CD' || criteria['field_values'] %>
+                      <td>
+                        <% if criteria_field.object.complete?.nil? %>
+                          <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                        <% elsif criteria_field.object.result_complete %>
+                          <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                        <% else %>
+                          <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                        <% end %>
+                        <%= criteria_field.text_field :recorded_result, hide_label: false %>
+                      </td>
+                    <% else %>
+                      </td>
+                    <% end %>
+                  </tr>
+                  </tr>
+                <% end %>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+        <% if product_test.status != 'passing' %>
+          <div class = 'panel-footer'>
+            <%= f.submit 'Save', class: 'btn btn-default' %>
+            <span class = 'small-indent'></span>
+          </div>
+        <% else %>
+          <div class = 'panel-footer'>
+            <%= f.submit 'Save', class: 'btn btn-danger', disabled: true %>
+            <span class = 'small-indent'></span>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/checklist_tests/_checklist_measures.html.erb
+++ b/app/views/checklist_tests/_checklist_measures.html.erb
@@ -1,136 +1,16 @@
+
 <% if @product_test.tasks[0].most_recent_execution && @product_test.tasks[0].most_recent_execution.incomplete? %>
-<script>
-  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_measures' }});
-</script>
+  <script>
+    $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_measures' }});
+  </script>
 <% end %>
-<div id='save_options' >
-  <% unless product_test.status != 'passing' %>
-                  <%= render :partial => 'alert', locals: {
-                                                  alert_type: 'warning',
-                                                  messages: 'Saving this checklist will overide previous results.',
-                                                  confirmation: 'Yes, let me save this checklist' } %>
-<% end %>
-<% measures = product_test.measures %>
-<% if measures %>
-  <%= bootstrap_nested_form_for([product, product_test], :url => { :controller => 'checklist_tests', :action => 'update' }) do |f| %>
-    <% measures.sort_by(&:cms_int).each do |measure| %>
-      <div class = 'panel-group' id = '<%= measure.cms_id %>' disabled = true>
-        <div class = 'panel panel-default'>
-          <div class = 'panel-heading'>
-            <h1 class='panel-title'>
-              <%= "#{measure.cms_id} #{measure.name}" %>
-            </h1>
-          </div>
-          <div class = 'panel-body'>
-            <div class = 'checklist-panel'>
-              <table class = 'table table-condensed'>
-                <thead>
-                  <tr>
-                    <th class = 'col-sm-1' scope = 'col'>Validated in QRDA</th>
-                    <th class = 'col-sm-2' scope = 'col'>Data Criteria</th>
-                    <th class = 'col-sm-1' scope = 'col'>Section</th>
-                    <th class = 'col-sm-1' scope = 'col'>Required Attributes</th>
-                    <th class = 'col-sm-3' scope = 'col'>Value Set(s)</th>
-                    <th class = 'col-sm-3' scope = 'col'>Recorded Code/Attribute Value</th>
-                    <th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <%= f.fields_for :checked_criteria, product_test.checked_criteria.all(measure_id: measure.id) do |criteria_field| %>
-                    <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
-                    <% if criteria.has_key?('description') %>
-                      <tr>
-                        <td rowspan="3">
-                          <% if criteria_field.object.passed_qrda %>
-                            <span class="sr-only">Passes QRDA</span>
-                            <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-                          <% else %>
-                            <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-                          <% end %>
-                        </td>
-                        <% valuessets = criteria_field.object.get_all_valuesets_for_dc(measure) %>
-                        <% if valuessets.empty? %>
-                          <td rowspan="3"/>
-                          <tr>
-                            <td/>
-                          <td/>
-                          <td/>
-                        </tr>
-                        <% else %>
-                          <td rowspan="3"><%= criteria[:description].chomp(': ' + criteria[:title]) %></td>
-                          <tr>
-                          <td> <strong>Valuesets</strong> </td>
-                          <td/>
-                          <td><span>
-                            <ul class='list-unstyled'>
-                            <% valuessets.each do |vs| %>
-                            <li class="valueset-listitem"><%= "#{lookup_valueset_name(vs)}" %></li>
-                            <% end %>
-                            </ul>
-                          </span></td>
-                          <td>
-                            <% if criteria_field.object.complete?.nil? %>
-                              <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-                            <% elsif criteria_field.object.code_complete %>
-                              <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-                            <% else %>
-                              <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
-                            <% end %>
-                            <%= criteria_field.text_field :code, hide_label: false %>
-                          </td>
-                        </tr>
-                        <% end %>
-                        <tr>
-                          <td> <strong> Attributes </strong> </td>
-                        <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
-                        <td><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value']} if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %></td>
-                        <% if coded_attribute?(criteria) %>
-                          <td>
-                            <% if criteria_field.object.complete?.nil? %>
-                              <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-                            <% elsif criteria_field.object.attribute_complete %>
-                              <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-                            <% else %>
-                              <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
-                            <% end %>
-                            <%= criteria_field.text_field :attribute_code, hide_label: false %>
-                          </td>
-                        <% elsif criteria['value'] && criteria['value'].type != 'CD' || criteria['field_values'] %>
-                          <td>
-                            <% if criteria_field.object.complete?.nil? %>
-                              <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
-                            <% elsif criteria_field.object.result_complete %>
-                              <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
-                            <% else %>
-                              <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
-                            <% end %>
-                            <%= criteria_field.text_field :recorded_result, hide_label: false %>
-                          </td>
-                        <% else %>
-                          </td>
-                        <% end %>
-                      </tr>
-                      </tr>
-                    <% end %>
-                  <% end %>
-                </tbody>
-              </table>
-            </div>
-            <% if product_test.status != 'passing' %>
-              <div class = 'panel-footer'>
-                <%= f.submit 'Save', class: 'btn btn-default' %>
-                <span class = 'small-indent'>This saves the entire Manual Entry Test page</span>
-              </div>
-            <% else %>
-              <div class = 'panel-footer'>
-                <%= f.submit 'Save', class: 'btn btn-danger', disabled: true %>
-                <span class = 'small-indent'>This saves the entire Manual Entry Test page, and will override previous results</span>
-              </div>
-            <% end %>
-          </div>
-        </div>
-      </div>
-    <% end %>
+
+<div id='save_options'>
+  <% unless @product_test.status != 'passing' %>
+    <%= render :partial => 'alert', locals: { alert_type: 'warning', messages: 'Saving this checklist will overide previous results.', confirmation: 'Yes, let me save this checklist' } %>
   <% end %>
-<% end %>
 </div>
+
+<% @product_test.measures.sort_by(&:cms_int).each do |measure| %>
+  <%= render partial: 'checklist_measure', locals: { product: @product_test.product, product_test: @product_test, measure: measure } %>
+<% end %>

--- a/app/views/checklist_tests/measure.html.erb
+++ b/app/views/checklist_tests/measure.html.erb
@@ -1,0 +1,25 @@
+<% product = @product_test.product %>
+
+<%= render partial: 'application/certification_bar', locals: { product: product, active_certs: [true, false, product.c3_test, false] } %>
+
+<br/>
+<%= link_to(product_checklist_test_path(@product, @product_test), class: 'btn btn-primary') do %>
+  <i class = 'fa fa-fw fa-angle-left' aria-hidden = 'true'></i>Return to Manual Entry Test
+<% end %>
+
+<div class = 'test-steps'>
+  <div class="panel panel-info">
+    <div class="panel-heading">
+      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Checklist Instructions</h1>
+    </div>
+    <%= render partial: 'checklist_instructions', locals: { instructions: APP_CONFIG['tests']['ChecklistTest']['instructions'] } %>
+  </div>
+</div>
+
+<div id='save_options'>
+  <% unless @product_test.status != 'passing' %>
+    <%= render :partial => 'alert', locals: { alert_type: 'warning', messages: 'Saving this checklist will overide previous results.', confirmation: 'Yes, let me save this checklist' } %>
+  <% end %>
+</div>
+
+<%= render partial: 'checklist_measure', locals: { product: @product_test.product, product_test: @product_test, measure: @measure } %>

--- a/app/views/checklist_tests/show.html.erb
+++ b/app/views/checklist_tests/show.html.erb
@@ -1,4 +1,6 @@
 <% product = @product %>
+<% has_many_measures = @product_test.measures.count > CAT1_CONFIG['number_of_checklist_measures'] %>
+
 <%= render partial: 'application/certification_bar', locals: { product: product, active_certs: [true, false, product.c3_test, false] } %>
 
 <div class="panel-actions pull-right">
@@ -7,43 +9,45 @@
   <% end %>
 </div>
 <h1>Manual Entry Test</h1>
-  <div class = 'test-steps'>
-    <div class="panel panel-info">
-      <div class="panel-heading">
-        <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Manual Entry Instructions</h1>
-      </div>
-      <%= render partial: 'checklist_instructions', locals: { instructions: APP_CONFIG['tests']['ChecklistTest']['instructions'] } %>
+<div class = 'test-steps'>
+  <div class="panel panel-info">
+    <div class="panel-heading">
+      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Manual Entry Instructions</h1>
+    </div>
+    <%= render partial: 'checklist_instructions', locals: { instructions: APP_CONFIG['tests']['ChecklistTest']['instructions'] } %>
+  </div>
+</div>
+<div class = 'test-steps'>
+  <div class="panel panel-info">
+    <div class="panel-heading disable">
+      <h1 class="panel-title test-step disable">
+        <%= 2 %> <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= 'Upload Files' %>
+      </h1>
+    </div>
+    <div class="panel-body">
+      <%= render partial: 'test_executions/execution_upload', locals: { disable: disable_qrda_submission?, product_test: @product_test, task: @product_test.tasks.c1_manual_task } %>
     </div>
   </div>
-  <div class = 'test-steps'>
-    <div class="panel panel-info">
-      <div class="panel-heading disable">
-        <h1 class="panel-title test-step disable">
-          <%= 2 %> <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= 'Upload Files' %>
-        </h1>
+</div>
+<div class = 'test-steps'>
+  <div class = 'panel panel-info'>
+    <div class = 'panel-heading'>
+      <h1 class = 'panel-title test-step'>
+        3 <i class = 'fa fa-fw fa-bolt' aria-hidden = 'true'></i> View Results
+      </h1>
+    </div>
+    <div class = 'panel-body'>
+      <div id = 'display_checklist_status' >
+        <%= render partial: 'checklist_status_display', locals: { product: product, has_many_measures: has_many_measures } %>
       </div>
-      <div class="panel-body">
-        <%= render partial: 'test_executions/execution_upload', locals: { disable: disable_qrda_submission?, product_test: @product_test, task: @product_test.tasks.c1_manual_task } %>
+      <div id = 'display_checklist_execution_results'>
+        <%= render partial: 'checklist_execution_results', locals: { task: @product_test.tasks.c1_manual_task } %>
       </div>
     </div>
   </div>
-  <div class = 'test-steps'>
-    <div class = 'panel panel-info'>
-      <div class = 'panel-heading'>
-        <h1 class = 'panel-title test-step'>
-          3 <i class = 'fa fa-fw fa-bolt' aria-hidden = 'true'></i> View Results
-        </h1>
-      </div>
-      <div class = 'panel-body'>
-        <div id = 'display_checklist_status' >
-          <%= render partial: 'checklist_status_display', locals: { product: product } %>
-        </div>
-        <div id = 'display_checklist_execution_results'>
-          <%= render partial: 'checklist_execution_results', locals: { task: @product_test.tasks.c1_manual_task } %>
-        </div>
-      </div>
-    </div>
-  </div>
+</div>
+<% unless has_many_measures %>
   <div id = 'display_checklist_measures' >
     <%= render partial: 'checklist_measures', locals: { product_test: @product_test, product: @product_test.product } %>
   </div>
+<% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -32,7 +32,10 @@
 
       <% # Manual Entry Tab %>
       <% if test_type == 'ChecklistTest' %>
-        <%= render partial: 'checklist_status_display', locals: { product: @product } %>
+        <% checklist_test = @product.product_tests.checklist_tests.first %>
+        <%= button_to 'View Manual Entry', product_checklist_test_path(@product, checklist_test), class: 'btn btn-primary', method: :get %><p></p>
+        <% has_many_measures = checklist_test.measures.count > CAT1_CONFIG['number_of_checklist_measures'] %>
+        <%= render partial: 'checklist_status_display', locals: { product: @product, has_many_measures: has_many_measures } %>
         <div id = 'display_checklist_execution_results'>
           <%= render partial: 'checklist_execution_results', locals: { task: @product.product_tests.checklist_tests.first.tasks.c1_manual_task } %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,12 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :checklist_tests, only: [:create, :show, :update, :destroy] do
+    member do
+      get 'measure/:measure_id', action: 'measure', as: 'measure'
+    end
+  end
+
   resources :product_tests, only: [:show] do
     member do
       get :patients

--- a/features/checklist_tests/show.feature
+++ b/features/checklist_tests/show.feature
@@ -80,3 +80,9 @@ Scenario: Upload Cat I with QRDA Error on C3 Manual Task Execution but Valid Sou
   Then the user should see they are passing the manual entry test
   And the user should see upload results for c1, c3 certifications
   And the user should see failing for upload results
+
+Scenario: Viewing an Individual Measure for Checklist Test
+  When the user creates a product that certifies c1, c3 and visits the manual entry page
+  And the user fills out the manual entry with good data
+  And the user visits the individual measure checklist page for measure 1
+  Then the user should see the individual measure checklist page for measure 1

--- a/features/step_definitions/checklist_test.rb
+++ b/features/step_definitions/checklist_test.rb
@@ -117,6 +117,15 @@ def wait_for_all_delayed_jobs_to_run
   end
 end
 
+When(/^the user visits the individual measure checklist page for measure (.*)$/) do |measure_number|
+  measure = nth_measure(measure_number)
+  visit measure_checklist_test_path(@test, measure)
+end
+
+def nth_measure(measure_number)
+  @test.measures.sort { |x, y| x.created_at <=> y.created_at }[measure_number.to_i - 1]
+end
+
 # # # # # # # #
 #   T H E N   #
 # # # # # # # #
@@ -184,4 +193,11 @@ def task_status_to_execution_status_message(task_status)
   when 'incomplete'
     'Not Started'
   end
+end
+
+Then(/^the user should see the individual measure checklist page for measure (.*)$/) do |measure_number|
+  measure = nth_measure(measure_number)
+  page.assert_text(measure.cms_id)
+  page.assert_text(measure.name)
+  page.assert_text 'Return to Manual Entry Test'
 end

--- a/test/controllers/checklist_tests_controller_test.rb
+++ b/test/controllers/checklist_tests_controller_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+class ChecklistTestsControllerTest < ActionController::TestCase
+  include Devise::TestHelpers
+  include ActiveJob::TestHelper
+
+  setup do
+    collection_fixtures('vendors', 'products', 'product_tests', 'users', 'roles', 'bundles', 'measures')
+    @vendor = Vendor.find(EHR1)
+    @product = @vendor.products.find('4f57a88a1d41c851eb000004')
+    @test = @product.product_tests.find('4f58f8de1d41c851eb000478')
+    @test['_type'] = MeasureTest # each measure test should have a _type of MeasureTest and cms_id
+    @test['cms_id'] = 'CMS001'
+    @test.save!
+  end
+
+  test 'should be able to view measure' do
+    measure_ids = ['40280381-4B9A-3825-014B-C1A59E160733']
+    product = @vendor.products.create!(name: "my product #{rand}", c1_test: true, bundle_id: '4fdb62e01d41c820f6000001', measure_ids: measure_ids)
+    product.product_tests.create!({ name: "my measure test #{rand}", measure_ids: measure_ids }, MeasureTest)
+    checklist_test = product.product_tests.create!({ name: "my measure test #{rand}", measure_ids: measure_ids }, ChecklistTest)
+    measure = checklist_test.measures.first
+
+    # admin, atl, owner, and user should have access to view measure for checklist test
+    for_each_logged_in_user([ADMIN, ATL, OWNER, USER]) do
+      get :measure, :id => checklist_test.id, :measure_id => measure.id, :format => :format_does_not_matter
+      assert_response :success, "#{@user.email} should have access. response was #{response.status}"
+      assert_not_nil assigns(:measure)
+      assert_not_nil assigns(:product_test)
+      # assert_equal 'application/zip', response.headers['Content-Type']
+    end
+
+    # vendor and other vendor should not have access to view measure for checklist test
+    for_each_logged_in_user([VENDOR, OTHER_VENDOR]) do
+      get :measure, :id => checklist_test.id, :measure_id => measure.id, :format => :format_does_not_matter
+      assert_response :unauthorized, "#{@user.email} should not have access. response was #{response.status}"
+    end
+  end
+end


### PR DESCRIPTION
- added individual measure page for checklist test
- users are directed to individual measure pages if there are more than four measures for a manual entry test (done to reduces load time of checklist test show page)
- added test for `measure()` action on checklist test controller

if there are four or less manual measures on product show page:
<img width="1125" alt="used_to_look_like" src="https://cloud.githubusercontent.com/assets/14349011/17148366/e78aed80-5334-11e6-825f-09c7d9a5fb11.png">

if there are more than four manual measures on a product show page:
<img width="1138" alt="product_show" src="https://cloud.githubusercontent.com/assets/14349011/17148403/0e0e2706-5335-11e6-908e-43fb638e766c.png">

checklist show page with many measures does not show manual entry section:
<img width="1127" alt="checklist_test_show" src="https://cloud.githubusercontent.com/assets/14349011/17148416/1e81b8fa-5335-11e6-9df3-597c5dad89f5.png">

view an individual measure for manual entry:
<img width="1122" alt="individual_measure" src="https://cloud.githubusercontent.com/assets/14349011/17148442/356945ce-5335-11e6-8bde-ac6a5eb01f82.png">
