### PR TITLE
Code lookup feature and Manual Entry Test name change

### DIFF
--- a/app/assets/javascripts/checklist_measures.js
+++ b/app/assets/javascripts/checklist_measures.js
@@ -8,7 +8,34 @@ ready_run_once = function() {
     $('.btn-danger').attr('disabled', false);
   });
 
+
 };
 
 $(document).ready(ready_run_once);
 $(document).on('page:load', ready_run_once);
+
+var pop_up;
+pop_up = function(){
+
+	var pop_up = document.getElementById('code_lookup');
+	pop_up.classList.toggle('show');
+}
+
+function lookupFunction() {
+    // Declare variables
+    var input, filter, ul, li, a, i;
+    input = document.getElementById('lookupFilter');
+    filter = input.value.toUpperCase();
+    ul = document.getElementById("lookup_codes");
+    li = ul.getElementsByTagName('li');
+
+    // Loop through all list items, and hide those who don't match the search query
+    for (i = 0; i < li.length; i++) {
+        a = li[i].getElementsByTagName("a")[0];
+        if (a.innerHTML.toUpperCase().indexOf(filter) > -1) {
+            li[i].style.display = "";
+        } else {
+            li[i].style.display = "none";
+        }
+    }
+}

--- a/app/assets/stylesheets/cypress/_modal.scss
+++ b/app/assets/stylesheets/cypress/_modal.scss
@@ -1,3 +1,12 @@
 .modal-footer {
   text-align: left;
 }
+
+.modal {
+	overflow: hidden;
+}
+
+.modal-body{
+	height: 300px;
+	overflow: auto;
+}

--- a/app/assets/stylesheets/cypress/_valuesets.scss
+++ b/app/assets/stylesheets/cypress/_valuesets.scss
@@ -1,0 +1,42 @@
+
+
+
+.value-set-group {
+	@extend .btn; 
+	background-color: red;
+	padding: 4px;
+	text-align: left;
+	color: black;
+	border: 0px;
+	width: 100%
+		
+}
+.set-menu {
+	@extend .btn;
+	background-color: transparent;
+	border-bottom-color: black; 
+	box-shadow: 0; 	
+	&:hover {
+		color: black;
+		background-color: gray;
+		border: 0px;
+	} 
+}
+.value-set-list {
+	@extend .list-group;
+	margin-bottom: 8px;
+	background-color: transparent;
+}
+.value-set-item-header {
+	@extend .list-group-item;
+	font-weight: bold;
+	padding: 2px 8px;
+	background-color: #F0F0F0;
+
+}
+.value-set-item-oid {
+	@extend .list-group-item;
+	padding: 2px 8px;
+	background-color: white;
+
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -109,7 +109,7 @@ class ApplicationController < ActionController::Base
 
   def set_product_test
     @product_test = params[:product_test_id] ? ProductTest.find(params[:product_test_id]) : ProductTest.find(params[:id])
-    @title = "#{@product_test.product.name} C1 Manual Test" if @product_test.is_a?(ChecklistTest)
+    @title = "#{@product_test.product.name} C1 Record Sample" if @product_test.is_a?(ChecklistTest)
   end
 
   def set_task

--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -59,7 +59,7 @@ class ChecklistTestsController < ProductTestsController
     add_breadcrumb 'Dashboard', :vendors_path
     add_breadcrumb 'Vendor: ' + @product.vendor.name, vendor_path(@product.vendor_id)
     add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor_id, @product)
-    add_breadcrumb 'Manual Entry Test', product_checklist_test_path(@product, @product_test)
+    add_breadcrumb 'Record Sample', product_checklist_test_path(@product, @product_test)
   end
 
   def set_measures

--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -71,7 +71,7 @@ module ChecklistTestsHelper
 
   def lookup_codevalues(oid, bundle)
     vs = HealthDataStandards::SVS::ValueSet.where(oid: oid)
-    return oid unless vs && vs.first
+    return [] unless vs && vs.first
     vs.first.concepts.map {|con| "#{con.display_name}: #{con.code}"}
   end
 end

