### PR TITLE
Optimize requests on the vendor product page

### DIFF
--- a/app/assets/javascripts/products.js
+++ b/app/assets/javascripts/products.js
@@ -40,18 +40,6 @@ var reticulateSplines = function() {
     if ($('#display_bulk_download').length && $('#display_bulk_download').find('p:first').text().indexOf('being built') > -1) {
         $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'bulk_download' }});
     }
-
-    if ($('#display_measure_tests_table').length && ($('#display_measure_tests_table').find('i.fa-refresh').length ||
-        $('#display_measure_tests_table').find('span.text-muted').text().indexOf('queued') > -1) ||
-        $('#display_measure_tests_table').find('i.fa-gavel').length) {
-      $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'measure_tests_table' }});
-    }
-
-    if ($('#display_filtering_test_status_display').length && ($('#display_filtering_test_status_display').find('i.fa-refresh').length ||
-        $('#display_filtering_test_status_display').find('span.text-muted').text().indexOf('queued') > -1) ||
-        $('#display_filtering_test_status_display').find('i.fa-gavel').length) {
-      $.ajax({url: window.location.pathname, type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display' }});
-    }
 };
 
 $(document).ready(ready);

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -81,11 +81,29 @@ module ProductsHelper
     false
   end
 
-  def should_reload_measure_test_row?(task)
+  def should_reload_product_test_status_display?(tests)
+    tests.each do |test|
+      if should_reload_product_test_link?(with_c3_task(test.cat1_task)) || should_reload_product_test_link?(with_c3_task(test.cat3_task))
+        return true
+      end
+    end
+    false
+  end
+
+  def measure_test_running_for_row?(task)
     return true if task.product_test.state != :ready && task.product_test.state != :errored
     executions = [task.most_recent_execution]
     executions << task.most_recent_execution.sibling_execution if task.most_recent_execution
     return true if executions.compact.any? { |execution| execution.state == :pending }
+    false
+  end
+
+  # Takes a collection of tasks and determines if a measure test is running for any of the tasks.
+  # If one is then we need to be refreshing the measure tests table.
+  def should_reload_measure_test_table?(tasks)
+    tasks.each do |task|
+      return true if measure_test_running_for_row?(task)
+    end
     false
   end
 

--- a/app/views/products/_filtering_test_link.html.erb
+++ b/app/views/products/_filtering_test_link.html.erb
@@ -9,6 +9,7 @@
 
 %>
 
+<% parent_reloading = false unless (defined? parent_reloading) %>
 <% tasks = with_c3_task(task) %>
 
 <% if test.state != :ready %>
@@ -52,8 +53,10 @@
   <% end %>
 <% end %>
 
-<% if should_reload_product_test_link?(tasks) %>
+<% if should_reload_product_test_link?(tasks) && !parent_reloading %>
   <script>
+  $(document).ready(function() {
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_link', task_id: "<%= task.id.to_s %>" }});
+  });
   </script>
 <% end %>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -3,6 +3,7 @@
 # local variable 'tests' should be filtering_tests
 
 %>
+<% tests = @product.product_tests.filtering_tests %>
 
 <table class = 'table' id = 'filtering_test_status_display'>
   <thead>
@@ -22,10 +23,10 @@
           <% end %>
         </td>
         <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(test.cat1_task) %>">
-          <%= render partial: 'filtering_test_link', locals: { test: test, task: test.cat1_task } %>
+          <%= render partial: 'filtering_test_link', locals: { test: test, task: test.cat1_task, parent_reloading: true } %>
         </td>
         <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(test.cat3_task) %>">
-          <%= render partial: 'filtering_test_link', locals: { test: test, task: test.cat3_task } %>
+          <%= render partial: 'filtering_test_link', locals: { test: test, task: test.cat3_task, parent_reloading: true } %>
         </td>
         <td class="no-wrap"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
           <%= local_time_ago(test.updated_at) %></td>
@@ -33,3 +34,11 @@
     <% end %>
   </tbody>
 </table>
+
+<% if should_reload_product_test_status_display?(tests) %>
+  <script>
+    $(document).ready(function() {
+      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_status_display', html_id: "<%= html_id %>" }});
+    });
+  </script>
+<% end %>

--- a/app/views/products/_measure_test_link.html.erb
+++ b/app/views/products/_measure_test_link.html.erb
@@ -25,7 +25,7 @@
     <i class = 'fa fa-fw fa-gavel invisible' aria-hidden = 'true'></i>
     <%= render partial: '/products/product_test_upload', locals: { task: task, label_class: 'label-info' } %>
   <% when 'incomplete' %>
-    <% if should_reload_measure_test_row?(task) %>
+    <% if measure_test_running_for_row?(task) %>
       <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
       <span class = 'label label-default'>testing...</span>
     <% else %>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -2,10 +2,13 @@
 
 # local variables
 #
-#   tasks (array of Task)
+#   product (The parent product we are fetching tasks for)
+#   get_c1_tasks (whether the measure tasks we fetch should include c1 tasks)
 
 %>
-
+<% # Convert get_c1_tasks into a boolean if it is a string. %>
+<% get_c1_tasks = get_c1_tasks.eql? "true" if get_c1_tasks.is_a? String %>
+<% tasks = measure_test_tasks(@product, get_c1_tasks) %>
 <% return unless tasks.any? %>
 
 <% product = tasks.first.product_test.product %>
@@ -26,8 +29,16 @@
   <tbody>
     <% tasks.each do |task| %>
       <tr id = '<%= measure_tests_table_row_wrapper_id(task) %>'>
-        <%= render partial: 'measure_tests_table_row', locals: { task: task } %>
+        <%= render partial: 'measure_tests_table_row', locals: { task: task, parent_reloading: true } %>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<% if should_reload_measure_test_table?(tasks) %>
+  <script>
+    $(document).ready(function() {
+      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table', should_include_c1: "<%= get_c1_tasks %>", html_id: "<%= html_id %>" }});
+    });
+  </script>
+<% end %>

--- a/app/views/products/_measure_tests_table_row.html.erb
+++ b/app/views/products/_measure_tests_table_row.html.erb
@@ -3,8 +3,11 @@
 # local variables
 #
 #   task       (Task)
-
+#   parent_reloading is a boolean stating whether or not the measure_tests_table is already reloading via ajax, in order to make
+#   sure we don't reload at the same time and double up on requests.
 %>
+
+<% parent_reloading = false unless (defined? parent_reloading) %>
 
 <% test = task.product_test %>
 <% include_c3 = test.product.c3_test %>
@@ -27,8 +30,11 @@
   <i class="fa fa-fw fa-clock-o" aria-hidden="true"></i><%= local_time_ago(task.updated_at) %>
 </td>
 
-<% if should_reload_measure_test_row?(task) %>
+<% # Only reload if the measure_tests_table isn't reloading for us. (This currently only happens in create.js.erb) %>
+<% if measure_test_running_for_row?(task) && !parent_reloading %>
   <script>
-    $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= task.id.to_s %>" }});
+    $(document).ready(function() {
+      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= task.id.to_s %>" }});
+    });
   </script>
 <% end %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -44,14 +44,15 @@
       <% # Measure Test Tabs (both C1 or C2 tabs) %>
       <% if test_type == 'MeasureTest' %>
         <div id="display_measure_tests_table">
-          <%= render partial: 'measure_tests_table', locals: { tasks: measure_test_tasks(@product, title.include?('C1')) } %>
+          <%= render partial: 'measure_tests_table', locals: { product: @product, get_c1_tasks: title.include?('C1'),
+            html_id: html_id } %>
         </div>
       <% end %>
 
       <% # Filtering Test Tab %>
       <% if test_type == 'FilteringTest' %>
         <div id="display_filtering_test_status_display">
-          <%= render partial: 'filtering_test_status_display', locals: { tests: @product.product_tests.filtering_tests } %>
+          <%= render partial: 'filtering_test_status_display', locals: { product: @product, html_id: html_id } %>
         </div>
       <% end %>
 

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -4,23 +4,33 @@
     <% # wait 2 seconds. then reload the page %>
     setTimeout(function(){
       $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
-    }, 2000);
+    }, 5000);
   <% else %>
     <% # don't wait. just load the bulk download %>
     $('#display_bulk_download').html("<%= escape_javascript render partial: 'bulk_download', locals: { product: @product } %>");
   <% end %>
