### PR TITLE
Fix missing flash messages when no bundle is installed

### DIFF
--- a/app/controllers/admin/bundles_controller.rb
+++ b/app/controllers/admin/bundles_controller.rb
@@ -38,6 +38,7 @@ module Admin
         BundleUploadJob.perform_later(file_path, bundle_file.original_filename)
         redirect_to admin_path(anchor: 'bundles')
       else
+        flash[:alert] = 'No bundle file provided.'
         redirect_to new_admin_bundle_path
       end
     end

--- a/app/views/admin/bundles/new.html.erb
+++ b/app/views/admin/bundles/new.html.erb
@@ -7,7 +7,7 @@
   </div>
 
   <div class="panel-footer">
-    <%= f.submit 'Import Bundle', :class => "btn btn-success", :id => "submit_button" %>
+    <%= f.submit 'Import Bundle', :class => "btn btn-success", :id => "submit_button", data: { disable_with: "Please wait..." } %>
     <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>
   </div>
 <% end %>

--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -9,6 +9,12 @@ Given(/^the user is on the sign in page$/) do
   visit '/'
 end
 
+And(/^there are no bundles installed$/) do
+  Bundle.destroy_all
+  Rails.cache.clear
+  assert Bundle.count == 0
+end
+
 When(/^I click Sign up$/) do
   page.click_link_or_button 'Sign up'
   sleep(1) # Gross, but otherwise this randomly fails @SS

--- a/features/users/login_no_bundle.feature
+++ b/features/users/login_no_bundle.feature
@@ -1,0 +1,25 @@
+Feature: Test Login Features with No Bundle Installed
+
+Background:
+  Given a user has an account
+  And there are no bundles installed
+
+Scenario: Unsuccessful login
+  When the user tries to log in with invalid information
+  Then the user should see an log in error message
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
+
+Scenario: Successful login
+  When the user logs in
+  Then the user should see an log in success message
+  And the user should see a sign out link
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
+
+Scenario: Not Logged In
+  When the user navigates to the home page
+  Then the user should be redirected to the sign in page
+  And the user should not see a warning message
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa


### PR DESCRIPTION
Also a few other small improvements to the bundle detection code. This removes the caching of a nil value when a bundle is not installed and only caches when a bundle is actually imported. Also it stops the user from spamming the bundle import button and causing the same bundle to be imported multiple times. Finally it adds tests to make sure the flash messages do show up correctly.