--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -59,6 +59,19 @@ module ChecklistTestsHelper
   def lookup_valueset_name(oid)
     vs = HealthDataStandards::SVS::ValueSet.where(oid: oid)
     return oid unless vs && vs.first
-    "#{vs.first.display_name}: #{oid}"
+    "#{vs.first.display_name}"
+  end
+
+
+  def lookup_valueset_oid(oid)
+    vs = HealthDataStandards::SVS::ValueSet.where(oid: oid)
+    return oid unless vs && vs.first
+    "#{oid}"
+  end
+
+  def lookup_codevalues(oid, bundle)
+    vs = HealthDataStandards::SVS::ValueSet.where(oid: oid)
+    return oid unless vs && vs.first
+    vs.first.concepts.map {|con| "#{con.display_name}: #{con.code}"}
   end
 end

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -56,13 +56,16 @@
                       <tr>
                       <td> <strong>Valuesets</strong> </td>
                       <td/>
-                      <td><span>
-                        <ul class='list-unstyled'>
+                      <td>
+                      <div type = "button" class ="value-set-group set-menu" data-toggle="modal" data-target="#lookupModal">
+                        <ul class="value-set-list">
                         <% valuessets.each do |vs| %>
-                        <li class="valueset-listitem"><%= "#{lookup_valueset_name(vs)}" %></li>
+                        <li class="value-set-item-header"><%= "#{lookup_valueset_name(vs)}" %></li>
+                        <li class="value-set-item-oid"><%="#{lookup_valueset_oid(vs)}" %></li>
                         <% end %>
                         </ul>
-                      </span></td>
+                        </div>
+                       </td>
                       <td>
                         <% if criteria_field.object.complete?.nil? %>
                           <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
@@ -72,13 +75,38 @@
                           <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
                         <% end %>
                         <%= criteria_field.text_field :code, hide_label: false %>
+                          <div id="lookupModal" class="modal fade" role="dialog">
+                            <div class = "modal-dialog" id ="lookupModal-dialog">
+                              <div class="modal-content" id="lookupModal-content">
+                                <div class= "modal-header" id= "lookupModal-header">
+                                  <button type="button" class="close" id="lookupModal-close" data-dismiss="modal">&times;</button>
+                                    <h4 class="modal-title" id="lookupModal-title"> List of codes</h4>
+                                 </div>
+                                    <div class="modal-body" id="lookupModal-body">
+                                      <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
+                                      <ul class='list-unstyled' id="lookup_codes">
+                                      <% valuessets.each do |vs| %>
+                                        <% lookup_codevalues(vs, product_test.bundle).each do |pair_string| %>
+                                          <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
+                                        <% end %>
+                                     <% end %>
+                                     </ul>
+                                  </div>
+                                 <div class="modal-footer" id="lookupModal-footer">
+                                <button type="button" data-dismiss="modal">Close</button>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
                       </td>
                     </tr>
                     <% end %>
                     <tr>
                       <td> <strong> Attributes </strong> </td>
                     <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
-                    <td><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value']} if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %></td>
+                    <td>
+                    <%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value'], product_test: product_test } if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %>
+                    </td>
                     <% if coded_attribute?(criteria) %>
                       <td>
                         <% if criteria_field.object.complete?.nil? %>

--- a/app/views/checklist_tests/_field_values.html.erb
+++ b/app/views/checklist_tests/_field_values.html.erb
@@ -12,6 +12,7 @@
    <li class="value-set-item-header"><%= "#{lookup_valueset_name(negation)}" %></li>
    <li class="value-set-item-oid"><%= "#{lookup_valueset_oid(negation)}" %> </li>
   </ul>
+  </div>
     <div id="lookupModal-negation" class="modal fade" role="dialog">
     <div class = "modal-dialog" id ="lookupModal-dialog">
       <div class="modal-content" id="lookupModal-content">