+
+<% elsif params[:partial] == 'filtering_test_status_display' %>
+  setTimeout(function() {
+    $("#<%= params[:html_id] %> #filtering_test_status_display_wrapper").html("<%= escape_javascript render partial: 'filtering_test_status_display', locals: { html_id: params[:html_id] } %>");
+  }, 10000);
 
 <% elsif params[:partial] == 'filtering_test_link' %>
   <% task = Task.find(params[:task_id]) %>
   <% wrapper_id = id_for_html_wrapper_of_task(task) %>
   setTimeout(function() {
     $("#<%= wrapper_id %>").html("<%= escape_javascript render partial: 'filtering_test_link', locals: { test: task.product_test, task: task } %>");
-  }, 500);
+  }, 2000);
+
+<% elsif params[:partial] == 'measure_tests_table' %>
+  setTimeout(function() {
+    $("#<%= params[:html_id] %> #display_measure_tests_table").html("<%= escape_javascript render partial: 'measure_tests_table', locals: { get_c1_tasks: params[:should_include_c1], html_id: params[:html_id] } %>");
+  }, 10000);
 
 <% elsif params[:partial] == 'measure_tests_table_row' %>
   <% task = Task.find(params[:task_id]) %>
   <% wrapper_id = measure_tests_table_row_wrapper_id(task) %>
   setTimeout(function() {
     $("#<%= wrapper_id %>").html("<%= escape_javascript render partial: 'measure_tests_table_row', locals: { task: task } %>");
-  }, 500);
+  }, 2000);
 <% end %>

