### PR TITLE
Make tests more verbose on failure

### DIFF
--- a/features/step_definitions/user.rb
+++ b/features/step_definitions/user.rb
@@ -16,7 +16,8 @@ end
 
 When(/^I click Sign up$/) do
   page.click_link_or_button 'Sign up'
-  sleep(1) # Gross, but otherwise this randomly fails @SS
+  # Sign up should be one of the only pages with the text Confirm Password
+  page.has_text?('Confirm Password')
 end
 
 When(/^I fill in the form with correct information$/) do

--- a/features/support/debugging.rb
+++ b/features/support/debugging.rb
@@ -1,6 +1,7 @@
 After do |scenario|
   if scenario.failed?
-    # When a scenario fails, stop running tests and open the current page.
+    # When a scenario fails, print the page source and stop running tests.
+    Cucumber.logger.info page.html
     Cucumber.wants_to_quit = true
   end
 end


### PR DESCRIPTION
Currently when the test suite fails on cucumber there is no way for us to get any idea why it happened. By dumping the source of the page we can at least get an idea of what is going on.

Also I replaced a sleep message with a more "cucumbery" way of doing things.