### PR TITLE
Fix Breadcrumbs and Added Integration Tests for Tabs

### DIFF
--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -82,8 +82,7 @@ class TestExecutionsController < ApplicationController
     add_breadcrumb 'Dashboard', :vendors_path
     add_breadcrumb 'Vendor: ' + @product_test.product.vendor.name, vendor_path(@product_test.product.vendor)
     add_breadcrumb 'Product: ' + @product_test.product.name, vendor_product_path(@product_test.product.vendor, @product_test.product)
-    add_breadcrumb 'Checklist Dashboard: ' + @product_test.name, product_checklist_test_path(@product_test.product,
-                                                                                             @product_test) if @product_test._type == 'ChecklistTest'
+    add_breadcrumb 'Manual Entry Test', product_checklist_test_path(@product_test.product, @product_test) if @product_test._type == 'ChecklistTest'
     add_test_execution_breadcrumb
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -143,7 +143,7 @@ module ProductsHelper
   end
 
   def html_id_for_tab(product, test_type, is_c1_measure_test = true)
-    title_for(product, test_type, is_c1_measure_test).tr(' ', '_').tr('(', '_').tr(')', '_').underscore
+    title_for(product, test_type, is_c1_measure_test).tr(' ', '_').tr('(', '_').tr(')', '_').tr('+', '_').underscore
   end
 
   # input test_type should only be 'ChecklistTest', 'MeasureTest', or 'FilteringTest'

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -4,28 +4,40 @@ Background:
   Given the user is signed in
   And the user has created a vendor with a product
 
-Scenario: Successful View Measure Test Tab
-  When a user creates a product with c2 certifications and visits that product page
-  Then the user should see the the appropriate tabs
-
-Scenario: Successful Not View Measure Test Tab
+Scenario: Successful Select C1 and View Tabs
   When a user creates a product with c1 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
-Scenario: Successful View Filtering Test Tab
+Scenario: Successful Select C2 and View Tabs
+  When a user creates a product with c2 certifications and visits that product page
+  Then the user should see the the appropriate tabs
+
+Scenario: Successful Select C1 and C3 and View Tabs
+  When a user creates a product with c1, c3 certifications and visits that product page
+  Then the user should see the the appropriate tabs
+
+Scenario: Successful Select C1 and C4 and View Tabs
   When a user creates a product with c1, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
-Scenario: Successful Not View Filtering Test Tab
-  When a user creates a product with c1 certifications and visits that product page
+Scenario: Successful Select C2 and C3 and View Tabs
+  When a user creates a product with c2, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
-Scenario: Successful View Checklist Test Tab
-  When a user creates a product with c1 certifications and visits that product page
+Scenario: Successful Select C2 and C4 and View Tabs
+  When a user creates a product with c2, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
-Scenario: Successful Not View Checklist Test Tab
-  When a user creates a product with c2 certifications and visits that product page
+Scenario: Successful Select C1 and C2 and C3 and View Tabs
+  When a user creates a product with c1, c2, c3 certifications and visits that product page
+  Then the user should see the the appropriate tabs
+
+Scenario: Successful Select C1 and C2 and C4 and View Tabs
+  When a user creates a product with c1, c2, c4 certifications and visits that product page
+  Then the user should see the the appropriate tabs
+
+Scenario: Successful Select C1 and C2 and C3 and C4 and View Tabs
+  When a user creates a product with c1, c2, c3, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Download All Patients

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -429,20 +429,14 @@ Then(/^the user should see the the appropriate tabs$/) do
   end
   if @product.c4_test
     title, description, html_id = title_description_and_html_id_for(@product, 'FilteringTest')
-    # byebug
     assert_tab_and_content_exist(title, description, html_id)
   end
 end
 
 def assert_tab_and_content_exist(title, description, html_id)
   page.click_link title
-  find("##{html_id}").assert_text description
+  find("##{html_id}", visible: false).assert_text description
 end
-
-# Then(/^the user should see the measure tests tab$/) do
-#   page.assert_text 'Measure Tests'
-#   find(html_id_for_tab(@product, 'MeasureTest', true)).assert_text 'Test the EHR system\'s ability to record and export (C1), import'
-# end
 
 Then(/^the user should not see the measure tests tab$/) do
   page.assert_no_text 'Measure Tests'


### PR DESCRIPTION
- renamed 'Checklist Dashboard' breadcrumb to 'Manual Entry Test' on test execution show page
- fixed issue with unselectable html id for tab content divs on product show page
- added integration tests for all permutations of tabs on product show page

<img width="1123" alt="screen shot 2016-07-27 at 4 59 23 pm" src="https://cloud.githubusercontent.com/assets/14349011/17192343/06af3e4a-541c-11e6-8871-8a54e613c419.png">
