### PR TITLE
Remove settingslogic gem from project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,8 +58,6 @@ gem 'carrierwave-mongoid', require: 'carrierwave/mongoid'
 # AJAX file uploads
 gem 'remotipart', '~> 1.2'
 
-gem 'settingslogic'
-
 # Server usage statistics
 gem 'vmstat'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -377,7 +377,6 @@ GEM
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
       websocket (~> 1.0)
-    settingslogic (2.0.9)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -496,7 +495,6 @@ DEPENDENCIES
   scss_lint
   sdoc (~> 0.4.0)
   selenium-webdriver (= 2.48.0)
-  settingslogic
   simplecov
   turbolinks (= 2.5.3)
   uglifier (>= 1.3.0)

--- a/app/controllers/admin/bundles_controller.rb
+++ b/app/controllers/admin/bundles_controller.rb
@@ -16,13 +16,13 @@ module Admin
     end
 
     def set_default
-      unless @bundle.version == Settings[:default_bundle]
+      unless @bundle.version == APP_CONFIG['default_bundle']
         Bundle.where(active: true).update_all(active: false)
         @bundle.active = true
         @bundle.save!
         Bundle.find_by(id: @bundle.id).active = true
-        Settings[:default_bundle] = @bundle.version
-        sub_yml_setting('default_bundle', Settings[:default_bundle])
+        APP_CONFIG['default_bundle'] = @bundle.version
+        sub_yml_setting('default_bundle', APP_CONFIG['default_bundle'])
       end
       redirect_to admin_path(anchor: 'bundles')
     end