--- a/app/views/checklist_tests/_field_values.html.erb
+++ b/app/views/checklist_tests/_field_values.html.erb
@@ -22,11 +22,9 @@
             <div class="modal-body" id="lookupModal-body">
               <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
               <ul class='list-unstyled' id="lookup_codes">
-              <% negation.each do |ng| %>
-                <% lookup_codevalues(ng, product_test.bundle).each do |pair_string| %>
+                <% lookup_codevalues(negation, product_test.bundle).each do |pair_string| %>
                   <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
                 <% end %>
-             <% end %>
              </ul>
           </div>
          <div class="modal-footer" id="lookupModal-footer">
@@ -53,11 +51,9 @@
             <div class="modal-body" id="lookupModal-body">
               <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
               <ul class='list-unstyled' id="lookup_codes">
-              <% result.each do |rs| %>
-                <% lookup_codevalues(rs, product_test.bundle).each do |pair_string| %>
+                <% lookup_codevalues(result, product_test.bundle).each do |pair_string| %>
                   <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
                 <% end %>
-             <% end %>
              </ul>
           </div>
          <div class="modal-footer" id="lookupModal-footer">

--- a/app/views/checklist_tests/_field_values.html.erb
+++ b/app/views/checklist_tests/_field_values.html.erb
@@ -3,21 +3,105 @@
 # local variables
 #
 #   field_values   (Hash)
+#   product_test (ChecklistTest)
 
 %>
 <% if negation %>
-  <%= "#{lookup_valueset_name(negation)}" %>
+ <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="#lookupModal-negation">          
+  <ul class="value-set-list">
+   <li class="value-set-item-header"><%= "#{lookup_valueset_name(negation)}" %></li>
+   <li class="value-set-item-oid"><%= "#{lookup_valueset_oid(negation)}" %> </li>
+  </ul>
+    <div id="lookupModal-negation" class="modal fade" role="dialog">
+    <div class = "modal-dialog" id ="lookupModal-dialog">
+      <div class="modal-content" id="lookupModal-content">
+        <div class= "modal-header" id= "lookupModal-header">
+          <button type="button" class="close" id="lookupModal-close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title" id="lookupModal-title"> List of codes</h4>
+         </div>
+            <div class="modal-body" id="lookupModal-body">
+              <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
+              <ul class='list-unstyled' id="lookup_codes">
+              <% negation.each do |ng| %>
+                <% lookup_codevalues(ng, product_test.bundle).each do |pair_string| %>
+                  <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
+                <% end %>
+             <% end %>
+             </ul>
+          </div>
+         <div class="modal-footer" id="lookupModal-footer">
+        <button type="button" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
 <% elsif result %>
   <% if result.type == 'CD' && result['code_list_id'] %>
-    <%= "#{lookup_valueset_name(result.code_list_id)}" %>
+   <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="#lookupModal-result">          
+    <ul class="value-set-list">
+     <li class="value-set-item-header"><%= "#{lookup_valueset_name(result.code_list_id)}" %></li>
+     <li class="value-set-item-oid"><%= "#{lookup_valueset_oid(result.code_list_id)}" %></li>
+    </ul>
+   </div>
+       <div id="lookupModal-result" class="modal fade" role="dialog">
+    <div class = "modal-dialog" id ="lookupModal-dialog">
+      <div class="modal-content" id="lookupModal-content">
+        <div class= "modal-header" id= "lookupModal-header">
+          <button type="button" class="close" id="lookupModal-close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title" id="lookupModal-title"> List of codes</h4>
+         </div>
+            <div class="modal-body" id="lookupModal-body">
+              <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
+              <ul class='list-unstyled' id="lookup_codes">
+              <% result.each do |rs| %>
+                <% lookup_codevalues(rs, product_test.bundle).each do |pair_string| %>
+                  <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
+                <% end %>
+             <% end %>
+             </ul>
+          </div>
+         <div class="modal-footer" id="lookupModal-footer">
+        <button type="button" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
   <% end %>
 <% else %>
   <% field_values.each do |fv_key, fv_val| %>
     <% case fv_val['type'] %>
     <% when 'CD' %>
