### PR TITLE
Show CMS warnings seperately from other warnings

### DIFF
--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -28,11 +28,11 @@ class ExecutionError
   end
 
   def self.only_cms_warnings
-    where(cms: true).entries
+    by_type(:warning).where(cms: true).entries
   end
 
   def self.non_cms_warnings
-    where(cms: false).entries
+    by_type(:warning).where(cms: false).entries
   end
 
   # only if validator is one of 'CDA SDTC Validator', 'QRDA Cat 1 R3 Validator', 'QRDA Cat 1 Validator', or 'QRDA Cat 3 Validator'

--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -11,6 +11,7 @@ class ExecutionError
   field :stratification, type: String
   field :location
   field :file_name, type: String
+  field :cms, type: Boolean, default: false
   validates :msg_type, presence: true
   validates :message, presence: true
 
@@ -24,6 +25,14 @@ class ExecutionError
 
   def self.only_warnings
     by_type(:warning).entries
+  end
+
+  def self.only_cms_warnings
+    where(cms: true).entries
+  end
+
+  def self.non_cms_warnings
+    where(cms: false).entries
   end
 
   # only if validator is one of 'CDA SDTC Validator', 'QRDA Cat 1 R3 Validator', 'QRDA Cat 1 Validator', or 'QRDA Cat 3 Validator'

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -65,7 +65,7 @@
               <% total_errors = error_result.keys.map{ |s| error_result[s].execution_errors.count }.reduce(&:+) %>
               <% if total_errors > 0 %>
                 <div class="file-name">
-                  <% if error_result.keys.any? { |s| s != 'Warnings' && error_result[s].execution_errors.count > 0} %>
+                  <% if error_result.keys.any? { |s| s != 'Other Warnings' && s != 'CMS Warnings' && error_result[s].execution_errors.count > 0} %>
                     <i aria-hidden='true' class='fa fa-fw fa-times text-danger'></i>
                   <% else %>
                     <i aria-hidden='true' class='fa fa-fw fa-exclamation-triangle text-warning'></i>

--- a/app/views/test_executions/results/_execution_results_for_file.html.erb
+++ b/app/views/test_executions/results/_execution_results_for_file.html.erb
@@ -31,16 +31,16 @@
   <ul>
     <% error_result.each do |error_type, error_hash| %>
       <li>
-        <%= link_to "##{error_type}_#{identifier}" do %>
+        <%= link_to "##{error_type.tr(' ', '_')}_#{identifier}" do %>
           <%= error_type %> <span>(<%= error_hash.execution_errors.count %>)</span>
         <% end %>
       </li>
     <% end %>
   </ul>
   <% error_result.each do |error_type, error_hash| %>
-    <div id=<%= "#{error_type}_#{identifier}" %>>
+    <div id=<%= "#{error_type.tr(' ', '_')}_#{identifier}" %>>
       <% if error_hash.execution_errors.count > 0 %>
-        <% message_title = error_type == 'Warnings' ? 'Warning' : 'Error' %>
+        <% message_title = error_type == 'Other Warnings' || error_type == 'CMS Warnings' ? 'Warning' : 'Error' %>
 
         <% if error_type == "Reporting" %>
           <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
@@ -64,11 +64,6 @@
             </div>
           </div>
         <% end %>
-      <% else %>
-        <p class="lead">
-          <i class="fa fa-fw fa-check text-success" aria-hidden="true"></i>
-          <%= "#{error_type} - No problems found" %>
-        </p>
       <% end %>
     </div>
   <% end %>

--- a/lib/cypress/error_collector.rb
+++ b/lib/cypress/error_collector.rb
@@ -49,7 +49,8 @@ module Cypress
       file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
       file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
       file_error_hash['Submission'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_errors) : { execution_errors: [] }
-      file_error_hash['Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_warnings) : { execution_errors: [] }
+      file_error_hash['CMS Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.only_cms_warnings) : { execution_errors: [] }
+      file_error_hash['Other Warnings'] = related_errs.count > 0 ? error_hash(doc, related_errs.non_cms_warnings) : { execution_errors: [] }
       file_error_hash
     end
 

--- a/lib/validators/cms_schematron_validator.rb
+++ b/lib/validators/cms_schematron_validator.rb
@@ -7,7 +7,7 @@ module Validators
     @bundle_version = APP_CONFIG.default_bundle
 
     def initialize(schematron_file, name, bundle_version = APP_CONFIG.default_bundle)
-      @validator = Schematron::Validator.new(name, schematron_file) if File.exists?(schematron_file)
+      @validator = Schematron::Validator.new(name, schematron_file) if File.exist?(schematron_file)
       @bundle_version = bundle_version
     end
 
@@ -22,7 +22,7 @@ module Validators
       default_errors = ApplicationController.helpers.config_for_version(@bundle_version)["#{class_name}_warnings"]
       if default_errors
         default_errors.each do |error|
-          add_warning error, :validator_type => :xml_validation, :file_name => @options[:file_name]
+          add_warning error, :validator_type => :xml_validation, :file_name => @options[:file_name], :cms => true
         end
       end
       if @validator
@@ -32,7 +32,8 @@ module Validators
                       :location => error.location,
                       :validator => error.validator,
                       :validator_type => :xml_validation,
-                      :file_name => @options[:file_name]
+                      :file_name => @options[:file_name],
+                      :cms => true
         end
       end
     end

--- a/test/helpers/xml_view_helper_test.rb
+++ b/test/helpers/xml_view_helper_test.rb
@@ -25,7 +25,7 @@ class XmlViewHelperTest < ActiveSupport::TestCase
     errs = collected_errors(@te)
     assert_equal 0, errs.nonfile.count
     assert_equal 4, errs.files.keys.count, 'should contain four files with errors'
-    assert_equal %w(QRDA Reporting Submission Warnings), errs.files['0_Dental_Peds_A.xml'].keys, 'should contain right error keys for each file'
+    assert_equal ['QRDA', 'Reporting', 'Submission', 'CMS Warnings', 'Other Warnings'], errs.files['0_Dental_Peds_A.xml'].keys, 'should contain right error keys for each file'
   end
 
   def test_popup_attributes_multiple_errors


### PR DESCRIPTION
**Splits 'Warnings' tab in execution results into two different tabs:**

![screen shot 2016-09-21 at 1 14 59 pm](https://cloud.githubusercontent.com/assets/8235974/18721217/77f1728c-7ffd-11e6-9317-2935c9059235.png)
