### PR TITLE
Grab the compiled assets version of the background

### DIFF
--- a/app/assets/stylesheets/cypress/_sessions.scss
+++ b/app/assets/stylesheets/cypress/_sessions.scss
@@ -1,6 +1,6 @@
 .splash-panel {
   height: 381px;
-  background: url('cypress_bg_cropped.png');
+  background: image-url('cypress_bg_cropped.png');
   background-size: auto 381px;
 }
 


### PR DESCRIPTION
Without this in production it will try to grab the non-compiled version which will not load and cause the page to load without a background. This is due to the fact that we were not using the asset pipeline helper that does this for us.