### PR TITLE
Remove duplicate declaration of bundle_id

### DIFF
--- a/lib/ext/record.rb
+++ b/lib/ext/record.rb
@@ -2,7 +2,6 @@
 
 class Record
   include Mongoid::Document
-  field :bundle_id
   field :measures, type: Hash
   index test_id: 1
   index bundle_id: 1


### PR DESCRIPTION
Bundle_id is already declared in the latest version of HDS which we now depend on. Removing the duplicate declaration to get rid of the warning on startup. This happened due to https://github.com/projectcypress/cypress/pull/765 and I unfortunately didn't realize it until a little bit after merging.