### PR TITLE
Fix app config on production

### DIFF
--- a/config/initializers/cypress.rb
+++ b/config/initializers/cypress.rb
@@ -6,7 +6,7 @@ Faker::Config.locale = 'en-US'
 
 Rails.application.configure do
   config.after_initialize do
-    Cypress::AppConfig.refresh
+    Cypress::AppConfig.clear
 
     # sync default bundle with cypress.yml
     Bundle.each do |bundle|

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,2 +1,3 @@
+ENV['IS_SERVER'] = '1'
 timeout 120
 worker_processes 4

--- a/lib/cypress/app_config.rb
+++ b/lib/cypress/app_config.rb
@@ -1,18 +1,21 @@
 # When this module is called from a test, make sure it is wrapped in Faker. Otherwise you will have problems with travis.
 module Cypress
   class AppConfig
+    def self.clear
+      Rails.cache.delete('config_values') unless Rails.cache.nil?
+    end
+
     def self.[](key)
       # Allow accessing app config during app init, before Rails.cache exists
-      if Rails.cache.nil?
-        if @init_app_config.nil?
-          @init_app_config = YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)
-        end
-        return @init_app_config[key]
+      # Also check if we are running in non-server mode. If we are then we must not pollute
+      # the cache with potentially bad values for app_config
+      if Rails.cache.nil? || !ENV['IS_SERVER']
+        YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)[key]
+      else
+        Rails.cache.fetch('config_values') do
+          YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)
+        end[key]
       end
-
-      Rails.cache.fetch('config_values') do
-        YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)
-      end[key]
     end
 
     # This method writes a new value to a setting in cypress.yml
@@ -35,15 +38,7 @@ module Cypress
       File.open("#{Rails.root}/config/cypress.yml", 'w') { |file| file.puts yml_text }
 
       # Allow setting app config during app init, before Rails.cache exists
-      if Rails.cache.nil?
-        @init_app_config = YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)
-      else
-        Rails.cache.delete('config_values')
-      end
-    end
-
-    def self.clear
-      Rails.cache.delete('config_values')
+      clear
     end
   end
 end

--- a/lib/cypress/app_config.rb
+++ b/lib/cypress/app_config.rb
@@ -42,10 +42,8 @@ module Cypress
       end
     end
 
-    def self.refresh
-      Rails.cache.fetch('config_values', force: true) do
-        YAML.load(ERB.new(File.read("#{Rails.root}/config/cypress.yml")).result)
-      end
+    def self.clear
+      Rails.cache.delete('config_values')
     end
   end
 end


### PR DESCRIPTION
Currently the new app config was not handling production mode quite right. If the user ran any rake task or other task in non-server mode and did an action that triggered the Cypress::AppConfig the value for different app config settings would be thrown out of sync. This fixes the problem by only updating the cache if the production server is the one requesting it.