--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -9,8 +9,8 @@ module Admin
     def edit
       add_breadcrumb 'Edit Settings', :edit_settings_path
       render locals: {
-        banner_message: Settings.banner_message,
-        banner: Settings.banner,
+        banner_message: APP_CONFIG['banner_message'],
+        banner: APP_CONFIG['banner'],
         smtp_settings: Rails.application.config.action_mailer.smtp_settings,
         mode: application_mode,
         mode_settings: application_mode_settings,
@@ -35,8 +35,8 @@ module Admin
     def write_banner_message(settings)
       sub_yml_setting('banner_message', settings['banner_message'])
       sub_yml_setting('banner', settings['banner'] == '1')
-      Settings[:banner_message] = settings['banner_message']
-      Settings[:banner] = settings['banner'] == '1'
+      APP_CONFIG['banner_message'] = settings['banner_message']
+      APP_CONFIG['banner'] = settings['banner'] == '1'
     end
 
     def write_mailer_settings(settings)
@@ -51,10 +51,10 @@ module Admin
     end
 
     def write_mode_settings
-      sub_yml_setting('auto_approve', Settings[:auto_approve])
-      sub_yml_setting('ignore_roles', Settings[:ignore_roles])
-      sub_yml_setting('default_role', Settings[:default_role])
-      sub_yml_setting('enable_debug_features', Settings[:enable_debug_features])
+      sub_yml_setting('auto_approve', APP_CONFIG['auto_approve'])
+      sub_yml_setting('ignore_roles', APP_CONFIG['ignore_roles'])
+      sub_yml_setting('default_role', APP_CONFIG['default_role'])
+      sub_yml_setting('enable_debug_features', APP_CONFIG['enable_debug_features'])
     end
 
     def update_application_mode(mode_name, options = {})

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -8,12 +8,12 @@ class AdminController < ApplicationController
     @users = User.excludes(id: current_user.id).order_by(email:  1)
     @system_usage_stats = Vmstat.snapshot
     render locals: {
-      banner_message: Settings.banner_message,
-      banner: Settings.banner,
+      banner_message: APP_CONFIG['banner_message'],
+      banner: APP_CONFIG['banner'],
       smtp_settings: Rails.application.config.action_mailer.smtp_settings,
       mode: application_mode,
       mode_settings: application_mode_settings,
-      debug_features: Settings.enable_debug_features
+      debug_features: APP_CONFIG['enable_debug_features']
     }
   end
 
@@ -23,43 +23,44 @@ class AdminController < ApplicationController
   end
 
   def application_mode_settings
-    settings_hash = { auto_approve: Settings[:auto_approve], ignore_roles: Settings[:ignore_roles], debug_features: Settings[:enable_debug_features] }
-    settings_hash[:default_role] = if Settings[:default_role].nil?
+    settings_hash = { auto_approve: APP_CONFIG['auto_approve'], ignore_roles: APP_CONFIG['ignore_roles'],
+                      debug_features: APP_CONFIG['enable_debug_features'] }
+    settings_hash[:default_role] = if APP_CONFIG['default_role'].nil?
                                      'None'
-                                   elsif Settings[:default_role] == :atl
+                                   elsif APP_CONFIG['default_role'] == :atl
                                      'ATL'
                                    else
-                                     Settings[:default_role].to_s.humanize
+                                     APP_CONFIG['default_role'].to_s.humanize
                                    end
     settings_hash
   end
 
   def mode_internal
-    Settings[:auto_approve] = true
-    Settings[:ignore_roles] = true
-    Settings[:default_role] = nil
-    Settings[:enable_debug_features] = true
+    APP_CONFIG['auto_approve'] = true
+    APP_CONFIG['ignore_roles'] = true
+    APP_CONFIG['default_role'] = nil
+    APP_CONFIG['enable_debug_features'] = true
   end
 
   def mode_demo
-    Settings[:auto_approve] = true
-    Settings[:ignore_roles] = false
-    Settings[:default_role] = :user
-    Settings[:enable_debug_features] = true
+    APP_CONFIG['auto_approve'] = true
+    APP_CONFIG['ignore_roles'] = false
+    APP_CONFIG['default_role'] = :user
+    APP_CONFIG['enable_debug_features'] = true
   end
 
   def mode_atl
-    Settings[:auto_approve] = false
-    Settings[:ignore_roles] = false
-    Settings[:default_role] = nil
-    Settings[:enable_debug_features] = false
+    APP_CONFIG['auto_approve'] = false
+    APP_CONFIG['ignore_roles'] = false
+    APP_CONFIG['default_role'] = nil
+    APP_CONFIG['enable_debug_features'] = false
   end
 
   def mode_custom(settings)
-    Settings[:auto_approve] = settings['auto_approve'] == 'enable'
-    Settings[:ignore_roles] = settings['ignore_roles'] == 'enable'
-    Settings[:default_role] = settings['default_role'] == 'None' ? nil : settings['default_role'].underscore.to_sym
-    Settings[:enable_debug_features] = settings['debug_features'] == 'enable'
+    APP_CONFIG['auto_approve'] = settings['auto_approve'] == 'enable'
+    APP_CONFIG['ignore_roles'] = settings['ignore_roles'] == 'enable'
+    APP_CONFIG['default_role'] = settings['default_role'] == 'None' ? nil : settings['default_role'].underscore.to_sym
+    APP_CONFIG['enable_debug_features'] = settings['debug_features'] == 'enable'
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,15 +28,15 @@ class ApplicationController < ActionController::Base
   end
 
   def mode_internal?
-    Settings[:auto_approve] && Settings[:ignore_roles] && Settings[:enable_debug_features] && Settings[:default_role].nil?
+    APP_CONFIG['auto_approve'] && APP_CONFIG['ignore_roles'] && APP_CONFIG['enable_debug_features'] && APP_CONFIG['default_role'].nil?
   end
 
   def mode_demo?
-    Settings[:auto_approve] && !Settings[:ignore_roles] && Settings[:enable_debug_features] && Settings[:default_role] == :user
+    APP_CONFIG['auto_approve'] && !APP_CONFIG['ignore_roles'] && APP_CONFIG['enable_debug_features'] && APP_CONFIG['default_role'] == :user
   end
 
   def mode_atl?
-    !Settings[:auto_approve] && !Settings[:ignore_roles] && !Settings[:enable_debug_features] && Settings[:default_role].nil?
+    !APP_CONFIG['auto_approve'] && !APP_CONFIG['ignore_roles'] && !APP_CONFIG['enable_debug_features'] && APP_CONFIG['default_role'].nil?
   end
 
   def application_mode

--- a/app/jobs/bundle_upload_job.rb
+++ b/app/jobs/bundle_upload_job.rb
@@ -25,8 +25,8 @@ class BundleUploadJob < ActiveJob::Base
       @bundle.active = false
       @bundle.save!
     else
-      Settings[:default_bundle] = @bundle.version
-      sub_yml_setting('default_bundle', Settings[:default_bundle])
+      APP_CONFIG['default_bundle'] = @bundle.version
+      sub_yml_setting('default_bundle', APP_CONFIG['default_bundle'])
     end
   end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -1,3 +1,0 @@
-class Settings < Settingslogic
-  source "#{Rails.root}/config/cypress.yml"
-end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,7 @@ class User
   index(invitation_token: 1)
   index(invitation_by_id: 1)
 
-  field :approved, type: Boolean, default: Settings[:auto_approve] || false
+  field :approved, type: Boolean, default: APP_CONFIG['auto_approve'] || false
 
   validates :terms_and_conditions, :acceptance => true, :on => :create, :allow_nil => false
 
@@ -101,11 +101,11 @@ class User
   end
 
   def assign_default_role
-    dr = Settings[:default_role]
+    dr = APP_CONFIG['default_role']
     add_role dr if dr
   end
 
   def user_role?(*args)
-    has_role?(*args) || Settings[:ignore_roles]
+    has_role?(*args) || APP_CONFIG['ignore_roles']
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,8 +18,8 @@
 <body <%= yield(:body_attributes) %>>
   <a href="#main-content" class="sr-only sr-only-focusable">Skip to main content</a>
 
-  <% if Settings.banner %>
-    <div class="demo"><%= Settings.banner_message %></div>
+  <% if APP_CONFIG['banner'] %>
+    <div class="demo"><%= APP_CONFIG['banner_message'] %></div>
   <% end %>
 
   <header role="banner">

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -32,7 +32,7 @@
         </div>
 
         <div class="col-md-6">
-          <% if Settings[:enable_debug_features]%>
+          <% if APP_CONFIG['enable_debug_features']%>
             <fieldset>
               <legend class="control-label">Records Options</legend>
               <%= f.form_group help: "Recommended for most robust testing." do %>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -28,7 +28,7 @@
   <br/>
   <% unless @task.is_a? C1ManualTask %>
   <%= link_to 'View Patients', { controller: 'records', task_id: @task.id}, method: :get %>
-  <% if Settings['enable_debug_features'] %>
+  <% if APP_CONFIG['enable_debug_features'] %>
   <br/>
   <%= link_to 'Get Known Good Result', good_results_task_path(@task), data: { no_turbolink: true } %>
   <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require 'sprockets/railtie'
 require 'rails/test_unit/railtie'
 require_relative '../lib/hash'
 
-APP_CONFIG = YAML.load(File.read(File.expand_path('../cypress.yml', __FILE__)))
+APP_CONFIG = YAML.load(ERB.new(File.read(File.expand_path('../cypress.yml', __FILE__))).result)
 CAT1_CONFIG = YAML.load(File.read(File.expand_path('../cat1checklist.yml', __FILE__)))
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,12 +45,12 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: Settings[:mailer_address],
-    port: Settings[:mailer_port],
-    domain: Settings[:mailer_domain],
-    user_name: Settings[:mailer_user_name],
-    password: Settings[:mailer_password],
-    authentication: Settings[:mailer_authentication]
+    address: APP_CONFIG['mailer_address'],
+    port: APP_CONFIG['mailer_port'],
+    domain: APP_CONFIG['mailer_domain'],
+    user_name: APP_CONFIG['mailer_user_name'],
+    password: APP_CONFIG['mailer_password'],
+    authentication: APP_CONFIG['mailer_authentication']
   }
 
   # Raises error for missing translations

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -64,16 +64,16 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.default_url_options = { host: Settings[:website_domain], port: Settings[:website_port] }
+  config.action_mailer.default_url_options = { host: APP_CONFIG['website_domain'], port: APP_CONFIG['website_port'] }
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address: Settings[:mailer_address],
-    port: Settings[:mailer_port],
-    domain: Settings[:mailer_domain],
-    user_name: Settings[:mailer_user_name],
-    password: Settings[:mailer_password],
-    authentication: Settings[:mailer_authentication]
+    address: APP_CONFIG['mailer_address'],
+    port: APP_CONFIG['mailer_port'],
+    domain: APP_CONFIG['mailer_domain'],
+    user_name: APP_CONFIG['mailer_user_name'],
+    password: APP_CONFIG['mailer_password'],
+    authentication: APP_CONFIG['mailer_authentication']
   }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,12 +38,12 @@ Rails.application.configure do
 
   # Note that these will not be used because delivery_method is :test. These are here so tests don't break.
   config.action_mailer.smtp_settings = {
-    address: Settings[:mailer_address],
-    port: Settings[:mailer_port],
-    domain: Settings[:mailer_domain],
-    user_name: Settings[:mailer_user_name],
-    password: Settings[:mailer_password],
-    authentication: Settings[:mailer_authentication]
+    address: APP_CONFIG['mailer_address'],
+    port: APP_CONFIG['mailer_port'],
+    domain: APP_CONFIG['mailer_domain'],
+    user_name: APP_CONFIG['mailer_user_name'],
+    password: APP_CONFIG['mailer_password'],
+    authentication: APP_CONFIG['mailer_authentication']
   }
 
   # Randomize the order test cases are executed.

