### PR TITLE
Vendor and Product deletion Optimization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,7 +16,7 @@ Metrics/MethodLength:
   CountComments: false  # count full line comments?
   Max: 20
 Metrics/ClassLength:
-  Max: 100
+  Max: 110
   Exclude:
     - 'test/**/*'
     - 'lib/cypress/api_measure_evaluator.rb'

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -101,6 +101,14 @@ class Product
     end
   end
 
+  # This method does nothing more than attempt to cleanup a lot of data instead of making rails do it,
+  # since rails is really bad at cleaning up quickly.
+  def destroy
+    ProductTest.destroy_by_ids(product_test_ids)
+
+    super
+  end
+
   # - - - - - - - - - #
   #   P R I V A T E   #
   # - - - - - - - - - #

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -34,6 +34,20 @@ class Vendor
     end
   end
 
+  # This method does nothing more than attempt to cleanup a lot of data instead of making rails do it,
+  # since rails is really bad at cleaning up quickly. Note that this bypasses the dependent => destroy
+  # calls on product, product tests, etc, all the way down and does them manually. This means that
+  # if any of those structures change then this code will need to be updated accordingly.
+  def destroy
+    product_tests = ProductTest.where(:product_id.in => product_ids)
+    product_test_ids = product_tests.pluck(:_id)
+    ProductTest.destroy_by_ids(product_test_ids)
+
+    Product.in(id: product_ids).delete
+
+    super
+  end
+
   def status
     Rails.cache.fetch("#{cache_key}/status") do
       total = products.count

--- a/test/models/vendor_test.rb
+++ b/test/models/vendor_test.rb
@@ -131,6 +131,13 @@ class VendorTest < ActiveSupport::TestCase
       assert v.save!
     end
   end
+
+  def test_vendor_can_be_destroyed
+    v = Vendor.create!(name: 'test_vendor_name')
+    assert_difference 'Vendor.count', -1 do
+      v.destroy
+    end
+  end
 end
 
 class VendorCachingTest < CachingTest


### PR DESCRIPTION
This cleans up the destroy commands to run many drop commands all at once in order instead of one by one in order to save from an expensive activerecord callback to every item.

**Results:**

    # Old product deletion code:

    Measure Mode: wall_time
    Thread ID: 70211009151460
    Fiber ID: 70211092997080
    Total: 1.391805
    Sort by: self_time

    # New product deletion code:

    Measure Mode: wall_time
    Thread ID: 70102058131940
    Fiber ID: 70102131343280
    Total: 0.180934
    Sort by: self_time

    # Old vendor deletion code:

    Measure Mode: wall_time
    Thread ID: 70115970128860
    Fiber ID: 70116032985480
    Total: 403.965664
    Sort by: self_time

    # New vendor deletion code:

    Measure Mode: wall_time
    Thread ID: 70106575397360
    Fiber ID: 70106659652940
    Total: 1.284944
    Sort by: self_time 

I can commit the code used to generate the test results if desired.