### PR TITLE
Remove use of depreciated devise method

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -18,6 +18,6 @@ class RegistrationsController < Devise::RegistrationsController
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.for(:sign_up).push(:terms_and_conditions)
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:terms_and_conditions])
   end
 end


### PR DESCRIPTION
The method that was previously used is depreciated in devise 4.2, removing it before it causes a problem.