### PR TITLE
MPL download updates

### DIFF
--- a/app/assets/stylesheets/cypress/_buttons.scss
+++ b/app/assets/stylesheets/cypress/_buttons.scss
@@ -55,3 +55,8 @@
     display: inline-block;
   }
 }
+
+.download-btn {
+  padding: 6px 12px;
+  display: inline-block
+}

--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -42,13 +42,12 @@ class RecordsController < ApplicationController
 
   def download_mpl
     bundle = Bundle.find(BSON::ObjectId.from_string(params[:format]))
-    file_path = File.join(Rails.root, 'tmp', 'cache', "bundle_#{bundle.id}_mpl.zip")
 
-    unless File.exist?(file_path)
+    unless File.exist?(bundle.mpl_path)
       MplDownloadCreateJob.perform_now(bundle.id.to_s)
     end
 
-    file = File.new(file_path)
+    file = File.new(bundle.mpl_path)
     expires_in 1.month, public: true
     send_data file.read, type: 'application/zip', disposition: 'attachment', filename: "bundle_#{bundle.version}_mpl.zip"
   end

--- a/app/jobs/bundle_upload_job.rb
+++ b/app/jobs/bundle_upload_job.rb
@@ -28,5 +28,6 @@ class BundleUploadJob < ActiveJob::Base
       APP_CONFIG['default_bundle'] = @bundle.version
       sub_yml_setting('default_bundle', APP_CONFIG['default_bundle'])
     end
+    MplDownloadCreateJob.perform_later(@bundle.id.to_s)
   end
 end

--- a/app/jobs/mpl_download_create_job.rb
+++ b/app/jobs/mpl_download_create_job.rb
@@ -1,0 +1,19 @@
+class MplDownloadCreateJob < ActiveJob::Base
+  include Job::Status
+  include CypressYaml
+  after_enqueue do |job|
+    tracker = job.tracker
+    tracker.options['original_filename'] = job.arguments[1]
+    tracker.save
+  end
+  def perform(bundle_id)
+    tracker.log('Creating Download')
+    bundle = Bundle.find(BSON::ObjectId.from_string(bundle_id))
+    path = File.join(Rails.root, 'tmp', 'cache', 'bundle_download', bundle.id.to_s)
+    zip_path = File.join(Rails.root, 'tmp', 'cache', "bundle_#{bundle.id}_mpl.zip")
+    Cypress::CreateDownloadZip.bundle_directory(bundle, path)
+    zfg = ZipFileGenerator.new(path, zip_path)
+    zfg.write
+    FileUtils.rm_rf(path)
+  end
+end

--- a/app/jobs/mpl_download_create_job.rb
+++ b/app/jobs/mpl_download_create_job.rb
@@ -10,9 +10,8 @@ class MplDownloadCreateJob < ActiveJob::Base
     tracker.log('Creating Download')
     bundle = Bundle.find(BSON::ObjectId.from_string(bundle_id))
     path = File.join(Rails.root, 'tmp', 'cache', 'bundle_download', bundle.id.to_s)
-    zip_path = File.join(Rails.root, 'tmp', 'cache', "bundle_#{bundle.id}_mpl.zip")
     Cypress::CreateDownloadZip.bundle_directory(bundle, path)
-    zfg = ZipFileGenerator.new(path, zip_path)
+    zfg = ZipFileGenerator.new(path, bundle.mpl_path)
     zfg.write
     FileUtils.rm_rf(path)
   end

--- a/app/views/records/_mpl_download.html.erb
+++ b/app/views/records/_mpl_download.html.erb
@@ -1,0 +1,6 @@
+<div class="radio download-btn" style="">
+  <span class="sr-only">Download <%= bundle.title %></span>
+  <%= link_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
+    Download <span class="sr-only"><%= bundle.title %></span>
+  <% end %>
+</div>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -39,12 +39,7 @@
           <div class="radio" style="padding: 6px 12px; display: inline-block">
             <!-- label --> <%= @bundle.title %>
           </div>
