### PR TITLE
Improve functionality and validations in POC section of vendor form

### DIFF
--- a/app/assets/javascripts/form_validations.js
+++ b/app/assets/javascripts/form_validations.js
@@ -21,4 +21,15 @@ $(function() {
         en: 'Does not have at least 3 of the specified character types.',
       }
     });
+
+  window.Parsley
+    .addValidator('phonenumber', {
+      requirementType: 'regexp',
+      validateString: function(value, requirement) {
+        return value.search(/[A-Za-z]/) == -1;
+      },
+      messages: {
+        en: 'This value may not contain letters.'
+      }
+    });
 });

--- a/app/views/vendors/_vendor_form.html.erb
+++ b/app/views/vendors/_vendor_form.html.erb
@@ -12,11 +12,11 @@
 
     <%= f.fields_for :points_of_contact do |poc_field| %>
       <div class="row">
-        <%= poc_field.text_field :name, wrapper: { class: 'col-sm-3'}, label_class: 'label-block', label: 'POC Name' %>
+        <%= poc_field.text_field :name, wrapper: { class: 'col-sm-3'}, label_class: 'label-block', label: 'POC Name', 'data-parsley-required': '' %>
         <%= poc_field.email_field :email, autocorrect: 'off', autocapitalize: 'off', wrapper: { class: 'col-sm-3'}, label_class: 'label-block', label: 'Email'%>
-        <%= poc_field.phone_field :phone, wrapper: { class: 'col-sm-3' }, label_class: 'label-block', label: 'Telephone' %>
+        <%= poc_field.phone_field :phone, wrapper: { class: 'col-sm-3' }, label_class: 'label-block', label: 'Telephone', 'data-parsley-phonenumber': '' %>
         <%= poc_field.text_field :contact_type, wrapper: { class: 'col-sm-2' }, label_class: 'label-block', label: 'Type of Contact' %>
-        <%= f.link_to_remove "Remove", :class => "btn btn-xs btn-danger", :type => "button" %>
+        <%= poc_field.link_to_remove "Remove", :class => "btn btn-xs btn-danger", :type => "button" %>
       </div>
     <% end %>
 

--- a/app/views/vendors/edit.html.erb
+++ b/app/views/vendors/edit.html.erb
@@ -3,7 +3,7 @@
 
   <%= render partial: 'remove_modal' %>
 
-  <%= render :partial => 'vendor_form', locals: {submit_text: 'Edit Vendor'} %>
+  <%= render :partial => 'vendor_form', locals: {submit_text: 'Save Changes'} %>
 
   <%= render partial: 'remove_panel', locals: { name: @vendor.name, type: 'vendor', message: 'Removing a vendor will also delete all associated products, product tests, and test execution results. Be sure you want to do this.', delete_path: vendor_path(@vendor) } %>
 

--- a/features/step_definitions/vendor.rb
+++ b/features/step_definitions/vendor.rb
@@ -57,7 +57,7 @@ When(/^the user edits the vendor$/) do
   visit '/'
   page.click_button 'Edit Vendor'
   page.fill_in 'URL', with: 'www.example.com'
-  page.click_button 'Edit Vendor'
+  page.click_button 'Save Changes'
 end
 
 When(/^the user removes the vendor$/) do


### PR DESCRIPTION
## Summary
- Add front end validation for point of contact phone number
  - Just don't allow letters. The back end strips out everything but numbers anyway.
- Add front end validation that requires POC name. Previously this was only enforced on the back end.
- Add ability to remove a point of contact (Remove button didn't actually work before)
- Change form submit button text: "Edit Vendor" -> "Save Changes"

## Views
![screen shot 2016-08-04 at 10 15 04 am](https://cloud.githubusercontent.com/assets/8235974/17405159/6852a252-5a2c-11e6-9594-59e410d3352c.png)


