### PR TITLE
Add polling for bundle upload status

### DIFF
--- a/app/assets/javascripts/bundles.js
+++ b/app/assets/javascripts/bundles.js
@@ -1,0 +1,11 @@
+function elementContainsText(selector, text) {
+    return $(selector).text().indexOf(text) > -1;
+}
+
+var updateBundleStatus = function() {
+  if (elementContainsText('.tracker-status', 'queued') || elementContainsText('.tracker-status', 'working')) {
+    $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'bundle_list'}});
+  }
+}
+
+$(document).on('page:change', updateBundleStatus);

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -13,58 +13,67 @@
   </thead>
   <tbody>
     <% @bundles.each do |bundle| %>
-      <tr>
-        <td> <%= bundle.title %> <%= '(Default)' if bundle.version == Settings[:default_bundle] %> </td>
-        <td class = "text-center"><%= bundle.version %></td>
-        <!--td class = "text-center">some other value</td -->
-        <td class="text-center">
+      <% unless bundle.respond_to?('done_importing') && !bundle.done_importing %>
+        <tr>
+          <td> <%= bundle.title %> <%= '(Default)' if bundle.version == Settings[:default_bundle] %> </td>
+          <td class = "text-center"><%= bundle.version %></td>
+          <td class="text-center">
 
-        <% unless @disabled %>
+            <% unless @disabled %>
 
-        <% unless bundle.version == Settings[:default_bundle] %>
-          <%= button_to "Set Default", set_default_admin_bundle_path(bundle), :method => :post, :class => "btn btn-xs btn-default" %>
-          <%= render partial: 'remove_button', locals: {
-                          button_text: 'Remove',
-                          button_classes: 'btn btn-xs btn-danger',
-                          object: bundle,
-                          object_type: 'bundle',
-                          object_name: bundle.title,
-                          object_path: admin_bundle_path(bundle),
-                          modal_message: 'Removing a bundle will also delete all associated products and test results.'
-                    } %>
-        <% end %>
-        <% end %>
-        </td>
-      </tr>
+              <% unless bundle.version == Settings[:default_bundle] %>
+                <%= button_to "Set Default", set_default_admin_bundle_path(bundle), :method => :post, :class => "btn btn-xs btn-default" %>
+                <%= render partial: 'remove_button', locals: {
+                                button_text: 'Remove',
+                                button_classes: 'btn btn-xs btn-danger',
+                                object: bundle,
+                                object_type: 'bundle',
+                                object_name: bundle.title,
+                                object_path: admin_bundle_path(bundle),
+                                modal_message: 'Removing a bundle will also delete all associated products and test results.'
+                          } %>
+              <% end %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
   </tbody>
 </table>
-
 
 <% if BundleUploadJob.trackers.count > 0  %>
-<p>
-<h1>Current Bundle Import Jobs</h1>
-<table class="table table-hover">
-  <thead>
-    <tr>
-      <th class = "col-sm-4">File</th>
-      <th class = "col-sm-4">Status</th>
-      <td class = "text-center"></td>
-      <td></td>
-    </tr>
-  </thead>
-  <tbody>
-    <% BundleUploadJob.trackers.reverse_each do |tracker| %>
-    <tr>
-      <td><%= tracker.options["original_filename"]%></td>
-      <td><%= tracker.status%></td>
-      <td><%= tracker.log_message.last%></td>
-      <td>
-        <%= link_to "", admin_tracker_path(tracker), :method => :delete, :class => "close fa fa-fw fa-close" if tracker.status == :failed %>
-      </td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+  <p>
+  <h1>Current Bundle Import Jobs</h1>
+  <table class="table table-hover">
+    <thead>
+      <tr>
+        <th class = "col-sm-4">File</th>
+        <th class = "col-sm-4">Status</th>
+        <td class = "text-center"></td>
+        <td></td>
+      </tr>
+    </thead>
+    <tbody>
+      <% BundleUploadJob.trackers.reverse_each do |tracker| %>
+      <tr>
+        <td><%= tracker.options["original_filename"]%></td>
+        <td class="tracker-status">
+          <%= tracker.status %>
+          <% if tracker.status == :working %>
+            <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i>
+          <% end %>
+        </td>
+        <td><%= tracker.log_message.last%></td>
+        <td>
+          <%= link_to "", admin_tracker_path(tracker), :method => :delete, :class => "close fa fa-fw fa-close" if tracker.status == :failed %>
+        </td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+  <% if BundleUploadJob.trackers.or({ :status => :queued }, { :status => :working }).count > 0 %>
+    <script>
+      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'bundle_list' }});
+    </script>
+  <% end %>
 <% end %>
-<%= render partial: 'remove_modal' %>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -20,8 +20,11 @@
     <%= render partial: "user_list" %>
   </div>
 
-  <div id="bundles" >
-    <%= render partial: "bundle_list"%>
+  <div id="bundles">
+    <div id="display_bundle_list" >
+      <%= render partial: "bundle_list"%>
+    </div>
+    <%= render partial: 'remove_modal' %>
   </div>
 
   <!-- <div id="application_status" >

--- a/app/views/admin/show.js.erb
+++ b/app/views/admin/show.js.erb
@@ -1,0 +1,9 @@
+<% if params[:partial] == 'bundle_list' %>
+  <% if BundleUploadJob.trackers.or({ :status => :queued }, { :status => :working }).count > 0 %>
+    setTimeout(function(){
+      $('#display_bundle_list').html("<%= escape_javascript render partial: '/admin/bundle_list' %>");
+    }, 2000);
+  <% else %>
+    $('#display_bundle_list').html("<%= escape_javascript render partial: '/admin/bundle_list' %>");
+  <% end %>
+<% end %>


### PR DESCRIPTION
## Summary
- Adds polling to asynchronously update the bundle import status. Previously, the user had to refresh the page
- Fixes a bug caused by the user removing a bundle during import by not allowing them to remove through the UI until the import is finished. **Important**: This change depends on this HDS change as well: https://github.com/projectcypress/health-data-standards/pull/412

## Views

**/admin#bundles**
Note that the bundle being imported does not show in the Installed Bundles table during import, and the live updating is indicated by a spinny wheel.

![screen shot 2016-07-26 at 3 32 05 pm](https://cloud.githubusercontent.com/assets/8235974/17152541/2fe0b6e4-5346-11e6-8da8-902508d2f8a9.png)
