### PR TITLE
Commented out bundle_id in lib/ext/record.rb

### DIFF
--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -2,7 +2,7 @@
 
 class Record
   include Mongoid::Document
-  field :bundle_id
+  # field :bundle_id
   field :measures, type: Hash
   index test_id: 1
   index bundle_id: 1


### PR DESCRIPTION
To solve a potential `NoMethodError`, `bundle_id` was added to HDS's `Record` model. 

I didn't delete `bundle_id` completely, because we should review whether `bundle_id` should be in HDS's `Record` model in the long term.

This pull request should not get merged in until HDS has been updated.