### PR TITLE
Allow for progressive manual entry test

### DIFF
--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -1,6 +1,7 @@
 module ChecklistTestsHelper
   def disable_qrda_submission?
-    !@product_test.checked_criteria.all?(&:checklist_complete?) || @product_test.state == :errored
+    # only disable if none of the measures have all good checklist criteria
+    @product_test.checked_criteria.group_by(&:measure_id).values.all? { |cc_group| cc_group.any? { |cc| !cc.checklist_complete? } }
   end
 
   def checklist_test_criteria_attribute(measure, criteria)


### PR DESCRIPTION
On the manual entry page, it would only allow you to upload a file if all checked criteria for all of the measures were good. This makes it so you can upload a file if all checked criteria for at least one of the measures are good.