### PR TITLE
Optimize product and vendor load times

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,9 @@ gem 'jquery-ui-rails', '~> 5.0.5'
 gem 'modernizr-rails', '~> 2.7.1'
 gem 'font-awesome-sass'
 
+# Add pagination support
+gem 'kaminari-mongoid'
+
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '>= 1.3.0'
 # Bake the best breadcrumbs

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,6 +224,11 @@ GEM
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.3)
+    kaminari (0.17.0)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
+    kaminari-mongoid (0.1.2)
+      kaminari
     kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -470,6 +475,7 @@ DEPENDENCIES
   jquery-datatables-rails (~> 3.3.0)
   jquery-rails (~> 4.0.4)
   jquery-ui-rails (~> 5.0.5)
+  kaminari-mongoid
   launchy
   local_time
   minitest

--- a/app/assets/javascripts/infinite-scroll.js
+++ b/app/assets/javascripts/infinite-scroll.js
@@ -1,0 +1,44 @@
+$(function() {
+  var approachingBottomOfPage, loadNextPageAt, nextPage, nextPageFnRunning, viewMore;
+
+  viewMore = $('#view-more');
+  nextPageFnRunning = false;
+  loadNextPageAt = 3000;
+
+  approachingBottomOfPage = function() {
+    return $(window).scrollTop() > $(document).height() - $(window).height() - loadNextPageAt;
+  };
+
+  nextPage = function() {
+    var loadingMore, url;
+    viewMore = $('#view-more');
+    loadingMore = $('#loading-more');
+    url = viewMore.find('a').attr('href');
+    if (nextPageFnRunning || !url) {
+      return;
+    }
+    viewMore.hide();
+    loadingMore.show();
+    nextPageFnRunning = true;
+    return $.ajax({
+      url: url,
+      method: 'GET',
+      dataType: 'script'
+    }).always(function() {
+      nextPageFnRunning = false;
+      viewMore.show();
+      return loadingMore.hide();
+    });
+  };
+
+  $(window).on('load scroll', function() {
+    if (approachingBottomOfPage()) {
+      return nextPage();
+    }
+  });
+
+  viewMore.find('a').unbind('click').click(function(e) {
+    nextPage();
+    return e.preventDefault();
+  });
+});

--- a/app/assets/stylesheets/cypress/_vendor.scss
+++ b/app/assets/stylesheets/cypress/_vendor.scss
@@ -22,6 +22,16 @@
   border: 1px solid darken($state-info-bg, 20%);
 }
 
