### PR TITLE
Handles errors from broken files better

### DIFF
--- a/app/helpers/xml_view_helper.rb
+++ b/app/helpers/xml_view_helper.rb
@@ -44,22 +44,28 @@ module XmlViewHelper
     # gonna return all the errors for this execution, structured in a reasonable way.
     collected_errors = { nonfile: get_nonfile_errors(execution), files: {} }
     execution.artifact.file_names.each do |this_name|
-      file_error_hash = {}
       all_errs = execution.execution_errors.by_file(this_name.force_encoding('UTF-8'))
       related_errs = execution.sibling_execution ? execution.sibling_execution.execution_errors.by_file(this_name) : [] # c3
       next unless (all_errs.count + related_errs.count) > 0
       doc = get_file(execution.artifact, this_name)
-      file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
-      file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
-      file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : { execution_errors: [] }
-      file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : { execution_errors: [] }
-      collected_errors[:files][this_name] = file_error_hash
+      collected_errors[:files][this_name] = create_file_error_hash(doc, all_errs, related_errs)
     end
     collected_errors
+  rescue => e
+    { nonfile: [], files: {}, exception: e }
   end
 
   def get_file(artifact, file_name)
     data_to_doc(artifact.get_file(file_name))
+  end
+
+  def create_file_error_hash(doc, all_errs, related_errs)
+    file_error_hash = {}
+    file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
+    file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
+    file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : { execution_errors: [] }
+    file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : { execution_errors: [] }
+    file_error_hash
   end
 
   # used for errors popup in node partial

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -17,6 +17,7 @@ class Artifact
   before_save :update_asset_attributes
 
   def correct_file_type
+    return unless file_changed?
     content_extension = file.content_type ? MIME_FILE_TYPES[file.content_type] : nil
     case content_extension
     when :zip

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -21,7 +21,7 @@
     <% [execution, execution.sibling_execution].compact.each do |ex| %>
       <% ex_type = ex.task._type[0, 2] # get first two letters e.g. C1 or C3 %>
       <% if ex.errored? %>
-        <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occured</p>
+        <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occurred</p>
       <% elsif ex.passing? %>
         <%= render partial: 'test_executions/results/passing_result', locals: { execution: ex, execution_type: ex_type } %>
       <% elsif ex.failing? %>
@@ -39,6 +39,12 @@
   <% end %>
 
   <% collected_errors = collected_errors(execution) %>
+
+  <% if collected_errors[:exception] %>
+    <h2>An internal error occurred when loading this page</h2>
+    <p><%= collected_errors[:exception] %></p>
+    <span class="help-block">Please report this issue to the Cypress team at <a href="https://github.com/projectcypress/cypress/issues" target="_blank">https://github.com/projectcypress/cypress/issues</a> and include: the uploaded file, the measure being tested, and the error message received.</span>
+  <% end %>
 
   <% if collected_errors.nonfile.count > 0 %>
     <h2>Missing or Duplicate Files</h2>


### PR DESCRIPTION
When uploading a bad file (for example some other file type renamed to .zip), the test execution now shows the "errored" status and a little more detail instead of spinning forever.

![errors2](https://cloud.githubusercontent.com/assets/13512036/17151866/4459eff8-5343-11e6-9de9-9bc03b1efa10.JPG)