--- a/config/initializers/cypress.rb
+++ b/config/initializers/cypress.rb
@@ -8,7 +8,7 @@ Faker::Config.locale = 'en-US'
 Rails.application.configure do
   config.after_initialize do
     Bundle.each do |bundle|
-      bundle.active = bundle.version == Settings[:default_bundle]
+      bundle.active = bundle.version == APP_CONFIG['default_bundle']
       bundle.save!
     end
   end

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -17,7 +17,7 @@ Given(/^the user is signed in as a non admin$/) do
   @user = FactoryGirl.create(:user)
   @user.approved = true
   login_as @user, :scope => :user
-  Settings[:ignore_roles] = false
+  APP_CONFIG['ignore_roles'] = false
   steps %( Given the user is on the sign in page )
 end
 

--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -1,7 +1,7 @@
 Given(/^the user is signed in$/) do
   steps %( Given a user has an account )
   login_as @user, :scope => :user
-  Settings[:ignore_roles] = false
+  APP_CONFIG['ignore_roles'] = false
   steps %( Given the user is on the sign in page )
 end
 

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -14,17 +14,17 @@ class Admin::SettingsControllerTest < ActionController::TestCase
                        mailer_user_name: 'testuser', mailer_password: 'password123', mode: 'custom',
                        custom_options: { auto_approve: 'disable', ignore_roles: 'disable', default_role: 'admin', debug_features: 'disable' }
       end
