### PR TITLE
Removed manual comparison of task type from multiple points in the code

### DIFF
--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -20,7 +20,7 @@ class TestExecutionsController < ApplicationController
     authorize! :execute_task, @task.product_test.product.vendor
     @test_execution = @task.execute(results_params)
     respond_with(@test_execution) do |f|
-      if @task._type == 'C1ManualTask'
+      if @task.is_a? C1ManualTask
         f.html { redirect_to product_checklist_test_path(@task.product_test.product, @task.product_test) }
       else
         f.html { redirect_to task_test_execution_path(task_id: @task.id, id: @test_execution.id) }
@@ -82,7 +82,7 @@ class TestExecutionsController < ApplicationController
     add_breadcrumb 'Dashboard', :vendors_path
     add_breadcrumb 'Vendor: ' + @product_test.product.vendor.name, vendor_path(@product_test.product.vendor)
     add_breadcrumb 'Product: ' + @product_test.product.name, vendor_product_path(@product_test.product.vendor, @product_test.product)
-    add_breadcrumb 'Manual Entry Test', product_checklist_test_path(@product_test.product, @product_test) if @product_test._type == 'ChecklistTest'
+    add_breadcrumb 'Manual Entry Test', product_checklist_test_path(@product_test.product, @product_test) if @product_test.is_a? ChecklistTest
     add_test_execution_breadcrumb
   end
 

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -127,10 +127,10 @@ module ProductsHelper
   # input should be a c1 or c2 task
   def with_c3_task(task)
     return [task] unless task.product_test.product.c3_test
-    case task._type
-    when 'C1Task'
+    case task
+    when C1Task
       return [task, task.product_test.tasks.c3_cat1_task]
-    when 'C2Task'
+    when C2Task
       return [task, task.product_test.tasks.c3_cat3_task]
     end
     [task]

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -3,7 +3,7 @@ module TestExecutionsHelper
   include Cypress::ErrorCollector
 
   def displaying_cat1?(task)
-    (task._type == 'C1Task') || (task._type == 'Cat1FilterTask') || task._type == 'C1ManualTask'
+    task.is_a?(C1Task) || task.is_a?(Cat1FilterTask) || task.is_a?(C1ManualTask)
   end
 
   def task_type_to_title(task_type, c3)
@@ -47,7 +47,7 @@ module TestExecutionsHelper
 
   def get_title_message(test, task)
     msg = ''
-    if test._type == 'MeasureTest'
+    if test.is_a? MeasureTest
       msg << task_type_to_title(task._type, task.product_test.product.c3_test)
       msg << ' certification'
       msg << 's' if test.product.c3_test
@@ -86,10 +86,10 @@ module TestExecutionsHelper
   end
 
   def info_title_for_product_test(product_test)
-    case product_test._type
-    when 'MeasureTest' then 'Measure Test Information'
-    when 'FilteringTest' then 'Filtering Test Information'
-    when 'ChecklistTest' then 'Manual Entry Test Information'
+    case product_test
+    when MeasureTest then 'Measure Test Information'
+    when FilteringTest then 'Filtering Test Information'
+    when ChecklistTest then 'Manual Entry Test Information'
     else 'Test Information'
     end
   end
@@ -100,7 +100,7 @@ module TestExecutionsHelper
 
   def iterate_task(task, direction)
     tests = task.product_test.product.product_tests
-    tests = if task._type == 'Cat1FilterTask' || task._type == 'Cat3FilterTask'
+    tests = if task.is_a?(Cat1FilterTask) || task.is_a?(Cat3FilterTask)
               tests.filtering_tests.sort_by { |t| cms_int(t.cms_id) }
             else
               tests.measure_tests.sort_by { |t| cms_int(t.cms_id) }
@@ -115,6 +115,6 @@ module TestExecutionsHelper
   end
 
   def should_display_expected_results(task)
-    !hide_patient_calculation? && (task._type == 'C2Task' || task.product_test._type == 'FilteringTest')
+    !hide_patient_calculation? && (task.is_a?(C2Task) || task.product_test.is_a?(FilteringTest))
   end
 end

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -93,10 +93,6 @@ module TestExecutionsResultsHelper
 
   private
 
