### PR TITLE
download of html patients for product test

### DIFF
--- a/app/controllers/product_tests_controller.rb
+++ b/app/controllers/product_tests_controller.rb
@@ -1,8 +1,8 @@
 class ProductTestsController < ApplicationController
   include API::Controller
 
-  before_action :set_product, except: [:show, :patients, :measure]
-  before_action :set_product_test, only: [:show, :update, :destroy, :patients, :measure]
+  before_action :set_product, except: [:show, :patients, :measure, :html_patients]
+  before_action :set_product_test, only: [:show, :update, :destroy, :patients, :measure, :html_patients]
   before_action :authorize_vendor
 
   def index
@@ -18,6 +18,11 @@ class ProductTestsController < ApplicationController
   def patients
     file_name = "#{@product_test.cms_id}_#{@product_test.id}.qrda.zip".tr(' ', '_')
     send_data @product_test.patient_archive.read, type: 'application/zip', disposition: 'attachment', filename: file_name
+  end
+
+  def html_patients
+    file_name = "#{@product_test.cms_id}_#{@product_test.id}.html.zip".tr(' ', '_')
+    send_data @product_test.html_archive.read, type: 'application/zip', disposition: 'attachment', filename: file_name
   end
 
   private

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -47,6 +47,10 @@ class MeasureTest < ProductTest
     end
     Cypress::PatientZipper.zip(file, recs, :qrda)
     self.patient_archive = file
+
+    file = Tempfile.new("product_test-html-#{id}.zip")
+    Cypress::PatientZipper.zip(file, recs, :html)
+    self.html_archive = file
     save
   end
 

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/ClassLength
 class ProductTest
   include Mongoid::Document
   include Mongoid::Timestamps
@@ -31,6 +32,7 @@ class ProductTest
   validates :product, presence: true
   validates :measure_ids, presence: true
   mount_uploader :patient_archive, PatientArchiveUploader
+  mount_uploader :html_archive, PatientArchiveUploader
 
   delegate :effective_date, :to => :product
   delegate :bundle, :to => :product
@@ -63,6 +65,10 @@ class ProductTest
     file = Tempfile.new("product_test-#{id}.zip")
     Cypress::PatientZipper.zip(file, records, :qrda)
     self.patient_archive = file
+
+    file = Tempfile.new("product_test-html-#{id}.zip")
+    Cypress::PatientZipper.zip(file, records, :html)
+    self.html_archive = file
     save
   end
 

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,5 +1,8 @@
 <% if @task && @product_test %>
   <h1>Patient List</h1>
+  <%= button_to html_patients_product_test_path(@product_test), :method => :get, :class => "btn btn-default pull-right" do %>
+    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download HTML Patients
+  <% end %>
 <% else %>
   <h1>Master Patient List</h1>
 <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Rails.application.routes.draw do
   resources :product_tests, only: [:show] do
     member do
       get :patients
+      get :html_patients
     end
     resources :tasks, only: [:index, :show]
     resources :records, only: [:index, :show]

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -45,7 +45,9 @@ class MeasureTestTest < ActiveJob::TestCase
       assert pt.records.count > 0, 'product test creation should have created random number of test records'
       pt.reload
       assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
+      assert_not_nil pt.html_archive, 'Product test should have archived patient HTMLs'
       assert pt.records.count < count_zip_entries(pt.patient_archive.file.path), 'Archive should contain more files than the test'
+      assert count_zip_entries(pt.html_archive.file.path) == count_zip_entries(pt.patient_archive.file.path), 'QRDA Archive and HTML archive should have same # files'
       assert_not_nil pt.expected_results, 'Product test should have expected results'
     end
   end
@@ -68,6 +70,8 @@ class MeasureTestTest < ActiveJob::TestCase
 
       pt.reload
       assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
+      assert_not_nil pt.html_archive, 'Product test should have archived patient HTMLs'
+      assert count_zip_entries(pt.html_archive.file.path) == count_zip_entries(pt.patient_archive.file.path), 'QRDA Archive and HTML archive should have same # files'
       assert_not_nil pt.expected_results, 'Product test should have expected results'
     end
   end


### PR DESCRIPTION
Ability to download HTML versions of patients. HTML patients are created & cached alongside QRDA versions of patients in the initial setup job

![download2](https://cloud.githubusercontent.com/assets/13512036/17177484/9e4e1c2c-53df-11e6-92cc-d61cbbde00ea.JPG)
