### PR TITLE
Fix startup warnings

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -3,9 +3,6 @@
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
 
-Mime::Type.register 'application/zip', :zip
-Mime::Type.register 'text/xml', :xml
-
 # Mime::Type.register 'application/vnd.api+json', :json_api
 # ActionController::Renderers.add :json_api do |obj, options|
 #   self.content_type ||= Mime[:json_api]

--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -2,7 +2,6 @@
 
 class Record
   include Mongoid::Document
-  field :test_id, type: BSON::ObjectId
   field :bundle_id
   field :measures, type: Hash
   index test_id: 1


### PR DESCRIPTION
There have been a few warnings on startup on Cypress for a while now, these two commits fix them. 

Before:

    => Booting WEBrick
    => Rails 4.2.7.1 application starting in development on http://localhost:3000
    => Run `rails server -h` for more startup options
    => Ctrl-C to shutdown server
    W, [2016-11-04T11:59:07.959888 #16296]  WARN -- : Overwriting existing field test_id in class Record.
    /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/actionpack-4.2.7.1/lib/action_dispatch/http/mime_type.rb:163: warning: already initialized constant Mime::ZIP
    /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/actionpack-4.2.7.1/lib/action_dispatch/http/mime_type.rb:163: warning: previous definition of ZIP was here
    /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/actionpack-4.2.7.1/lib/action_dispatch/http/mime_type.rb:163: warning: already initialized constant Mime::XML
    /Users/rbclark/.rbenv/versions/2.2.5/lib/ruby/gems/2.2.0/gems/actionpack-4.2.7.1/lib/action_dispatch/http/mime_type.rb:163: warning: previous definition of XML was here

After:

    => Booting WEBrick
    => Rails 4.2.7.1 application starting in development on http://localhost:3000
    => Run `rails server -h` for more startup options
    => Ctrl-C to shutdown server