### PR TITLE
Add a field for error backtraces if a test execution errors out on us

### DIFF
--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -9,6 +9,7 @@ class TestExecution
   field :expected_results, type: Hash
   field :reported_results, type: Hash
   field :qrda_type, type: String
+  field :backtrace, type: String
   # a sibling test execution is a c3 test execution if the current execution is a c1 or c2 execution. vice versa
   #   and nil if c3 execution does not exist
   field :sibling_execution_id, type: String
@@ -44,8 +45,9 @@ class TestExecution
     end
     conditionally_add_task_specific_errors(file_count)
     execution_errors.only_errors.count > 0 ? fail : pass
-  rescue
-    errored
+  rescue => e
+    errored(e)
+    logger.error("Encountered an exception in Test Execution #{id}: #{e.message}, backgrace:\n#{e.backtrace}")
   end
 
   def conditionally_add_task_specific_errors(file_count)
@@ -92,8 +94,9 @@ class TestExecution
     save
   end
 
-  def errored
+  def errored(e = nil)
     self.state = :errored
+    self.backtrace = e.message + "\n" + e.backtrace.join("\n")
     save
   end
 

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -41,7 +41,7 @@ end
 When(/^a user creates a product with (.*) certifications and visits that product page$/) do |certs|
   certs = certs.split(', ')
   steps %( When the user navigates to the create product page for vendor #{@vendor.name} )
-  product_name = "my product #{rand}"
+  product_name = "mp #{rand}"
   page.fill_in 'Name', with: product_name
   page.find('#product_c1_test').click if certs.include? 'c1'
   page.find('#product_c2_test').click if certs.include? 'c2'

--- a/test/models/cat3_filter_task_test.rb
+++ b/test/models/cat3_filter_task_test.rb
@@ -7,9 +7,10 @@ class Cat3FilterTaskTest < ActiveSupport::TestCase
   def setup
     collection_fixtures('product_tests', 'products', 'bundles',
                         'measures', 'records', 'patient_cache',
-                        'health_data_standards_svs_value_sets')
+                        'health_data_standards_svs_value_sets', 'vendors')
 
     vendor = Vendor.create(name: 'test_vendor_name')
+    vendor.save!
     product = vendor.products.create(name: 'test_product', randomize_records: true, c2_test: true, c4_test: true,
                                      bundle_id: '4fdb62e01d41c820f6000001', measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'])
 
@@ -18,6 +19,7 @@ class Cat3FilterTaskTest < ActiveSupport::TestCase
     @product_test = product.product_tests.create({ name: 'test_for_measure_1a',
                                                    measure_ids: ['8A4D92B2-397A-48D2-0139-B0DC53B034A7'],
                                                    options: options }, FilteringTest)
+    MeasureEvaluationJob.perform_now(@product_test, {})
   end
 
   def test_create
@@ -32,6 +34,7 @@ class Cat3FilterTaskTest < ActiveSupport::TestCase
       te = task.execute(xml, User.first)
       te.reload
       assert_empty te.execution_errors, 'test execution with known good results should not have any errors'
+      assert te.passing?, 'test execution with known good results should pass'
     end
   end
 end

--- a/test/models/test_execution_test.rb
+++ b/test/models/test_execution_test.rb
@@ -27,6 +27,20 @@ class TestExecutionTest < ActiveSupport::TestCase
     assert te.passing?, 'te.passing? not returning true when execution is passing'
   end
 
+  def test_errored_should_contain_backtrace
+    se = StandardError.new('message')
+    se.set_backtrace(%w(line1 line2))
+
+    te = TestExecution.new
+    te.save
+
+    te.errored(se)
+
+    assert_equal te.backtrace, "message\nline1\nline2", 'te.errored doesn\'t set the correct backtrace message'
+
+    assert te.errored?, 'te.errored? not returning true when execution is errored'
+  end
+
   def test_qrda_reporting_and_submission_errors
     qrda_errors = [
       { validator: 'CDA SDTC Validator' },


### PR DESCRIPTION
This will help with debugging if people report errored test executions, or if we get internal errors during runs of the Measure Evaluator.