### PR TITLE
Automatically retry when cucumber and rake test fail.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ script:
   - bundle exec bundle-audit check
   - bundle exec overcommit --sign
   - bundle exec overcommit --run
-  - bundle exec rake test
-  - bundle exec rake cucumber
+  - travis_retry bundle exec rake test
+  - travis_retry bundle exec rake cucumber


### PR DESCRIPTION
Since cucumber likes to randomly fail, this may be a good idea. It should make travis automatically retry 3 times every time a build fails, which will hopefully guarantee that if a build fails it is actually failing and not just an intermittent issue.