-      assert_equal 'banner test', Settings['banner_message']
+      assert_equal 'banner test', APP_CONFIG['banner_message']
       assert_equal 'smtp.example.com', Rails.application.config.action_mailer.smtp_settings.address
       assert_equal 3000, Rails.application.config.action_mailer.smtp_settings.port
       assert_equal 'example.com', Rails.application.config.action_mailer.smtp_settings.domain
       assert_equal 'testuser', Rails.application.config.action_mailer.smtp_settings.user_name
       assert_equal 'password123', Rails.application.config.action_mailer.smtp_settings.password
       assert_equal 'Custom', @controller.application_mode
-      assert_equal false, Settings['auto_approve']
-      assert_equal false, Settings['ignore_roles']
-      assert_equal :admin, Settings['default_role']
-      assert_equal false, Settings['enable_debug_features']
+      assert_equal false, APP_CONFIG['auto_approve']
+      assert_equal false, APP_CONFIG['ignore_roles']
+      assert_equal :admin, APP_CONFIG['default_role']
+      assert_equal false, APP_CONFIG['enable_debug_features']
     ensure
       File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts orig_yml }
     end

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -5,7 +5,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
   def setup
     collection_fixtures 'users', 'roles', 'vendors'
     @user = User.find('4def93dd4f85cf8968000001')
-    Settings[:ignore_roles] = false
+    APP_CONFIG['ignore_roles'] = false
   end
 
   test 'Admin can view index ' do
@@ -39,7 +39,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
   test 'Admin can update user' do
     v = Vendor.find('4f57a8791d41c851eb000002')
-    Settings[:default_role] = nil
+    APP_CONFIG['default_role'] = nil
     u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
 
     for_each_logged_in_user([ADMIN]) do

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -7,12 +7,12 @@ class AdminControllerTest < ActionController::TestCase
 
   test 'should get show' do
     Rails.application.config.action_mailer.smtp_settings = {
-      address: Settings[:mailer_address],
-      port: Settings[:mailer_port],
-      domain: Settings[:mailer_domain],
-      user_name: Settings[:mailer_user_name],
-      password: Settings[:mailer_password],
-      authentication: Settings[:mailer_authentication]
+      address: APP_CONFIG['mailer_address'],
+      port: APP_CONFIG['mailer_port'],
+      domain: APP_CONFIG['mailer_domain'],
+      user_name: APP_CONFIG['mailer_user_name'],
+      password: APP_CONFIG['mailer_password'],
+      authentication: APP_CONFIG['mailer_authentication']
     }
     for_each_logged_in_user([ADMIN]) do
       get :show

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -30,12 +30,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def test_assign_default_role
-    Settings[:default_role] = :user
+    APP_CONFIG['default_role'] = :user
     u = User.create(email: 'vendor@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
     assert u.user_role? :user
     assert u.user_role? 'user'
 
-    Settings[:default_role] = nil
+    APP_CONFIG['default_role'] = nil
     u = User.create(email: 'vendor2@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
     assert_empty u.roles, 'user should not have any roles assigned '
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,7 +25,7 @@ Mongoid.logger.level = Logger::INFO
 
 class ActiveSupport::TestCase
   def setup
-    Settings[:ignore_roles] = false
+    APP_CONFIG['ignore_roles'] = false
   end
 
   def teardown


### PR DESCRIPTION
This removes unnecessary dependency on the settingslogic gem.

Note that this was initially to attempt to fix the modes bug. It did not fix it, but the change is still desirable.