### PR TITLE
Fix navbar from pushing onto two lines

### DIFF
--- a/app/assets/stylesheets/_bootstrap-variables.scss
+++ b/app/assets/stylesheets/_bootstrap-variables.scss
@@ -336,7 +336,7 @@ $grid-columns:              12 !default;
 $grid-gutter-width:         30px !default;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
-$grid-float-breakpoint:     $screen-sm-min !default;
+$grid-float-breakpoint:     $screen-md-min !default;
 //** Point at which the navbar begins collapsing.
 $grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
 


### PR DESCRIPTION
This is a fix for an issue identified by @tstrass, the navbar was not collapsing into a hamburger menu early enough. This PR fixes it.

**Before:**
<img width="852" alt="before" src="https://cloud.githubusercontent.com/assets/2308869/21235073/46450a10-c2c3-11e6-8c93-586af48daa50.png">

**After:**
<img width="851" alt="after" src="https://cloud.githubusercontent.com/assets/2308869/21235074/4645f38a-c2c3-11e6-86b2-6f9a68794df9.png">