-  def currently_viewing_c1?(task)
-    task._type == 'C1Task'
-  end
-
   # used for sorting errors by appearance in xml
   #   if no doc or xml element found then line number of 0 is returned
   def error_to_line_number(error, doc)

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -13,7 +13,7 @@ class FilteringTest < ProductTest
   end
 
   def cat1_task
-    cat1_tasks = tasks.select { |task| task._type == 'Cat1FilterTask' }
+    cat1_tasks = tasks.select { |task| task.is_a? Cat1FilterTask }
     if cat1_tasks.empty?
       false
     else
@@ -22,7 +22,7 @@ class FilteringTest < ProductTest
   end
 
   def cat3_task
-    cat3_tasks = tasks.select { |task| task._type == 'Cat3FilterTask' }
+    cat3_tasks = tasks.select { |task| task.is_a? Cat3FilterTask }
     if cat3_tasks.empty?
       false
     else

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -105,24 +105,11 @@ class ProductTest
     PatientCache.where('value.test_id' => id).order_by(['value.last', :asc])
   end
 
-  def ready
-    self.state = :ready
-    save
-  end
-
-  def queued
-    self.state = :queued
-    save
-  end
-
-  def building
-    self.state = :building
-    save
-  end
-
-  def errored
-    self.state = :errored
-    save
+  [:ready, :queued, :building, :errored].each do |test_state|
+    define_method test_state do
+      self.state = test_state
+      save
+    end
   end
 
   def status

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,68 +14,26 @@ class Task
   delegate :effective_date, :to => :product_test
   delegate :bundle, :to => :product_test
 
-  def self.c1_task
-    find_by(_type: 'C1Task')
-  rescue
-    false
+  %w(
+    C1Task C1ManualTask C3ManualTask C2Task C3Cat1Task
+    C3Cat3Task Cat1FilterTask Cat3FilterTask
+  ).each do |task_type|
+    # Define methods for fetching specific types of tasks,
+    # for example (Task.c1_task, Task.cat1_filter_task, etc)
+    define_singleton_method task_type.underscore do
+      begin
+        find_by(_type: task_type)
+      rescue
+        false
+      end
+    end
   end
 
-  def self.c1_manual_task
-    find_by(_type: 'C1ManualTask')
-  rescue
-    false
-  end
-
-  def self.c3_manual_task
-    find_by(_type: 'C3ManualTask')
-  rescue
-    false
-  end
-
-  def self.c2_task
-    find_by(_type: 'C2Task')
-  rescue
-    false
-  end
-
-  def self.c3_cat1_task
-    find_by(_type: 'C3Cat1Task')
-  rescue
-    false
-  end
-
-  def self.c3_cat3_task
-    find_by(_type: 'C3Cat3Task')
-  rescue
-    false
-  end
-
-  def self.cat1_filter_task
-    find_by(_type: 'Cat1FilterTask')
-  rescue
-    false
-  end
-
-  def self.cat3_filter_task
-    find_by(_type: 'Cat3FilterTask')
-  rescue
-    false
-  end
-
-  def passing?
-    status == 'passing'
-  end
-
-  def failing?
-    status == 'failing'
-  end
-
-  def errored?
-    status == 'errored'
-  end
-
-  def incomplete?
-    status == 'incomplete'
+  # Defines methods for checking task status (task.passing?, etc)
+  %w(passing failing errored incomplete).each do |task_state|
+    define_method "#{task_state}?" do
+      status == task_state
+    end
   end
 
   def status

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -48,11 +48,11 @@ class TestExecution
   end
 
   def conditionally_add_task_specific_errors(file_count)
-    if task._type == 'C1Task' && file_count != task.records.count
+    if task.is_a?(C1Task) && file_count != task.records.count
       execution_errors.build(:message => "#{task.records.count} files expected but was #{file_count}",
                              :msg_type => :error, :validator_type => :result_validation, :validator => :smoking_gun)
     end
