### PR TITLE
Update scripts for v3.0.2

### DIFF
--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -20,7 +20,7 @@
       "subnet_id": "{{user `subnet_id`}}",
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
-      "ami_name": "cypress_3.0.1",
+      "ami_name": "cypress_3.0.2",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 20,
@@ -34,7 +34,7 @@
     },
     {
       "name": "cypress.vmware",
-      "vm_name": "cypressv301",
+      "vm_name": "cypressv302",
       "type": "vmware-iso",
       "guest_os_type": "ubuntu-64",
       "iso_urls": [
@@ -115,7 +115,7 @@
     "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::install_cypress]" ],
     "json": {
       "cypress": {
-          "cypress_git_revision": "v3.0.1",
+          "cypress_git_revision": "v3.0.2",
           "generate_secrets_on_restart": true
       }
     }

--- a/contrib/cypress_cvu.json
+++ b/contrib/cypress_cvu.json
@@ -20,7 +20,7 @@
       "subnet_id": "{{user `subnet_id`}}",
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
-      "ami_name": "cypress_cvu_3.0.1",
+      "ami_name": "cypress_cvu_3.0.2",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 20,
@@ -34,7 +34,7 @@
     },
     {
       "name": "cypress.cvu.vmware",
-      "vm_name": "cypresscvuv301",
+      "vm_name": "cypresscvuv302",
       "type": "vmware-iso",
       "guest_os_type": "ubuntu-64",
       "iso_urls": [
@@ -115,7 +115,7 @@
     "run_list": [ "recipe[apt]", "recipe[git]", "recipe[cypress::default]" ],
     "json": {
       "cypress": {
-          "cypress_git_revision": "v3.0.1",
+          "cypress_git_revision": "v3.0.2",
           "cvu_git_revision": "v3.0.1",
           "generate_secrets_on_restart": true
       }


### PR DESCRIPTION
This PR makes a few small changes to how the upgrade script works. It now has a default version that it pulls in, however also allows for users to pass in parameters to it, for example:

`./upgrade_cypress_30.sh v3.0.2 v3.0.1` would upgrade to cypress tag 3.0.2 and cvu tag 3.0.1
`./upgrade_cypress_30.sh master master` would put both cypress and cvu on their respective master branches
`./upgrade_cypress_30.sh` defaults to the latest versions, which is currently 3.0.2 for cypress and 3.0.1 for cvu.

Support is now also added for upgrading the ruby version, however it will not trigger unless the needed version is not found on the system.