### PR TITLE
Added port range validation to smtp settings

### DIFF
--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -15,7 +15,7 @@
         <legend>Email Settings</legend>
         <div class="row">
           <%= f.text_field :mailer_address, wrapper: { class: "col-sm-10" },  label: "SMTP Server", value: smtp_settings.address %>
-          <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", maxLength: 5, value: smtp_settings.port %>
+          <%= f.number_field :mailer_port, wrapper: { class: "col-sm-2" }, label: "Port", value: smtp_settings.port, min: 1, max: 65535 %>
         </div>
         <%= f.text_field :mailer_domain, label: "Mailer Domain", value: smtp_settings.domain %>
         <%= f.text_field :mailer_user_name, label: "Mailer Username", value: smtp_settings.user_name %>


### PR DESCRIPTION
I was initially planning to add validation for all the fields however any additional validation has the potential to block legitimate settings. For example filtering the SMTP server name to only hostnames would mean that things such as localhost or an IP would be considered invalid, even though they could be perfectly valid settings. The case for the mailer username is similar since it could potentially be a full email or a single word and either would be valid.