-    task.product_test.build_execution_errors_for_incomplete_checked_criteria(self) if task._type == 'C1ManualTask'
+    task.product_test.build_execution_errors_for_incomplete_checked_criteria(self) if task.is_a?(C1ManualTask)
   end
 
   # Get the expected result for a particular measure

--- a/app/representers/product_test_representer.rb
+++ b/app/representers/product_test_representer.rb
@@ -33,7 +33,7 @@ module ProductTestRepresenter
     property :address, extend: AddressRepresenter, if: ->(_) { self['addresses'] }, getter: ->(_) { self['addresses'].first }
   end
 
-  hash :provider_filters, :if => ->(_) { _type == 'FilteringTest' && options.filters.key?('providers') && state == :ready }, :wrap => :filters,
+  hash :provider_filters, :if => ->(_) { is_a?(FilteringTest) && options.filters.key?('providers') && state == :ready }, :wrap => :filters,
                           :as => :filters, :extend => ProviderRepresenter,
                           :getter => (lambda do |*|
                             filters_copy = options.filters.clone

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -12,7 +12,7 @@
 <% return unless tasks.any? %>
 
 <% product = tasks.first.product_test.product %>
-<% first_results_col_label = tasks.first._type == 'C1Task' ? 'C1 Results' : 'C2 Results' %>
+<% first_results_col_label = tasks.first.is_a?(C1Task) ? 'C1 Results' : 'C2 Results' %>
 <% include_c3 = product.c3_test %>
 
 <table class = 'table table-hover measure_tests_table'>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -11,7 +11,7 @@
 <% execution = task.most_recent_execution %>
 
 <% panel_class = current_task ? 'panel-primary' : 'panel-inactive' %>
-<% task_status = task.product_test._type == 'MeasureTest' ? task.status_with_sibling : task.status %>
+<% task_status = task.product_test.is_a?(MeasureTest) ? task.status_with_sibling : task.status %>
 
 <div class = 'col-sm-4'>
   <div class = 'panel <%= panel_class %> task-panel'>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -6,16 +6,16 @@
 
 <div class = 'col-sm-4'>
   <h1><%= info_title_for_product_test(task.product_test) %></h1>
-  <% unless task.product_test._type == 'ChecklistTest' %>
+  <% unless task.product_test.is_a? ChecklistTest %>
     <strong>Measure: </strong><span><%= task.product_test.name %></span><br/>
   <% end %>
   <strong>HQMF ID: </strong><span><%= @task.product_test.measure_ids.join(',') %></span><br/>
-  <% unless task.product_test._type == 'ChecklistTest' %>
+  <% unless task.product_test.is_a? ChecklistTest %>
     <strong>CMS ID: </strong><span><%= task.product_test.cms_id %></span><br/>
   <% end %>
 
   <% # display provider information if the product test is a measure test %>
-  <% if task.product_test.class == MeasureTest %>
+  <% if task.product_test.is_a? MeasureTest %>
     <% provider = task.product_test.provider %>
     <% unless provider.nil? %>
       <br/>
@@ -26,7 +26,7 @@
   <% end %>
 
   <br/>
-  <% unless @task._type == 'C1ManualTask' %>
+  <% unless @task.is_a? C1ManualTask %>
   <%= link_to 'View Patients', { controller: 'records', task_id: @task.id}, method: :get %>
   <% if Settings['enable_debug_features'] %>
   <br/>

--- a/app/views/test_executions/create.js.erb
+++ b/app/views/test_executions/create.js.erb
@@ -7,7 +7,7 @@
 <% request.env['PATH_INFO'] = vendor_product_path(@product.vendor, @product) %>
 
 <% task = Task.find(params[:task_id]) %>
-<% is_measure_test_execution = task.product_test._type == 'MeasureTest' %>
+<% is_measure_test_execution = task.product_test.is_a? MeasureTest %>
 
 <% if is_measure_test_execution %>
   $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= params[:task_id] %>" }});

--- a/app/views/test_executions/results/_passing_result.html.erb
+++ b/app/views/test_executions/results/_passing_result.html.erb
@@ -3,7 +3,7 @@
     <p class="lead bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> <%= execution_type + " Execution: " unless execution_type.nil? %>Passed</p>
     <div class="row">
       <div class="col-sm-6">
-        <% if execution.task.product_test._type == 'MeasureTest' %>
+        <% if execution.task.product_test.is_a? MeasureTest %>
           <% cat1_task = execution.task.product_test.tasks.c1_task %>
           <% cat3_task = execution.task.product_test.tasks.c2_task %>
         <% else %>

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -1,7 +1,7 @@
 <%= content_for(:body_attributes) do %>data-no-turbolink<% end %>
 
 <% displaying_cat1 = displaying_cat1?(@task) %>
-<% viewing_measure_test = @task.product_test._type == 'MeasureTest' %>
+<% viewing_measure_test = @task.product_test.is_a? MeasureTest %>
 <% if viewing_measure_test %>
   <% cat1_task = @task.product_test.tasks.c1_task %>
   <% cat3_task = @task.product_test.tasks.c2_task %>
@@ -10,7 +10,7 @@
   <% cat3_task = @task.product_test.tasks.cat3_filter_task %>
 <% end %>
 <%= render partial: 'application/certification_bar', locals: { product: @product_test.product, active_certs: current_certifications(@task._type, @product_test.product.c3_test) } %>
-<% unless @task._type == 'C1ManualTask' || @task._type == 'C3ManualTask' %>
+<% unless @task.is_a?(C1ManualTask) || @task.is_a?(C3ManualTask) %>
   <div class="panel clearfix">
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'prev').id), :method => :get, :class => "btn btn-default pull-left" do %>
       <i class="fa fa-fw fa-step-backward" aria-hidden="true"></i> Previous Test: <%= iterate_task(@task, 'prev').product_test.cms_id %>
