### PR TITLE
Add mongo 3.4 upgrade to upgrade script

### DIFF
--- a/contrib/upgrade_cypress_30.sh
+++ b/contrib/upgrade_cypress_30.sh
@@ -196,6 +196,15 @@ if [ "$CVU_FOUND" = "true" ]; then
   systemctl restart cypress-validation-utility
 fi
 
+echo "Upgrading Mongo Version..."
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-3.4.list
+apt-get update
+apt-get -y install libc6 mongodb-org mongodb-org-mongos mongodb-org-server mongodb-org-shell mongodb-org-tools
+
+echo "restarting Mongo Service..."
+systemctl restart mongod
+
 echo "Installing NTP service..."
 apt-get -y --fix-missing install ntp
 


### PR DESCRIPTION
This bumps the version of mongo we are using to mongo 3.4. Overall I have yet to run into any issues experienced by performing this upgrade however we should probably wait to merge this until mongo 3.4 incompatibility is fixed with IBM Power Systems, see the note on [this page](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-ubuntu/). At this point the fix is already in xenial-proposed but has not yet been rolled out as an official update.

Once ubuntu xenial has version 2.24 of libc6 available in apt we can go ahead and deploy this.