### PR TITLE
Add a pending state in order to fix a race condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,8 @@ before_script:
   - cp ./.travis/mongoid.yml ./config/mongoid.yml
 script:
   - bundle exec brakeman -qAzw1
-  - bundle exec bundle-audit update
-  - bundle exec bundle-audit check
+  - bundle exec bundle-audit check --update
   - bundle exec overcommit --sign
   - bundle exec overcommit --run
   - travis_retry bundle exec rake test
-  - travis_retry bundle exec cucumber
+  - bundle exec cucumber

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -30,7 +30,7 @@ class Task
   end
 
   # Defines methods for checking task status (task.passing?, etc)
-  %w(passing failing errored incomplete).each do |task_state|
+  %w(passing failing errored pending incomplete).each do |task_state|
     define_method "#{task_state}?" do
       status == task_state
     end
@@ -46,8 +46,8 @@ class Task
         'failing'
       elsif recent_execution.errored?
         'errored'
-      else
-        'incomplete'
+      else # Test is not any of the above states but does exist, assume pending state
+        'pending'
       end
     end
   end

--- a/app/views/application/_checklist_execution_results.html.erb
+++ b/app/views/application/_checklist_execution_results.html.erb
@@ -7,6 +7,7 @@
 %>
 
 <% execution = task.most_recent_execution %>
+<% status_with_sibling = execution ? execution.status_with_sibling : nil %>
 <% c3_execution = execution ? execution.sibling_execution : nil %>
 <% should_include_c3 = task.product_test.product.c3_test %>
 
@@ -37,7 +38,7 @@
         <% end %>
       <td>
         <% unless execution.nil? %>
-          <% case execution.status_with_sibling %>
+          <% case status_with_sibling %>
           <% when 'passing' %>
             <i aria-hidden = 'true' class = 'fa fa-fw fa-check text-success'></i>
             <strong class = 'text-success'>Passing</strong>
@@ -60,7 +61,7 @@
   </tbody>
 </table>
 
-<% if !execution.nil? && execution.executions_pending? %>
+<% if !execution.nil? && status_with_sibling == 'incomplete' %>
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_execution_results', task_id: "<%= task.id.to_s %>" }});
   </script>

--- a/app/views/checklist_tests/_checklist_measures.html.erb
+++ b/app/views/checklist_tests/_checklist_measures.html.erb
@@ -1,5 +1,5 @@
 
-<% if @product_test.tasks[0].most_recent_execution && @product_test.tasks[0].most_recent_execution.incomplete? %>
+<% if @product_test.tasks.first.most_recent_execution && @product_test.tasks.first.most_recent_execution.incomplete? %>
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_measures' }});
   </script>
@@ -7,7 +7,7 @@
 
 <div id='save_options'>
   <% unless @product_test.status != 'passing' %>
-    <%= render :partial => 'alert', locals: { alert_type: 'warning', messages: 'Saving this checklist will overide previous results.', confirmation: 'Yes, let me save this checklist' } %>
+    <%= render :partial => 'alert', locals: { alert_type: 'warning', messages: 'Saving this checklist will override previous results.', confirmation: 'Yes, let me save this checklist' } %>
   <% end %>
 </div>
 

--- a/app/views/products/_filtering_test_link.html.erb
+++ b/app/views/products/_filtering_test_link.html.erb
@@ -11,7 +11,8 @@
 
 <% parent_reloading = false unless (defined? parent_reloading) %>
 <% tasks = with_c3_task(task) %>
-<% should_reload = should_reload_product_test_link?(tasks) %>
+<% status = tasks_status(tasks) %>
+<% should_reload = should_reload_product_test_link?(status, test) %>
 
 <% if test.state != :ready %>
   <% if test.state == :queued %>
@@ -25,7 +26,7 @@
   <strong class="text-info">Internal Error</strong>
   <% end %>
 <% else %>
-  <% case tasks_status(tasks) %>
+  <% case status %>
   <% when 'passing' %>
     <i class = 'fa fa-fw fa-check-circle text-success' aria-hidden="true"></i>
     <%= link_to 'view', new_task_test_execution_path(task), :class => "label label-success" %>
@@ -38,21 +39,16 @@
     <i class = 'fa fa-fw fa-exclamation-circle text-warning' aria-hidden="true"></i>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-warning" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
-  <% when 'incomplete' %>
-    <% if should_reload %>
-      <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
-      <%= link_to 'testing...', new_task_test_execution_path(task), :class => 'label label-default' %>
-    <% else %>
-      <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
-      <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
-      <%= render partial: '/products/product_test_upload', locals: { task: task } %>
-    <% end %>
+  <% when 'pending'%>
+    <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
+    <%= link_to 'testing...', new_task_test_execution_path(task), :class => 'label label-default' %>
   <% else %>
     <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
     <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% end %>
 <% end %>
+
 <% if should_reload && !parent_reloading %>
   <script>
   $(document).ready(function() {

--- a/app/views/products/_measure_test_link.html.erb
+++ b/app/views/products/_measure_test_link.html.erb
@@ -21,17 +21,9 @@
   <% end %>
 <% else %>
   <% case tasks_status(tasks) %>
-  <% when 'passing' || 'failing' || 'errored' %>
-    <i class = 'fa fa-fw fa-gavel invisible' aria-hidden = 'true'></i>
-    <%= render partial: '/products/product_test_upload', locals: { task: task, label_class: 'label-info' } %>
-  <% when 'incomplete' %>
-    <% if measure_test_running_for_row?(task) %>
-      <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
-      <span class = 'label label-default'>testing...</span>
-    <% else %>
-      <i class = 'fa fa-fw fa-gavel invisible' aria-hidden = 'true'></i>
-      <%= render partial: '/products/product_test_upload', locals: { task: task, label_class: 'label-info' } %>
-    <% end %>
+  <% when 'pending' %>
+    <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
+    <span class = 'label label-default'>testing...</span>
   <% else %>
     <i class = 'fa fa-fw fa-gavel invisible' aria-hidden = 'true'></i>
     <%= render partial: '/products/product_test_upload', locals: { task: task, label_class: 'label-info' } %>

--- a/config/initializers/mongo.rb
+++ b/config/initializers/mongo.rb
@@ -1,6 +1,8 @@
 module QME
   Mongoid.logger.level = Logger::INFO
+  Mongoid.logger = Rails.logger if ENV['MONGO_LOGS'].eql? 'true'
   Mongo::Logger.logger.level = Logger::WARN
+  Mongo::Logger.logger = Rails.logger if ENV['MONGO_LOGS'].eql? 'true'
   patient_cache = Mongoid.default_client['patient_cache']
   BSON::Config.validating_keys = false
 


### PR DESCRIPTION
Often when the test suite ran it would fail because the page was not refreshing properly due to a race condition between the state of the test and some other calls in the code. It was happening because the should_reload_product_test_link? function was being used in conjunction with the task_status to determine the test state. These would get out of sync and cause an incorrect code path to be taken, which would cause the page to stop refreshing even though the tests were not completed. This cleans up that code to make less queries which will cause the state to be more reliable.