### PR TITLE
Fix bundle upload + minor test fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,13 +97,13 @@ group :development, :test do
   gem 'axe-matchers'
   gem 'selenium-webdriver', '2.48.0'
   gem 'parallel_tests'
+  gem 'pry'
+  gem 'pry-nav'
 end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
-  gem 'pry'
-  gem 'pry-nav'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 end
 

--- a/app/views/admin/bundles/new.html.erb
+++ b/app/views/admin/bundles/new.html.erb
@@ -1,7 +1,7 @@
 <div class="panel panel-default">
 <div class="panel-heading"><h1>Import Bundle</h1></div>
 
-<%= bootstrap_form_tag url: admin_bundles_url, html: {id: "add_bundle_form"} do |f| %>
+<%= bootstrap_form_tag url: admin_bundles_path, html: {id: "add_bundle_form"} do |f| %>
   <div class="panel-body">
     <%= f.file_field :file, label: 'Bundle', accept: 'application/zip' %>
   </div>

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -17,7 +17,6 @@ Given(/^the user is signed in as a non admin$/) do
   @user = FactoryGirl.create(:user)
   @user.approved = true
   login_as @user, :scope => :user
-  Cypress::AppConfig['ignore_roles'] = false
   steps %( Given the user is on the sign in page )
 end
 

--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -1,7 +1,6 @@
 Given(/^the user is signed in$/) do
   steps %( Given a user has an account )
   login_as @user, :scope => :user
-  Cypress::AppConfig['ignore_roles'] = false
   steps %( Given the user is on the sign in page )
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,8 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+ENV['IGNORE_ROLES'] ||= 'false'
+
 require 'cucumber/rails'
 
 require 'capybara/cucumber'

--- a/test/controllers/admin/users_controller_test.rb
+++ b/test/controllers/admin/users_controller_test.rb
@@ -38,6 +38,9 @@ class Admin::UsersControllerTest < ActionController::TestCase
 
   test 'Admin can update user' do
     FakeFS do
+      # Defined in test_helper
+      setup_fakefs
+
       v = Vendor.find('4f57a8791d41c851eb000002')
       Cypress::AppConfig['default_role'] = nil
       u = User.create(email: 'admin_test@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,11 +1,10 @@
 require 'test_helper'
 
 class UserTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
   def test_user_can_be_associated_with_poc
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = true
       Vendor.destroy_all
       v = Vendor.new(name: 'test_vendor_name')
@@ -21,6 +20,8 @@ class UserTest < ActiveSupport::TestCase
 
   def test_user_cannot_be_associated_with_poc_if_turned_off
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = false
       Vendor.destroy_all
       v = Vendor.new(name: 'test_vendor_name')
@@ -35,6 +36,8 @@ class UserTest < ActiveSupport::TestCase
 
   def test_assign_default_role
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['default_role'] = :user
       u = User.create(email: 'vendor@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
       assert u.user_role? :user

--- a/test/models/vendor_test.rb
+++ b/test/models/vendor_test.rb
@@ -43,6 +43,8 @@ class VendorTest < ActiveSupport::TestCase
 
   def test_vendor_poc_can_be_associated_with_user
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = true
       v = Vendor.new(name: 'test_vendor_name')
       p = PointOfContact.new(name: 'test_poc_name', email: 'vendor@test.com')
@@ -54,6 +56,8 @@ class VendorTest < ActiveSupport::TestCase
 
   def test_updated_vendor_poc_can_be_associated_with_user
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = true
       v = Vendor.new(name: 'test_vendor_name')
       p = PointOfContact.new(name: 'test_poc_name')
@@ -68,6 +72,8 @@ class VendorTest < ActiveSupport::TestCase
 
   def test_vendor_poc_cannot_be_associated_with_user_if_turned_off
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = false
       v = Vendor.new(name: 'test_vendor_name')
       p = PointOfContact.new(name: 'test_poc_name', email: 'vendor@test.com')
@@ -79,6 +85,8 @@ class VendorTest < ActiveSupport::TestCase
 
   def test_updated_vendor_poc_cannot_be_associated_with_user_if_turned_off
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = false
       v = Vendor.new(name: 'test_vendor_name')
       p = PointOfContact.new(name: 'test_poc_name')
@@ -93,6 +101,8 @@ class VendorTest < ActiveSupport::TestCase
 
   def test_changing_poc_email_updates_user_roles
     FakeFS do
+      setup_fakefs
+
       Cypress::AppConfig['auto_associate_pocs'] = true
       v = Vendor.new(name: 'test_vendor_name')
       p = PointOfContact.new(name: 'test_poc_name', email: 'vendor@test.com')

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,14 +25,16 @@ Warden.test_mode!
 Mongoid.logger.level = Logger::INFO
 
 class ActiveSupport::TestCase
-  def setup
+  def teardown
+    drop_database
+  end
+
+  def setup_fakefs
     # Clone the cypress config yaml path whenever we use FakeFS in order to avoid
     # File not Found errors when calling Cypress::AppConfig
     FakeFS::FileSystem.clone(File.expand_path("#{Rails.root}/config/cypress.yml"))
-  end
-
-  def teardown
-    drop_database
+    # Fix rails autoloading when using FakeFS, see https://github.com/fakefs/fakefs/issues/170
+    FakeFS::FileSystem.clone(File.join(::Rails.root, 'app'))
   end
 
   def create_rack_test_file(filename, type)


### PR DESCRIPTION
The issues fixed are as follows:

Currently when you attempt to upload a new bundle to the application when behind a proxy server such as nginx the upload fails. This is due to the fact that the admin_bundles_url returns the absolute url which is incorrect when behind a proxy server. If we use admin_bundles_path instead then it returns a relative url which does not encounter this problem.

Move ignore_roles false setting to environment variable to stop the the cucumber tests from changing the cypress.yml file on disk.

Strange issues were happening with fakefs not properly creating the cypress.yml file and causing tests to fail. This reworks the way it works so that it will only call it when we absolutely need it. Also we add the app/ directory so that autoloading works again. There were some cases where you could run the test suite with specific seeds and rails would try to autoload a function while in the FakeFS wrapper and would not be able to find the needed file. Adding the app/ directory fixes these cases.

One example of a previously failing seed that is now fixed is `bundle exec rake test --seed 18576`