### PR TITLE
Cache records on the records index.html.erb page based on the measure passed in 

### DIFF
--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -59,7 +59,7 @@
 
 <% end %>
 
-<% cache @records do %>
+<% cache [@records, @measure] do %>
   <div class="row">
     <div id="records_list" class="col-sm-12">
       <%= render partial: 'records_list', locals: { records: @records } %>


### PR DESCRIPTION
This fixes a Pivotal bug where only the first measure of a measure with different submeasures would show up, because different sub IDs have different measure objects.

 This still works with the MPL, too; the measure is just marked as 'nil'