### PR TITLE
A few small optimization tweaks

### DIFF
--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -10,7 +10,7 @@ class ChecklistTestsController < ProductTestsController
     @product_test.save!
     @product_test.create_checked_criteria
     C1ManualTask.new(product_test: @product_test).save!
-    redirect_to vendor_product_path(@product.vendor, @product, anchor: 'ChecklistTest')
+    redirect_to vendor_product_path(@product.vendor_id, @product, anchor: 'ChecklistTest')
   end
 
   def show
@@ -37,7 +37,7 @@ class ChecklistTestsController < ProductTestsController
   def destroy
     @product_test.destroy
     respond_to do |format|
-      format.html { redirect_to vendor_product_path(@product.vendor, @product) }
+      format.html { redirect_to vendor_product_path(@product.vendor_id, @product) }
     end
   end
 
@@ -57,8 +57,8 @@ class ChecklistTestsController < ProductTestsController
 
   def set_breadcrumbs
     add_breadcrumb 'Dashboard', :vendors_path
-    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor)
-    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor, @product)
+    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor_id)
+    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor_id, @product)
     add_breadcrumb 'Manual Entry Test', product_checklist_test_path(@product, @product_test)
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -15,8 +15,8 @@ class ProductsController < ApplicationController
   end
 
   def show
-    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor)
-    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor, @product)
+    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor_id)
+    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor_id, @product)
     respond_with(@product, &:js)
   end
 
@@ -44,8 +44,8 @@ class ProductsController < ApplicationController
   end
 
   def edit
-    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor)
-    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor, @product)
+    add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor_id)
+    add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor_id, @product)
     add_breadcrumb 'Edit Product', :edit_vendor_path
     @selected_measure_ids = @product.measure_ids
   end
@@ -55,7 +55,7 @@ class ProductsController < ApplicationController
     @product.save!
     flash_comment(@product.name, 'info', 'edited')
     respond_with(@product) do |f|
-      f.html { redirect_to vendor_path(@product.vendor) }
+      f.html { redirect_to vendor_path(@product.vendor_id) }
     end
   rescue Mongoid::Errors::Validations, Mongoid::Errors::DocumentNotFound
     respond_with(@product) do |f|
@@ -70,7 +70,7 @@ class ProductsController < ApplicationController
     @product.destroy
     flash_comment(@product.name, 'danger', 'removed')
     respond_with(@product) do |f|
-      f.html { redirect_to vendor_path(@product.vendor) }
+      f.html { redirect_to vendor_path(@product.vendor_id) }
     end
   end
 
@@ -102,7 +102,7 @@ class ProductsController < ApplicationController
   end
 
   def setup_new
-    add_breadcrumb 'Vendor: ' + @vendor.name, vendor_path(@product.vendor)
+    add_breadcrumb 'Vendor: ' + @vendor.name, vendor_path(@product.vendor_id)
     add_breadcrumb 'Add Product', :new_vendor_path
     set_measures
     params[:action] = 'new'

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -48,10 +48,10 @@ module VendorsHelper
 
   def vendor_statuses(vendor)
     h = {}
-    h['passing'] = vendor.products_passing.count
-    h['failing'] = vendor.products_failing.count
-    h['errored'] = vendor.products_errored.count
-    h['incomplete'] = vendor.products_incomplete.count
+    h['passing'] = vendor.products_passing_count
+    h['failing'] = vendor.products_failing_count
+    h['errored'] = vendor.products_errored_count
+    h['incomplete'] = vendor.products_incomplete_count
     h['total'] = vendor.products.count
     h
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -97,6 +97,6 @@ class Task
   # returns the most recent execution for this task
   # if there are none, returns nil
   def most_recent_execution
-    test_executions.any? ? test_executions.order_by(created_at: 'desc').first : nil
+    test_executions.any? ? test_executions.order_by(created_at: 'desc').limit(1).first : nil
   end
 end

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -51,11 +51,11 @@ class Vendor
   def status
     Rails.cache.fetch("#{cache_key}/status") do
       total = products.count
-      if products_failing.count > 0
+      if products_failing_count > 0
         'failing'
-      elsif products_passing.count == total && total > 0
+      elsif products_passing_count == total && total > 0
         'passing'
-      elsif products_errored.count > 0
+      elsif products_errored_count > 0
         'errored'
       else
         'incomplete'

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -63,27 +63,17 @@ class Vendor
     end
   end
 
-  def products_passing
-    Rails.cache.fetch("#{cache_key}/products_passing") do
-      products.select { |product| product.status == 'passing' }
+  %w(passing failing errored incomplete).each do |product_state|
+    define_method "products_#{product_state}" do
+      Rails.cache.fetch("#{cache_key}/products_#{product_state}") do
+        products.select { |product| product.status == product_state }
+      end
     end
-  end
 
-  def products_failing
-    Rails.cache.fetch("#{cache_key}/products_failing") do
-      products.select { |product| product.status == 'failing' }
-    end
-  end
-
-  def products_errored
-    Rails.cache.fetch("#{cache_key}/products_errored") do
-      products.select { |product| product.status == 'errored' }
-    end
-  end
-
-  def products_incomplete
-    Rails.cache.fetch("#{cache_key}/products_incomplete") do
-      products.select { |product| product.status == 'incomplete' }
+    define_method "products_#{product_state}_count" do
+      Rails.cache.fetch("#{cache_key}/products_#{product_state}_count") do
+        products.count { |product| product.status == product_state }
+      end
     end
   end
 end

