### PR TITLE
Move to Mongo 3.4 on travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,10 @@ sudo: false
 addons:
   apt:
     sources:
-      - mongodb-upstart
-      - mongodb-3.0-precise
+      - sourceline: 'deb http://repo.mongodb.org/apt/ubuntu precise/mongodb-org/3.4 multiverse'
+        key_url: 'http://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x9ECBEC467F0CEB10'
     packages:
       - mongodb-org-server
-      - mongodb-org-shell
 services:
   - mongodb
 branches:

--- a/contrib/upgrade_cypress_30.sh
+++ b/contrib/upgrade_cypress_30.sh
@@ -196,6 +196,15 @@ if [ "$CVU_FOUND" = "true" ]; then
   systemctl restart cypress-validation-utility
 fi
 
+echo "Upgrading Mongo Version..."
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+apt-get update
+apt-get -y install libc6 mongodb-org mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
+
+echo "restarting Mongo Service..."
+systemctl restart mongod
+
 echo "Installing NTP service..."
 apt-get -y --fix-missing install ntp
 


### PR DESCRIPTION
This PR bumps travis CI to use mongo 3.4 instead of 3.0 for testing.