### PR TITLE
Make hamburger menu happen earlier in order to stop navigation button s from getting pushed below the header

### DIFF
--- a/app/assets/stylesheets/_bootstrap-variables.scss
+++ b/app/assets/stylesheets/_bootstrap-variables.scss
@@ -336,7 +336,7 @@ $grid-columns:              12 !default;
 $grid-gutter-width:         30px !default;
 // Navbar collapse
 //** Point at which the navbar becomes uncollapsed.
-$grid-float-breakpoint:     $screen-md-min !default;
+$grid-float-breakpoint:     $screen-lg-min !default;
 //** Point at which the navbar begins collapsing.
 $grid-float-breakpoint-max: ($grid-float-breakpoint - 1) !default;
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -159,6 +159,9 @@ def wait_for_all_delayed_jobs_to_run
 end
 
 Before do
+  # Make the window larger in order to account for navbar larger collapse point
+  Capybara.page.current_window.resize_to(1200, 800)
+
   Mongoid.default_client['users'].drop
   Mongoid.default_client['vendors'].drop
   Mongoid.default_client['products'].drop


### PR DESCRIPTION
Thought this was fixed previously however it looks like it still happens when the validation utility button is enabled. Bumping collapse point again.