### PR TITLE
Added unicorn config and made upgrade scripts check for it as well.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ tmp/*
 uploads/*
 bundles/*
 log/*
+contrib/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM rails:4.2.5
+FROM ruby:2.2
+
+RUN apt-get update \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV RAILS_ENV production
 ENV RAILS_SERVE_STATIC_FILES 1

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,2 @@
+timeout 120
+worker_processes 4

--- a/rails-entrypoint.sh
+++ b/rails-entrypoint.sh
@@ -3,6 +3,6 @@ set -e
 
 exec bin/delayed_job start -n 3 &
 exec rake assets:precompile &
-exec rails s -b 0.0.0.0
+exec unicorn -c config/unicorn.rb -p 3000
 
 exec "$@"


### PR DESCRIPTION
Fixed the cypress upgrade script to check for the config file and add it to the startup script if it exists. I did not add this to the upgrade to 3.0.1 script since 3.0.1 does not have a config/unicorn.rb, however the upgrade to 3.0.2 script when created needs to mirror this script. Running the upgrade script multiple times should not mess up the config file since the sed command is setup to check that -c and --config-file are not already set before updating the script.