-      <%= "#{fv_val['title']}: #{fv_val['code_list_id']}" %>
+      <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="#lookupModal-fieldvalues">          
+       <ul class="value-set-list">
+        <li class="value-set-item-header"><%= "#{fv_val['title']}" %></li>
+        <li class="value-set-item-oid"><%= "#{fv_val['code_list_id']}" %></li>
+       </ul>
+      </div>
+          <div id="lookupModal-fieldvalues" class="modal fade" role="dialog">
+    <div class = "modal-dialog" id ="lookupModal-dialog">
+      <div class="modal-content" id="lookupModal-content">
+        <div class= "modal-header" id= "lookupModal-header">
+          <button type="button" class="close" id="lookupModal-close" data-dismiss="modal">&times;</button>
+            <h4 class="modal-title" id="lookupModal-title"> List of codes</h4>
+         </div>
+            <div class="modal-body" id="lookupModal-body">
+              <input type="text" id="lookupFilter" onkeyup="lookupFunction()" placeholder="Filter codes">
+              <ul class='list-unstyled' id="lookup_codes">
+                <% lookup_codevalues(fv_val['code_list_id'], product_test.bundle).each do |pair_string| %>
+                  <li class="valueset-listitem" href="#"><a><%= pair_string %></a></li>
+                <% end %>
+             </ul>
+          </div>
+         <div class="modal-footer" id="lookupModal-footer">
+        <button type="button" data-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
     <% when 'IVL_PQ' %>
-      <%= raw length_of_stay_string(fv_val) %>
+     <ul class="value-set-list">
+      <li class="value-set"><%= raw length_of_stay_string(fv_val) %></li>
+     </ul>
     <% end %>
   <%end%>
 <% end %>

--- a/app/views/checklist_tests/measure.html.erb
+++ b/app/views/checklist_tests/measure.html.erb
@@ -4,7 +4,7 @@
 
 <br/>
 <%= link_to(product_checklist_test_path(@product, @product_test), class: 'btn btn-primary') do %>
-  <i class = 'fa fa-fw fa-angle-left' aria-hidden = 'true'></i>Return to Manual Entry Test
+  <i class = 'fa fa-fw fa-angle-left' aria-hidden = 'true'></i>Return to Record Sample
 <% end %>
 
 <div class = 'test-steps'>

--- a/app/views/checklist_tests/print_criteria.html.erb
+++ b/app/views/checklist_tests/print_criteria.html.erb
@@ -2,7 +2,7 @@
 
 <div class="product-report">
 
-<h1>Criteria List for C1 Manual Entry Test</h1>
+<h1>Criteria List for C1 Record Sample</h1>
 
 <% if checklist_test.measures %>
   <%= bootstrap_nested_form_for([@product, checklist_test], :url => { :controller => 'checklist_tests', :action => 'update' }) do |f| %>

--- a/app/views/checklist_tests/show.html.erb
+++ b/app/views/checklist_tests/show.html.erb
@@ -8,11 +8,11 @@
     <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Criteria List
   <% end %>
 </div>
-<h1>Manual Entry Test</h1>
+<h1>Record Sample</h1>
 <div class = 'test-steps'>
   <div class="panel panel-info">
     <div class="panel-heading">
-      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Manual Entry Instructions</h1>
+      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Record Sample Instructions</h1>
     </div>
     <%= render partial: 'checklist_instructions', locals: { instructions: Cypress::AppConfig['tests']['ChecklistTest']['instructions'] } %>
   </div>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -55,13 +55,13 @@
     </tbody>
   </table>
 
-  <% # Manual Entry Summary %>
+  <% # Record Sample Summary %>
   <% if @product.c1_test %>
-    <h2>C1 Manual Entry</h2>
+    <h2>C1 Record Sample</h2>
     <% unless @product.product_tests.checklist_tests.count == 0 %>
       <%= render partial: 'checklist_status_display', locals: { product: @product } %>
     <% else %>
