### PR TITLE
Fix bug with default bundle

### DIFF
--- a/app/controllers/admin/bundles_controller.rb
+++ b/app/controllers/admin/bundles_controller.rb
@@ -16,7 +16,7 @@ module Admin
     end
 
     def set_default
-      unless @bundle.active
+      unless @bundle.version == Settings[:default_bundle]
         Bundle.where(active: true).update_all(active: false)
         @bundle.active = true
         @bundle.save!

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -15,13 +15,13 @@
     <% @bundles.each do |bundle| %>
       <% unless bundle.respond_to?('done_importing') && !bundle.done_importing %>
         <tr>
-          <td> <%= bundle.title %> <%= '(Default)' if bundle.version == Settings[:default_bundle] %> </td>
+          <td> <%= bundle.title %> <%= '(Default)' if bundle.active %> </td>
           <td class = "text-center"><%= bundle.version %></td>
           <td class="text-center">
 
             <% unless @disabled %>
 
-              <% unless bundle.version == Settings[:default_bundle] %>
+              <% unless bundle.active %>
                 <%= button_to "Set Default", set_default_admin_bundle_path(bundle), :method => :post, :class => "btn btn-xs btn-default" %>
                 <%= render partial: 'remove_button', locals: {
                                 button_text: 'Remove',


### PR DESCRIPTION
Bug was caused by using `@bundle.active` where `Settings[:default_bundle]` should have been used, and the view updating before `Settings[:default_bundle]` is set.