### PR TITLE
restore ellipsis for product name

### DIFF
--- a/app/views/application/_product_status_table.html.erb
+++ b/app/views/application/_product_status_table.html.erb
@@ -16,15 +16,17 @@
     <tr id="product-status-<%=product.id%>">
       <% if show_product_link %>
         <th scope="col" rowspan="2" class="product-name">
-          <%= button_to vendor_product_favorite_path(product.vendor_id, product), remote: true, :class => "btn btn-link btn-pop" do %>
-            <% if (product.favorite_user_ids.include? current_user.id) %>
-              <i class="fa fa-fw fa-star" aria-hidden="true"></i>
-              <span class="sr-only">product favorited</span>
-            <% else %>
-              <i class="fa fa-fw fa-star-o" aria-hidden="true"></i>
-              <span class="sr-only">product not favorited</span>
+          <span>
+            <%= button_to vendor_product_favorite_path(product.vendor_id, product), remote: true, :class => "btn btn-link btn-pop" do %>
+              <% if (product.favorite_user_ids.include? current_user.id) %>
+                <i class="fa fa-fw fa-star" aria-hidden="true"></i>
+                <span class="sr-only">product favorited</span>
+              <% else %>
+                <i class="fa fa-fw fa-star-o" aria-hidden="true"></i>
+                <span class="sr-only">product not favorited</span>
+              <% end %>
             <% end %>
-          <% end %>
+          </span>
           <%= link_to product.name, vendor_product_path(product.vendor_id, product) %>
         </th>
       <% else %>


### PR DESCRIPTION

![screen shot 2017-03-08 at 10 11 10 am](https://cloud.githubusercontent.com/assets/2643955/23709496/a25ca0aa-03e7-11e7-8f74-842bc4454191.png)
![screen shot 2017-03-08 at 10 11 23 am](https://cloud.githubusercontent.com/assets/2643955/23709497/a26050b0-03e7-11e7-9b79-c054d9394da5.png)

text styling for the product name link on the product list (in the show vendor page) was altered by the inclusion of a favorite button. Favorite button has now been offset from styling by placing it in a span tag