-      <p><%= render partial: 'products/report/status_icon', locals: { passing: false } %> Manual Entry Test has not been started.</p>
+      <p><%= render partial: 'products/report/status_icon', locals: { passing: false } %> Record Sample has not been started.</p>
     <% end %>
   <% end %>
 
@@ -123,7 +123,7 @@
       </table>
     <% end %>
   <% else %>
-    <p><%= render partial: 'products/report/status_icon', locals: { passing: false } %> Manual Entry Test has not been started.</p>
+    <p><%= render partial: 'products/report/status_icon', locals: { passing: false } %> Record Sample has not been started.</p>
   <% end %>
 
   <% # C1 Not Started Measure Tests %>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -30,10 +30,10 @@
     <div id = '<%= html_id %>'>
       <p class = 'lead'><%= description %></p>
 
-      <% # Manual Entry Tab %>
+      <% # Record Sample Tab %>
       <% if test_type == 'ChecklistTest' %>
         <% checklist_test = @product.product_tests.checklist_tests.first %>
-        <%= button_to 'View Manual Entry', product_checklist_test_path(@product, checklist_test), class: 'btn btn-primary', method: :get %><p></p>
+        <%= button_to 'View Record Sample', product_checklist_test_path(@product, checklist_test), class: 'btn btn-primary', method: :get %><p></p>
         <div id = 'display_checklist_execution_results'>
           <%= render partial: 'checklist_execution_results', locals: { task: @product.product_tests.checklist_tests.first.tasks.c1_manual_task } %>
         </div>

--- a/app/views/test_executions/results/_passing_result.html.erb
+++ b/app/views/test_executions/results/_passing_result.html.erb
@@ -38,7 +38,7 @@
             </li>
             <li>
               <i class="fa-li fa fa-eye" aria-hidden="true"></i>
-              <%= link_to 'Try a Manual Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
+              <%= link_to 'Try a Record Sample', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
             </li>
           <% end %>
 

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -190,7 +190,7 @@ tests:
     certifications:
       - 'C4'
   ChecklistTest:
-    title: 'Manual Entry Test'
+    title: 'Record Sample'
     description: 'Validate the EHR system for C1 certification by manually entering specified patient data for the following measures.'
     instructions:
       - instruction: 'Fill in the Data Criteria fields below.'

--- a/features/step_definitions/checklist_test.rb
+++ b/features/step_definitions/checklist_test.rb
@@ -193,5 +193,5 @@ Then(/^the user should see the individual measure checklist page for measure (.*
   measure = nth_measure(measure_number)
   page.assert_text(measure.cms_id)
   page.assert_text(measure.name)
-  page.assert_text 'Return to Manual Entry Test'
+  page.assert_text 'Return to Record Sample'
 end

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -486,12 +486,12 @@ Then(/^the user should not see the filtering tests tab$/) do
 end
 
 Then(/^the user should see the checklist tests tab$/) do
-  page.assert_text 'Manual Entry Test'
+  page.assert_text 'Record Sample'
   find('#ChecklistTest').assert_text 'Validate the EHR system for C1 certification by manually entering specified patient data for the following'
 end
 
 Then(/^the user should not see the checklist tests tab$/) do
-  page.assert_no_text 'Manual Entry Test'
+  page.assert_no_text 'Record Sample'
 end
 
 # ^ ^ ^ product tests tabs ^ ^ ^ #


### PR DESCRIPTION
Created a new feature where you can now click on the valuesets and attritubutes in the record sample form and get a modal pop up with the list of codes associated to that oid. There is a filter functionality for that pop up so you can find the code you need. You can copy and paste any of the codes into the text box. Also changed all of the buttons headers etc. from Manual Entry Test to Record Sample. 

![screen shot 2017-01-06 at 3 11 51 pm](https://cloud.githubusercontent.com/assets/22615706/21731468/7d6b5970-d422-11e6-9d45-909d4fb230aa.png)
![screen shot 2017-01-06 at 3 12 01 pm](https://cloud.githubusercontent.com/assets/22615706/21731469/8011a1ca-d422-11e6-88fa-d24fc1cb791d.png)