--- a/app/views/application/_header_product.html.erb
+++ b/app/views/application/_header_product.html.erb
@@ -1,11 +1,11 @@
 <div class="panel panel-primary">
   <div class="panel-body">
     <div class="panel-actions pull-right">
-      <%= button_to edit_vendor_product_path(@product.vendor, @product), :method => :get, :class => "btn btn-default" do %>
+      <%= button_to edit_vendor_product_path(@product.vendor_id, @product), :method => :get, :class => "btn btn-default" do %>
         <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Product
       <% end %>
       <% if current_user.user_role?(:atl) || current_user.user_role?(:admin) %>
-        <%= button_to report_vendor_product_path(@product.vendor, @product), :method => :get, :class => "btn btn-default" do %>
+        <%= button_to report_vendor_product_path(@product.vendor_id, @product), :method => :get, :class => "btn btn-default" do %>
           <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Report
         <% end %>
       <% end %>

--- a/app/views/application/_product_status_table.html.erb
+++ b/app/views/application/_product_status_table.html.erb
@@ -16,7 +16,7 @@
     <tr>
       <% if show_product_link %>
         <th scope="col" rowspan="2" class="product-name">
-          <%= link_to product.name, vendor_product_path(product.vendor, product) %>
+          <%= link_to product.name, vendor_product_path(product.vendor_id, product) %>
         </th>
       <% else %>
         <td rowspan="2"><span class="sr-only">Status</span></td>

--- a/app/views/checklist_tests/print_criteria.html.erb
+++ b/app/views/checklist_tests/print_criteria.html.erb
@@ -5,7 +5,7 @@
 <h1>Criteria List for C1 Manual Entry Test</h1>
 
 <% add_breadcrumb 'Dashboard', vendors_path %>
-<% add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor) %>
+<% add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor_id) %>
 <% add_breadcrumb 'Product: ' + @product.name, product_path(@product) %>
 <% add_breadcrumb 'Manual Entry Test: ', product_checklist_test_path(@product, checklist_test) %>
 <% add_breadcrumb 'Criteria List' %>

--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -10,7 +10,7 @@
 <% num_measure_tests_ready = product.product_tests.measure_tests.where(state: :ready).count %>
 <% if num_measure_tests_ready == num_measure_tests %>
   <p>This download contains a folder for each measure selected for this product. Inside these folders are XML documents for each patient associated with that measure.</p>
-  <%= form_for product, url: patients_vendor_product_path(product.vendor, product), :html => { :method => 'GET' } do |f| %>
+  <%= form_for product, url: patients_vendor_product_path(product.vendor_id, product), :html => { :method => 'GET' } do |f| %>
     <%= button_tag(type: 'submit', class: 'btn btn-primary') do %>
       <i class = 'fa fa-fw fa-download'></i> Download All Patients (.zip)
     <% end %>

--- a/app/views/products/edit.html.erb
+++ b/app/views/products/edit.html.erb
@@ -2,4 +2,4 @@
 
 <%= render :partial => 'product_form', locals: { submit_text: "Edit Product" } %>
 
-<%= render partial: 'remove_panel', locals: { name: @product.name, type: 'product', message: 'Removing a product will also delete all associated product tests and test execution results. Be sure you want to do this.', delete_path: vendor_product_path(@product.vendor, @product) } %>
+<%= render partial: 'remove_panel', locals: { name: @product.name, type: 'product', message: 'Removing a product will also delete all associated product tests and test execution results. Be sure you want to do this.', delete_path: vendor_product_path(@product.vendor_id, @product) } %>

--- a/app/views/test_executions/create.js.erb
+++ b/app/views/test_executions/create.js.erb
@@ -4,7 +4,7 @@
 <% @product = @test_execution.task.product_test.product %>
 
 <% # set PATH_INFO so AJAX call can be made in /products/measure_tests_table partial. this AJAX call is for reloading each product_test_link %>
-<% request.env['PATH_INFO'] = vendor_product_path(@product.vendor, @product) %>
+<% request.env['PATH_INFO'] = vendor_product_path(@product.vendor_id, @product) %>
 
 <% task = Task.find(params[:task_id]) %>
 <% is_measure_test_execution = task.product_test._type == 'MeasureTest' %>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -29,12 +29,12 @@
         <tr>
           <th scope="row"><div class = "abbreviated"><%= link_to vendor.name, vendor_path(vendor) %></div></th>
           <td>
-            <% if vendor.products.count == 0 %>
+            <% if vendor_statuses['total'] == 0 %>
               <%= button_to new_vendor_product_path(vendor), :method => :get, :class => "btn btn-primary btn-sm" do %>
                 <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
               <% end %>
             <% else %>
-              <%= vendor.products.count %>
+              <%= vendor_statuses['total'] %>
             <% end %>
           </td>
 


### PR DESCRIPTION
Removed duplicated counting of the number of products in a vendor. Use vendor_id instead of vendor when generating a link to the vendor product path since calling product.vendor generates another database query (for the complete vendor) but vendor_id doesn't.