@@ -32,13 +32,13 @@
       { title: 'Download Test Deck', partial: 'execution_download', disable: false, disable_msg: '' },
       { title: 'Upload Files', partial: 'execution_upload', disable: @task.product_test.state == :errored, disable_msg: 'Cannot upload files to an errored test.' }
       ] %>
-  <% elsif @task.product_test._type == 'FilteringTest' %>
+  <% elsif @task.product_test.is_a? FilteringTest %>
     <% steps = [
       { title: 'Download Test Deck', partial: 'execution_download', disable: false, disable_msg: '' },
       { title: 'Filter Patients', partial: 'filter_instructions', disable: false, disable_msg: '' },
       { title: 'Upload Files', partial: 'execution_upload', disable: @task.product_test.state == :errored, disable_msg: 'Cannot upload files to an errored test.' }
       ] %>
-  <% elsif @task.product_test._type == 'ChecklistTest' %>
+  <% elsif @task.product_test.is_a? ChecklistTest %>
     <% steps = [
       { title: 'Upload Files', partial: 'execution_upload', disable: @task.product_test.state == :errored, disable_msg: 'Cannot upload files to an errored test.' }
       ] %>

--- a/test/helpers/products_helper_test.rb
+++ b/test/helpers/products_helper_test.rb
@@ -394,7 +394,7 @@ class ProductsHelperTest < ActiveJob::TestCase
   end
 
   def test_measure_test_tasks
-    assert measure_test_tasks(@product, true).all? { |task| task._type == 'C1Task' }
-    assert measure_test_tasks(@product, false).all? { |task| task._type == 'C2Task' }
+    assert measure_test_tasks(@product, true).all? { |task| task.is_a? C1Task }
+    assert measure_test_tasks(@product, false).all? { |task| task.is_a? C2Task }
   end
 end


### PR DESCRIPTION
Added helper methods in order to add the ability to call (for example) `task.C1Task?` instead of having to call `task._type == 'C1Task'`. Dynamically generate methods in order to reduce code duplication.

The biggest objection I can see to this PR is the dynamic method generation. It makes the code a lot more concise and makes it a lot easier to add additional test states or states if ever needed, however it adds a little more of a learning curve to the code.