+.scroll-link-wrapper {
+  // Provide reasonable clearance to bottom of page
+  height: 30px;
+  padding-bottom: 40px;
+
+  .default-hidden {
+    display: none;
+  }
+}
+
 .vendor-details {
   margin-left: 1.5em;
   display: flex;

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -9,6 +9,8 @@ class VendorsController < ApplicationController
   add_breadcrumb 'Dashboard', :vendors_path
   add_breadcrumb 'Add Vendor', :new_vendor_path, only: [:new, :create]
 
+  respond_to :js, only: [:show]
+
   def index
     # get all of the vendors that the user can see
     @vendors = Vendor.accessible_by(current_user).order(:updated_at => :desc) # Vendor.accessible_by(current_user).all.order(:updated_at => :desc)
@@ -17,7 +19,7 @@ class VendorsController < ApplicationController
 
   def show
     add_breadcrumb 'Vendor: ' + @vendor.name, :vendor_path
-    @products = Product.where(vendor_id: @vendor.id).order_by(state: 'desc')
+    @products = Product.where(vendor_id: @vendor.id).order_by(state: 'desc').page(params[:page]).per(5)
     respond_with(@vendor)
   end
 

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -52,7 +52,7 @@ module VendorsHelper
     h['failing'] = vendor.products_failing_count
     h['errored'] = vendor.products_errored_count
     h['incomplete'] = vendor.products_incomplete_count
-    h['total'] = vendor.products.count
+    h['total'] = h['passing'] + h['failing'] + h['errored'] + h['incomplete']
     h
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,22 +34,17 @@ class Product
 
   def status
     Rails.cache.fetch("#{cache_key}/status") do
-      total = product_tests.count
-      if product_tests_for_status('failing').count > 0
+      grouped_products = product_tests.includes(:tasks).group_by(&:status)
+      total = product_tests.size
+      if grouped_products.key?('failing') && grouped_products['failing'].count > 0
         'failing'
-      elsif product_tests_for_status('passing').count == total && total > 0
+      elsif grouped_products.key?('passing') && grouped_products['passing'].count == total
         c1_test && product_tests.checklist_tests.empty? ? 'incomplete' : 'passing'
-      elsif product_tests_for_status('errored').count > 0
+      elsif grouped_products.key?('errored') && grouped_products['errored'].count > 0
         'errored'
       else
         'incomplete'
       end
-    end
-  end
-
-  def product_tests_for_status(status)
-    Rails.cache.fetch("#{cache_key}/product_tests_#{status}") do
-      product_tests.select { |product_test| product_test.status == status }
     end
   end
 

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -117,21 +117,16 @@ class ProductTest
 
   def status
     Rails.cache.fetch("#{cache_key}/status") do
-      if tasks_by_status('failing').count > 0
+      grouped_tasks = tasks.group_by(&:status)
+      if grouped_tasks.key?('failing') && grouped_tasks['failing'].count > 0
         'failing'
-      elsif tasks_by_status('passing').count == tasks.count && tasks.count > 0
+      elsif grouped_tasks.key?('passing') && grouped_tasks['passing'].count == tasks.size
         'passing'
-      elsif tasks_by_status('errored').count > 0
+      elsif grouped_tasks.key?('errored') && grouped_tasks['errored'].count > 0
         'errored'
       else
         'incomplete'
       end
-    end
-  end
-
-  def tasks_by_status(status)
-    Rails.cache.fetch("#{cache_key}/tasks_#{status}") do
-      tasks.select { |task| task.status == status }
     end
   end
 

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -33,7 +33,7 @@
             <tbody>
               <%= f.fields_for :checked_criteria, product_test.checked_criteria.all(measure_id: measure.id) do |criteria_field| %>
                 <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
-                <% if criteria.has_key?('description') %>
+                <% if criteria.key?('description') %>
                   <tr>
                     <td rowspan="3">
                       <% if criteria_field.object.passed_qrda %>

--- a/app/views/checklist_tests/print_criteria.html.erb
+++ b/app/views/checklist_tests/print_criteria.html.erb
@@ -34,7 +34,7 @@
                 <tbody>
                   <%= f.fields_for :checked_criteria, checklist_test.checked_criteria.all(measure_id: measure.id) do |criteria_field| %>
                     <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
-                    <% if criteria.has_key?('description') %>
+                    <% if criteria.key?('description') %>
                       <tr>
                         <% valuessets = criteria_field.object.get_all_valuesets_for_dc(measure) %>
                         <% if valuessets.empty? %>

--- a/app/views/vendors/_vendor.html.erb
+++ b/app/views/vendors/_vendor.html.erb
@@ -1,0 +1,29 @@
+<% vendor_statuses = vendor_statuses(vendor) %>
+<tr>
+  <th scope="row"><div class = "abbreviated"><%= link_to vendor.name, vendor_path(vendor) %></div></th>
+  <td>
+    <% if vendor_statuses['total'] == 0 %>
+      <%= button_to new_vendor_product_path(vendor), :method => :get, :class => "btn btn-primary btn-sm" do %>
+        <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
+      <% end %>
+    <% else %>
+      <%= vendor_statuses['total'] %>
+    <% end %>
+  </td>
+
+  <% %w(passing failing errored incomplete).each do |status| %>
+    <% if vendor_statuses[status] > 0 %>
+      <% classes = status_to_css_classes(status) %>
+      <td class="<%= classes['cell'] %> text-center">
+        <%= vendor_statuses[status] %>
+      </td>
+    <% else %>
+      <td></td>
+    <% end %>
+  <% end %>
+  <td class="text-right">
+    <%= button_to edit_vendor_path(vendor), :method => :get, :class => "btn btn-sm btn-default" do %>
+      <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Vendor
+    <% end %>
+  </td>
+</tr>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -24,37 +24,7 @@
       </tr>
     </thead>
     <tbody>
-      <% @vendors.each do |vendor| %>
-        <% vendor_statuses = vendor_statuses(vendor) %>
-        <tr>
-          <th scope="row"><div class = "abbreviated"><%= link_to vendor.name, vendor_path(vendor) %></div></th>
-          <td>
-            <% if vendor_statuses['total'] == 0 %>
-              <%= button_to new_vendor_product_path(vendor), :method => :get, :class => "btn btn-primary btn-sm" do %>
-                <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
-              <% end %>
-            <% else %>
-              <%= vendor_statuses['total'] %>
-            <% end %>
-          </td>
-
-          <% %w(passing failing errored incomplete).each do |status| %>
-            <% if vendor_statuses[status] > 0 %>
-              <% classes = status_to_css_classes(status) %>
-              <td class="<%= classes['cell'] %> text-center">
-                <%= vendor_statuses[status] %>
-              </td>
-            <% else %>
-              <td></td>
-            <% end %>
-          <% end %>
-          <td class="text-right">
-            <%= button_to edit_vendor_path(vendor), :method => :get, :class => "btn btn-sm btn-default" do %>
-              <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Vendor
-            <% end %>
-          </td>
-        </tr>
-      <% end %>
+      <%= render partial: 'vendor', collection: @vendors %>
     </tbody>
   </table>
 <% end %>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -9,9 +9,19 @@
   </p>
 <% else %>
   <h1><%= @products.count %> Products</h1>
-  <div class="vendor-product-status">
-    <% @products.each do |product| %>
-      <%= render partial: 'product_status_table', locals: { show_product_link: true, product: product } %>
-    <% end %>
+  <div class="vendor-product-status infinite-scroll">
+    <%= render partial: 'product_status_table', collection: @products, as: :product, locals: { show_product_link: true } %>
   </div>
+  <% unless @products.current_page == @products.total_pages %>
+    <div class="text-center scroll-link-wrapper">
+      <p id="view-more">
+        <!-- Error should only show up when the page is not properly infinitely scrolling -->
+        <%= link_to('Loading Error - Try Again?', url_for(page: @products.current_page + 1)) %>
+      </p>
+      <p id="loading-more" class="default-hidden">
+        <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i>
+        Loading More Products
+      </p>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/vendors/show.js.erb
+++ b/app/views/vendors/show.js.erb
@@ -1,0 +1,7 @@
+$('.infinite-scroll').append("<%=j render(partial:'product_status_table', collection: @products, as: :product, locals: { show_product_link: true }) %>");
+
+<% if @products.current_page == @products.total_pages %>
+  $('#view-more').remove();
+<% else %>
+  $('#view-more a').attr('href', '<%= url_for(page: @products.current_page + 1) %>');
+<% end %>

--- a/lib/tasks/tmp.rake
+++ b/lib/tasks/tmp.rake
@@ -1,0 +1,15 @@
+require 'rails/tasks'
+
+namespace :tmp do
+  namespace :cache do
+    # desc "Cleans and then rebuilds the cypress cache"
+    task rebuild: [:environment] do
+      puts 'Warming the vendor and product state cache...'
+      Vendor.each(&:status)
+    end
+  end
+end
+
+Rake::Task['tmp:cache:clear'].enhance do
+  Rake::Task['tmp:cache:rebuild'].invoke
+end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -278,22 +278,10 @@ end
 class ProductCachingTest < CachingTest
   def test_product_status_and_product_test_groups_are_not_cached_on_start
     assert !Rails.cache.exist?("#{@product.cache_key}/status"), 'cache key for product status should not exist'
-    assert !Rails.cache.exist?("#{@product.cache_key}/product_tests_passing"), "cache key for product's passing product tests should not exist"
-    assert !Rails.cache.exist?("#{@product.cache_key}/product_tests_failing"), "cache key for product's failing product tests should not exist"
-    assert !Rails.cache.exist?("#{@product.cache_key}/product_tests_incomplete"), "cache key for product's incomplete product tests should not exist"
   end
 
   def test_product_status_is_cached_after_checking_status
     @product.status
     assert Rails.cache.exist?("#{@product.cache_key}/status"), 'cache key for product status should exist'
-  end
-
-  def test_product_test_groups_are_cached_after_checking_each
-    @product.product_tests_for_status('passing')
-    @product.product_tests_for_status('failing')
-    @product.product_tests_for_status('incomplete')
-    assert Rails.cache.exist?("#{@product.cache_key}/product_tests_passing"), "cache key for product's passing products tests should exist"
-    assert Rails.cache.exist?("#{@product.cache_key}/product_tests_failing"), "cache key for product's failing products tests should exist"
-    assert Rails.cache.exist?("#{@product.cache_key}/product_tests_incomplete"), "cache key for product's incomplete products tests should exist"
   end
 end

--- a/test/models/vendor_test.rb
+++ b/test/models/vendor_test.rb
@@ -143,9 +143,7 @@ end
 class VendorCachingTest < CachingTest
   def test_vendor_status_and_product_groups_are_not_cached_on_start
     assert !Rails.cache.exist?("#{@vendor.cache_key}/status"), 'cache key for vendor status should not exist'
-    assert !Rails.cache.exist?("#{@vendor.cache_key}/products_passing"), "cache key for vendor's passing products should not exist"
-    assert !Rails.cache.exist?("#{@vendor.cache_key}/products_failing"), "cache key for vendor's failing products should not exist"
-    assert !Rails.cache.exist?("#{@vendor.cache_key}/products_incomplete"), "cache key for vendor's incomplete products should not exist"
+    assert !Rails.cache.exist?("#{@vendor.cache_key}/product_counts"), 'cache key for vendor products count should not exist'
   end
 
   def test_vendor_status_is_cached_after_checking_status
@@ -153,13 +151,9 @@ class VendorCachingTest < CachingTest
     assert Rails.cache.exist?("#{@vendor.cache_key}/status"), 'cache key for vendor status should exist'
   end
 
-  def test_product_groups_are_cached_after_checking_each
-    @vendor.products_passing
-    @vendor.products_failing
-    @vendor.products_incomplete
-    assert Rails.cache.exist?("#{@vendor.cache_key}/products_passing"), "cache key for vendor's passing products should exist"
-    assert Rails.cache.exist?("#{@vendor.cache_key}/products_failing"), "cache key for vendor's failing products should exist"
-    assert Rails.cache.exist?("#{@vendor.cache_key}/products_incomplete"), "cache key for vendor's incomplete products should exist"
+  def test_product_groups_counts_are_cached_after_checking_any
+    @vendor.products_passing_count
+    assert Rails.cache.exist?("#{@vendor.cache_key}/product_counts"), 'cache key for vendor products count should exist'
   end
 
   def test_adding_test_execution_updates_vendor_cache_key


### PR DESCRIPTION
This PR has two different parts to it. The first part is some optimizations to make the vendor and product pages load faster. The result of the optimizations in the first commit are as follows:

> Without any optimizations: 112516ms (10340 sql queries in vendors)
> With "includes" optimizations 80057ms (6384 sql queries in vendors)

Additionally the tmp:clear rake task is now enhanced to also rebuild the cache right away after it is cleared. This means that in reality after running tmp:clear (which is run after every upgrade) the load time should be about `7868.5ms` with no sql queries run. I believe the additional time is due to the cache being actually loaded into memory. Subsequent reloads are in the `< 1s` range.

The second part of this is the infinite scrolling. Due to the design of the vendors page it was not possible to implement infinite scrolling on it, the problem being that sorting would no longer work correctly if additional elements were being added as the user scrolled. This problem was mitigated by the above optimizations. For the products page it was possible to implement actual infinite scrolling which helped the performance of that page on a cold cache considerably.

At this point I have not implemented any tests for the infinite scrolling code, if those are desired I can attempt to add those in as well.

@ehathaway The reason I included you on this specifically is due to the product infinite scrolling since it does affect the UI behavior a bit. 