### PR TITLE
use ajax binding to apply javascript to ajaxComplete and submit

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -35,4 +35,14 @@
 $(function() {
   Turbolinks.enableProgressBar();
   $('.breadcrumb').breadcrumb();
+
+  $(document).on('ajaxComplete',function(e){
+    $(e.delegateTarget.activeElement).blur();
+  });
+
+  $(document).on('submit',function(e){
+    window.setTimeout(function(){
+      $(e.delegateTarget.activeElement).blur();
+    }, 1500);
+  });
 });


### PR DESCRIPTION
Application-wide binding on buttons submitting (and ajax completing) so that the button's focus is blurred. This allows the user to purposefully put highlighting focus on a button, but if the button is clicked, the focus won't remain there indefinitely. One example is for favorite buttons as seen below, but this is also fixed for other buttons that stay on the same page, such as download buttons.

![screen shot 2017-03-06 at 9 26 43 am](https://cloud.githubusercontent.com/assets/2643955/23613908/2dcb3c40-024f-11e7-8770-f9fd945fbe24.png)
![screen shot 2017-03-06 at 9 27 25 am](https://cloud.githubusercontent.com/assets/2643955/23613909/2dcdffd4-024f-11e7-95af-07aeb4e16b23.png)

