### PR TITLE
Add debug panel

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'remotipart', '~> 1.2'
 
 gem 'settingslogic'
 
+# Server usage statistics
+gem 'vmstat'
+
 # bubble up errors from embedded documents in Mongoid.
 # gem 'mongoid-embedded-errors'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -422,6 +422,7 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    vmstat (2.2.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (2.3.0)
@@ -500,7 +501,8 @@ DEPENDENCIES
   turbolinks (= 2.5.3)
   uglifier (>= 1.3.0)
   unicorn-rails
+  vmstat
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -6,6 +6,7 @@ class AdminController < ApplicationController
     @bundles = Bundle.all
     # dont allow them to muck with their own account
     @users = User.excludes(id: current_user.id).order_by(email:  1)
+    @system_usage_stats = Vmstat.snapshot
     render locals: {
       banner_message: Settings.banner_message,
       banner: Settings.banner,
@@ -14,6 +15,11 @@ class AdminController < ApplicationController
       mode_settings: application_mode_settings,
       debug_features: Settings.enable_debug_features
     }
+  end
+
+  def download_logs
+    zip = Cypress::CreateDownloadZip.export_log_files.read
+    send_data zip, type: 'application/zip', disposition: 'attachment', filename: "application_logs-#{Time.now.to_i}.zip"
   end
 
   def application_mode_settings

--- a/app/views/admin/_application_status.html.erb
+++ b/app/views/admin/_application_status.html.erb
@@ -1,0 +1,52 @@
+<div class="inline-block pull-right">
+  <%= button_to admin_download_logs_path, :method => :get, :class => "btn btn-default" do %>
+    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Application Logs
+  <% end %>
+</div>
+
+<% cpu_count = @system_usage_stats.cpus.count %>
+<legend>Average CPU Usage (<%= pluralize(cpu_count, "CPU") %>)</legend>
+<% @system_usage_stats.load_average.each_pair do |key, avg_load| %>
+  <b><%= "Past #{key.to_s}".humanize %></b>
+  <% percentage = (avg_load > cpu_count) ? 100 : (avg_load / cpu_count * 100).round %>
+  <div class="progress">
+    <div class="progress-bar progress-bar-striped <%= 'progress-bar-danger' if percentage.eql? 100 %> active" role="progressbar"
+    aria-valuenow="<%= percentage %>" aria-valuemin="0" aria-valuemax="100" style="width:<%= percentage %>%">
+      <%= avg_load.round(2) %>
+    </div>
+  </div>
+<% end %>
+
+<legend>Memory Usage</legend>
+<div class="progress">
+  <% memory_usage = @system_usage_stats.memory %>
+  <% total_memory = memory_usage.wired + memory_usage.active + memory_usage.inactive + memory_usage.free %>
+  <% wired_percentage_used = (memory_usage.wired / total_memory.to_f) * 100 %>
+  <div class="progress-bar progress-bar-striped progress-bar-danger active" role="progressbar" style="width:<%= wired_percentage_used %>%">
+    Wired
+  </div>
+  <% active_percentage_used = (memory_usage.active / total_memory.to_f) * 100 %>
+  <div class="progress-bar progress-bar-striped progress-bar-warning active" role="progressbar" style="width:<%= active_percentage_used %>%">
+    Active
+  </div>
+  <% inactive_percentage_used = (memory_usage.inactive / total_memory.to_f) * 100 %>
+  <div class="progress-bar progress-bar-striped progress-bar-info active" role="progressbar" style="width:<%= inactive_percentage_used %>%">
+    Inactive
+  </div>
+</div>
+
+<legend>Disk Usage</legend>
+<% @system_usage_stats.disks.each do |disk| %>
+  <b>Mount point <%= disk.mount %></b>
+  <% percentage = 100 - ((disk.available_blocks / disk.total_blocks.to_f) * 100).round %>
+  <div class="progress">
+    <div class="progress-bar progress-bar-striped active" role="progressbar"
+    aria-valuenow="<%= percentage %>" aria-valuemin="0" aria-valuemax="100" style="width:<%= percentage %>%">
+      <%= percentage %>%
+    </div>
+  </div>
+<% end %>
+
+<script>
+  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'application_status' }});
+</script>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -6,7 +6,7 @@
 
 <div class="settings-tabs">
   <ul>
-    <% ['application_settings', 'user_management', 'bundles'].each do |target_id| %>
+    <% ['application_settings', 'user_management', 'bundles', 'application_status'].each do |target_id| %>
       <li><a href = '#<%= target_id %>'><%= target_id.humanize.titleize %></a></li>
     <% end %>
   </ul>
@@ -27,8 +27,8 @@
     <%= render partial: 'remove_modal' %>
   </div>
 
-  <!-- <div id="application_status" >
-    <h2>This feature is coming soon</h2>
-  </div> -->
+  <div id="application_status" >
+    <%= render partial: 'application_status' %>
+  </div>
 
 </div>

--- a/app/views/admin/show.js.erb
+++ b/app/views/admin/show.js.erb
@@ -6,4 +6,8 @@
   <% else %>
     $('#display_bundle_list').html("<%= escape_javascript render partial: '/admin/bundle_list' %>");
   <% end %>
+<% elsif params[:partial] == 'application_status' %>
+  setTimeout(function(){
+    $('#application_status').html("<%= escape_javascript render partial: '/admin/application_status' %>");
+  }, 10000);
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Rails.application.routes.draw do
   namespace 'admin' do
     resource :settings, only: [:show, :edit, :update]
     get 'users/send_invitation'
+    get :download_logs
     resources :users do
       member do
         get :unlock

--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -82,6 +82,16 @@ module Cypress
       file
     end
 
+    def self.export_log_files
+      file = Tempfile.new("application_logs-#{Time.now.to_i}.zip")
+      Zip::ZipOutputStream.open(file.path) do |z|
+        Dir.glob('*/*.log') do |log_file|
+          add_file_to_zip(z, log_file, IO.read(log_file))
+        end
+      end
+      file
+    end
+
     def self.add_file_to_zip(z, file_name, file_content)
       z.put_next_entry(file_name)
       z << file_content

--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -13,7 +13,7 @@ module Cypress
     end
 
     def self.all_patients
-      file = file = Tempfile.new("all-patients-#{Time.now.to_i}")
+      file = Tempfile.new("all-patients-#{Time.now.to_i}")
       Zip::ZipOutputStream.open(file.path) do |z|
         Bundle.each do |bundle|
           records = bundle.records


### PR DESCRIPTION
A few of the features initially requested were the ability to view the status of different services such as nginx, cypress, and delayed_job. I have not included those as of right now since if nginx or cypress are down then the user is not able to access the admin site to view the stats. I have included the stats that I normally look for when trying to figure out why the server is running slow. I also did not include the delayed job status since that is displayed on the top of the page if the delayed job process is not running. Finally there is a log download button in the top right.
<img width="1126" alt="screen shot 2016-10-21 at 10 51 50 am" src="https://cloud.githubusercontent.com/assets/2308869/19603154/183dbf42-977e-11e6-98b5-efd34e9ed203.png">