-          <div class="radio" style="padding: 6px 12px; display: inline-block">
-            <span class="sr-only">Download <%= @bundle.title %></span>
-            <%= button_to download_mpl_records_path(@bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
-              Download <span class="sr-only"><%= @bundle.title %></span>
-            <% end %>
-          </div>
+          <%= render partial: "mpl_download", locals: { bundle: @bundle } %>
           <% else %>
             <!-- loop through bundles & use radio buttons -->
             <%= bootstrap_form_tag do |f| %>
@@ -54,12 +49,7 @@
                   <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
                                      checked: bundle == @bundle %>
                 </div>
-                <div class="radio" style="padding: 6px 12px; display: inline-block">
-                  <span class="sr-only">Download <%= bundle.title %></span>
-                  <%= button_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
-                    Download <span class="sr-only"><%= bundle.title %></span>
-                  <% end %>
-                </div>
+                <%= render partial: "mpl_download", locals: { bundle: bundle } %>
                 <% end # bundle loop %>
               <% end # form_group %>
             <% end # form tag %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -21,38 +21,48 @@
 
 <% else %>
   <h1>Master Patient List</h1>
-  <div class="pull-right button-row">
-    <%= button_to download_mpl_records_path(@bundle), :method => :get, :class => "btn btn-default" do %>
-      <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Master Patient List
-    <% end %>
-  </div>
 
   <div class="row">
-    <div class="col-md-7 col-sm-8">
+    <div class="col-md-5 col-sm-6">
       <h1>Filter Patients</h1>
-      <div class="form-group col-md-8 col-sm-10">
+      <div class="form-group">
         <label for="search_measures">Type to search by measure</label>
         <input id="search_measures" type="search" class="form-control" placeholder="Type the name or CMS ID of a measure"/>
       </div>
     </div>
 
     <% if !@task && !@product_test %>
-      <div class="col-md-5 col-sm-4">
+      <div class="col-md-7 col-sm-6">
         <h1>Annual Update Bundle</h1>
-        <% if Bundle.count == 1 %>
-          <!-- label --> <%= @bundle.title %>
-        <% else %>
-          <!-- loop through bundles & use radio buttons -->
-          <%= bootstrap_form_tag do |f| %>
-          <%= f.form_group :bundle_id do %>
+        <div class="col-md-8">
+          <% if Bundle.count == 1 %>
+          <div class="radio" style="padding: 6px 12px;">
+            <!-- label --> <%= @bundle.title %>
+          </div>
+          <% else %>
+            <!-- loop through bundles & use radio buttons -->
+            <%= bootstrap_form_tag do |f| %>
+              <%= f.form_group :bundle_id do %>
+                <% Bundle.all.each do |bundle| %>
+                  <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
+                                     checked: bundle == @bundle %>
+                <% end # bundle loop %>
+              <% end # form_group %>
+            <% end # form tag %>
+          <% end # bundles.count %>
+        </div>
+        <div class="col-md-4">
+          <div class="form-group">
             <% Bundle.all.each do |bundle| %>
-              <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
-                                 checked: bundle == @bundle %>
-
+              <div class="radio" style="padding: 6px 12px;">
+                <span class="sr-only">Download <%= bundle.title %></span>
+                <%= button_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
+                  Download <span class="sr-only"><%= bundle.title %></span>
+                <% end %>
+              </div>
             <% end # bundle loop %>
-          <% end # form_group %>
-          <% end # form tag %>
-        <% end # bundles.count %>
+          </div>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -34,34 +34,36 @@
     <% if !@task && !@product_test %>
       <div class="col-md-7 col-sm-6">
         <h1>Annual Update Bundle</h1>
-        <div class="col-md-8">
+        <div class="col-md-12">
           <% if Bundle.count == 1 %>
-          <div class="radio" style="padding: 6px 12px;">
+          <div class="radio" style="padding: 6px 12px; display: inline-block">
             <!-- label --> <%= @bundle.title %>
+          </div>
+          <div class="radio" style="padding: 6px 12px; display: inline-block">
+            <span class="sr-only">Download <%= @bundle.title %></span>
+            <%= button_to download_mpl_records_path(@bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
+              Download <span class="sr-only"><%= @bundle.title %></span>
+            <% end %>
           </div>
           <% else %>
             <!-- loop through bundles & use radio buttons -->
             <%= bootstrap_form_tag do |f| %>
               <%= f.form_group :bundle_id do %>
                 <% Bundle.all.each do |bundle| %>
+                <div style="display: inline-block">
                   <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
                                      checked: bundle == @bundle %>
+                </div>
+                <div class="radio" style="padding: 6px 12px; display: inline-block">
+                  <span class="sr-only">Download <%= bundle.title %></span>
+                  <%= button_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
+                    Download <span class="sr-only"><%= bundle.title %></span>
+                  <% end %>
+                </div>
                 <% end # bundle loop %>
               <% end # form_group %>
             <% end # form tag %>
           <% end # bundles.count %>
-        </div>
-        <div class="col-md-4">
-          <div class="form-group">
-            <% Bundle.all.each do |bundle| %>
-              <div class="radio" style="padding: 6px 12px;">
-                <span class="sr-only">Download <%= bundle.title %></span>
-                <%= button_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
-                  Download <span class="sr-only"><%= bundle.title %></span>
-                <% end %>
-              </div>
-            <% end # bundle loop %>
-          </div>
         </div>
       </div>
     <% end %>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,7 +1,25 @@
 {
   "ignored_warnings": [
-    {}
+    {
+      "warning_type": "File Access",
+      "warning_code": 16,
+      "fingerprint": "8cbd192252dfa52c3403db8c9cb8dc1ad0b2c03ad3800ece4a11841d1e4157e2",
+      "message": "Parameter value used in file name",
+      "file": "app/controllers/records_controller.rb",
+      "line": 51,
+      "link": "http://brakemanscanner.org/docs/warning_types/file_access/",
+      "code": "File.new(Bundle.find(BSON::ObjectId.from_string(params[:format])).mpl_path)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "RecordsController",
+        "method": "download_mpl"
+      },
+      "user_input": "params[:format]",
+      "confidence": "Weak",
+      "note": ""
+    }
   ],
-  "updated": "2016-06-21 14:55:09 -0400",
-  "brakeman_version": "3.2.1"
+  "updated": "2016-11-03 14:03:27 -0400",
+  "brakeman_version": "3.3.2"
 }

--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -12,22 +12,19 @@ module Cypress
       file
     end
 
-    def self.all_patients
-      file = Tempfile.new("all-patients-#{Time.now.to_i}")
-      Zip::ZipOutputStream.open(file.path) do |z|
-        Bundle.each do |bundle|
-          records = bundle.records
-          %w(html qrda).each do |format|
-            extensions = { html: 'html', qrda: 'xml' }
-            formatter = formatter_for_patients(records, format)
-            records.each do |r|
-              filename = "#{bundle.title}/#{format}_records/#{r.first}_#{r.last}.#{extensions[format.to_sym]}".delete("'").tr(' ', '_')
-              add_file_to_zip(z, filename, formatter.export(r))
-            end
+    def self.bundle_directory(bundle, path)
+      records = bundle.records
+      %w(html qrda).each do |format|
+        extensions = { html: 'html', qrda: 'xml' }
+        formatter = formatter_for_patients(records, format)
+        FileUtils.mkdir_p(File.join(path, "#{format}_records/"))
+        records.each do |r|
+          filename = "#{format}_records/#{r.first}_#{r.last}.#{extensions[format.to_sym]}".delete("'").tr(' ', '_')
+          File.open(File.join(path, filename), 'w') do |f|
+            f.write(formatter.export(r))
           end
         end
       end
-      file
     end
 
     def self.create_total_test_zip(product, criteria_list, format = 'qrda')

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -11,7 +11,7 @@ class Bundle
   def destroy
     results.destroy
     Product.where(bundle_id: id).destroy_all
-    FileUtils.rm(File.join(Rails.root, 'tmp', 'cache', "bundle_#{id}_mpl.zip"))
+    FileUtils.rm(mpl_path) if File.exist?(mpl_path)
     delete
   end
 
@@ -29,6 +29,10 @@ class Bundle
 
   def modified_population_labels
     ApplicationController.helpers.config_for_version(version).modified_population_labels
+  end
+
+  def mpl_path
+    File.join(Rails.root, 'tmp', 'cache', "bundle_#{id}_mpl.zip")
   end
 
   def major_version

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -11,6 +11,7 @@ class Bundle
   def destroy
     results.destroy
     Product.where(bundle_id: id).destroy_all
+    FileUtils.rm(File.join(Rails.root, 'tmp', 'cache', "bundle_#{id}_mpl.zip"))
     delete
   end
 
@@ -28,6 +29,10 @@ class Bundle
 
   def modified_population_labels
     ApplicationController.helpers.config_for_version(version).modified_population_labels
+  end
+
+  def major_version
+    version.split('.')[0]
   end
 
   def self.default

--- a/lib/ext/zip_file_generator.rb
+++ b/lib/ext/zip_file_generator.rb
@@ -1,0 +1,44 @@
+class ZipFileGenerator
+  # Initialize with the directory to zip and the location of the output archive.
+  def initialize(input_dir, output_file)
+    @input_dir = input_dir
+    @output_file = output_file
+  end
+
+  # Zip the input directory.
+  def write
+    entries = Dir.entries(@input_dir) - %w(. .. .DS_Store)
+
+    ::Zip::File.open(@output_file, ::Zip::File::CREATE) do |io|
+      write_entries entries, '', io
+    end
+  end
+
+  private
+
+  # A helper method to make the recursion work.
+  def write_entries(entries, path, io)
+    entries.each do |e|
+      zip_file_path = path == '' ? e : File.join(path, e)
+      disk_file_path = File.join(@input_dir, zip_file_path)
+
+      if File.directory? disk_file_path
+        recursively_deflate_directory(disk_file_path, io, zip_file_path)
+      else
+        put_into_archive(disk_file_path, io, zip_file_path)
+      end
+    end
+  end
+
+  def recursively_deflate_directory(disk_file_path, io, zip_file_path)
+    io.mkdir zip_file_path
+    subdir = Dir.entries(disk_file_path) - %w(. ..)
+    write_entries subdir, zip_file_path, io
+  end
+
+  def put_into_archive(disk_file_path, io, zip_file_path)
+    io.get_output_stream(zip_file_path) do |f|
+      f.puts(File.open(disk_file_path, 'rb').read)
+    end
+  end
+end

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -35,7 +35,7 @@ class Admin::BundlesControllerTest < ActionController::TestCase
       upload = Rack::Test::UploadedFile.new(Rails.root.join('test/fixtures/bundles/minimal_bundle.zip'), 'application/zip')
       perform_enqueued_jobs do
         post :create, file: upload
-        assert_performed_jobs 1
+        assert_performed_jobs 2
         assert_equal orig_bundle_count + 1, Bundle.count, 'Should have added 1 new Bundle'
         assert orig_measure_count < Measure.count, 'Should have added new measures in the bundle'
         assert orig_record_count < Record.count, 'Should have added new records in the bundle'


### PR DESCRIPTION
* Created an `MplDownloadCreateJob` to create the MPL download zip on demand (either when bundle is uploaded, or if it doesn't exist, when the button is clicked)
* Added a task to the `BundleUploadJob` to call the `MplDownloadCreateJob`
* Separated out the downloading of multiple bundles, so each bundle now has its own "Download" button
* Improved the bundle download create task, by creating it on disk first then zipping it up for efficiency