### PR TITLE
Move version number out of the cypress config.

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-inverse">
   <div class="container">
     <div class="navbar-header">
-      <%= link_to root_path do %>cypress <small><%= APP_CONFIG.version %></small><% end %>
+      <%= link_to root_path do %>cypress <small><%= Cypress::Application::VERSION %></small><% end %>
       <button type="button" class="navbar-toggle navbar-right" data-toggle="collapse" data-target="#cypressNavbar" aria-label="navigation menu" role="button" aria-controls="cypressNavbar" aria-expanded="false">
         <i class="fa fa-bars fa-2x" aria-hidden="true"></i>
         <span class="sr-only">Expand navigation menu</span>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -14,7 +14,7 @@
     <dt>Bundle</dt>
     <dd><%= "#{@bundle.title} v#{@bundle.version}" %></dd>
     <dt>Cypress Version</dt>
-    <dd><%= APP_CONFIG.version %></dd>
+    <dd><%= Cypress::Application::VERSION %></dd>
   </dl>
 
   <h2>Measure Tests</h2>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -3,8 +3,6 @@ effective_date:
   month: 12
   day: 31
 
-version: 3.0.2
-
 default_bundle: "3.0.0"
 
 # Specify the folder to look for the schematron files in based on bundle version these folders are in ./resources/schematron/

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,0 +1,5 @@
+module Cypress
+  class Application
+    VERSION = '3.0.2'.freeze
+  end
+end


### PR DESCRIPTION
There are a few reasons this is useful. First of all the contents of the cypress.yml file can be changed by the user through the admin UI. This means that the cypress.yml file is not only changed by us every time a new version comes out, but it is also changed by the user when they tweak the admin UI. This leads us to a situation where the upgrade script currently has to stash the changes and then pop once the latest version has been pulled in. Moving the version out of the cypress.yml file helps make this less brittle.