### PR TITLE
Fail in a more clean manner when the upgrade script runs into an error  involving cypress.yml

### DIFF
--- a/contrib/upgrade_cypress_30.sh
+++ b/contrib/upgrade_cypress_30.sh
@@ -30,6 +30,16 @@ function pull_git_tag() {
     # pull in case we're on a branch
     sudo -u cypress git pull
     sudo -u cypress git stash pop
+    rc=$?
+    if [[ $rc != 0 ]]; then
+      sudo -u cypress cp config/cypress.yml config/cypress.yml.old
+      echo "WARNING: Unable to merge cypress config cleanly, you will need to manually reset your settings in `pwd`/config/cypress.yml manually or through the admin control panel."
+      echo "The old version of your config file can be found at `pwd`/config/cypress.yml.old"
+      # First time marks conflict as resolved, second unstages changes
+      sudo -u cypress git reset HEAD config/cypress.yml
+      sudo -u cypress git reset HEAD config/cypress.yml
+      sudo -u cypress git stash drop
+    fi
   else
     echo "Handling previous error..."
     echo "We do NOT have permission to pull cypress as the user cypress, using root to run git commands."
@@ -39,6 +49,16 @@ function pull_git_tag() {
     # pull in case we're on a branch
     git pull
     git stash pop
+    rc=$?
+    if [[ $rc != 0 ]]; then
+      cp config/cypress.yml config/cypress.yml.old
+      echo "WARNING: Unable to merge cypress config cleanly, you will need to manually reset your settings in `pwd`/config/cypress.yml manually or through the admin control panel."
+      echo "The old version of your config file can be found at `pwd`/config/cypress.yml.old"
+      # First time marks conflict as resolved, second unstages changes
+      git reset HEAD config/cypress.yml
+      git reset HEAD config/cypress.yml
+      git stash drop
+    fi
   fi
 }
 


### PR DESCRIPTION
When merging, if the changes between upstream and local cypress.yml do not merge cleanly it currently leaves the app in a broken state. This fixes it by reverting to the upstream version (which will reset any user settings in the file.)

I can pretty easily make this revert to the users version instead of the upstream version (thus preserving their settings but not pulling in changes to the cypress.yml file). I am not sure which is more desirable in this case.