### PR TITLE
Add cypress_3_2 branch to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 branches:
   only:
   - master
-  - cypress3
+  - cypress_3_2
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Cypress_3_2 branch added
Cypress3 branch removed, no longer in use