### PR TITLE
Bump sprockets version to fix deprecation warning on startup.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,7 +360,7 @@ GEM
     ruby-progressbar (1.8.1)
     rubyzip (1.2.0)
     sass (3.4.22)
-    sass-rails (5.0.5)
+    sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)


### PR DESCRIPTION
Currently the application is showing the following warning whenever starting up the rails server or console:

    DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
    Please register a mime type using `register_mime_type` then
    use `register_compressor` or `register_transformer`.
    https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
     (called from block (2 levels) in <class:Railtie> at /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/sass-rails-5.0.5/lib/sass/rails/railtie.rb:57)
    DEPRECATION WARNING: Sprockets method `register_engine` is deprecated.
    Please register a mime type using `register_mime_type` then
    use `register_compressor` or `register_transformer`.
    https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#supporting-all-versions-of-sprockets-in-processors
     (called from block (2 levels) in <class:Railtie> at /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/sass-rails-5.0.5/lib/sass/rails/railtie.rb:58)
    Loading development environment (Rails 4.2.7.1)

This is fixed by bumping the sass-rails version from 5.0.5 to 5.0.6. This PR does just that.