--- a/features/filtering_tests/show.feature
+++ b/features/filtering_tests/show.feature
@@ -3,8 +3,8 @@ Feature: C4 Filtering Test
 Background:
   Given the user is signed in
   And the user has created a vendor with a product selecting C4 testing
-  And the user visits the product show page with the filter test tab selected
   And the first filter task state has been set to ready
+  And the user visits the product show page with the filter test tab selected
 
 Scenario: Successful View CAT 1 Filtering Test
   When the user views the CAT 1 test for the first filter task

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -177,33 +177,33 @@ class ProductsHelperTest < ActiveJob::TestCase
     product_test, task = setup_product_test_and_task_for_should_reload_measure_test_row_test
 
     # product test with :pending state should need reloading
-    assert_equal true, should_reload_measure_test_row?(task)
+    assert_equal true, measure_test_running_for_row?(task)
 
     # product test with :ready state should not need reloading
     product_test.state = :ready
     product_test.save!
-    assert_equal false, should_reload_measure_test_row?(task)
+    assert_equal false, measure_test_running_for_row?(task)
 
     # if task has a pending most recent execution then needs reloading
     execution = task.test_executions.create!(:state => :pending)
-    assert_equal true, should_reload_measure_test_row?(task)
+    assert_equal true, measure_test_running_for_row?(task)
 
     # if task has a passing most recent execution then does not need reloading
     execution.state = :passed
     execution.save!
-    assert_equal false, should_reload_measure_test_row?(task)
+    assert_equal false, measure_test_running_for_row?(task)
 
     # if execution has a sibling execution that is pending then needs reloading
     sibling_task = product_test.tasks.create!
     sibling_execution = sibling_task.test_executions.create!(:sibling_execution_id => execution.id, :state => :pending)
     execution.sibling_execution_id = sibling_execution.id
     execution.save!
-    assert_equal true, should_reload_measure_test_row?(task)
+    assert_equal true, measure_test_running_for_row?(task)
 
     # if both executions are finished then does not need reloading
     sibling_execution.state = :failed
     sibling_execution.save!
-    assert_equal false, should_reload_measure_test_row?(task)
+    assert_equal false, measure_test_running_for_row?(task)
   end
 
   def test_tasks_status


### PR DESCRIPTION
Instead of pulling each row of the different tables one by one, pull them all at once and only pull one by one when individual tests are uploaded.

Results before when creating a new product and staying on the page for the duration of the processing:
<img width="296" alt="before" src="https://cloud.githubusercontent.com/assets/2308869/18180027/127d1294-7053-11e6-8093-b7fc6f1427b5.png">

Results after:
<img width="278" alt="after" src="https://cloud.githubusercontent.com/assets/2308869/18180028/127f9d48-7053-11e6-9059-d5ab1d5bd9e8.png">

Tests for this may be failing at the moment, I just rebased against master however it seems master may be failing as well.