### PR TITLE
Move effective_date out of cypress.yml

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -1,8 +1,3 @@
-effective_date:
-  year: 2015
-  month: 12
-  day: 31
-
 default_bundle: "3.0.0"
 
 # Specify the folder to look for the schematron files in based on bundle version these folders are in ./resources/schematron/

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -49,18 +49,18 @@ module Cypress
 
     def self.randomize_insurance_provider(record)
       ip = InsuranceProvider.new
-      randomize_payer(ip, record.birthdate)
+      randomize_payer(ip, record)
       ip.financial_responsibility_type = { 'code' => 'SELF', 'codeSystem' => 'HL7 Relationship Code' }
       ip.member_id = Faker::Number.number(10)
       ip.start_time = get_random_payer_start_date(record)
       record.insurance_providers = [ip]
     end
 
-    def self.randomize_payer(insurance_provider, birthdate)
+    def self.randomize_payer(insurance_provider, record)
       payer = Cypress::AppConfig['randomization']['payers'].sample
       # if the payer is Medicare and the patient is < 65 years old at the beginning of the measurement period, try again
       while payer['name'] == 'Medicare' &&
-            Time.at(birthdate).in_time_zone > Time.new(Cypress::AppConfig['effective_date']['year']).in_time_zone.years_ago(65)
+            Time.at(record.birthdate).in_time_zone > Time.at(record.bundle.effective_date).in_time_zone.years_ago(65)
         payer = Cypress::AppConfig['randomization']['payers'].sample
       end
       insurance_provider.codes = {}

--- a/lib/validators/measure_period_validator.rb
+++ b/lib/validators/measure_period_validator.rb
@@ -19,7 +19,7 @@ module Validators
     end
 
     def validate_start
-      measure_start = Cypress::AppConfig['effective_date']['year'].to_s + '0101'
+      measure_start = Time.at(@options['test_execution'].task.bundle.measure_period_start).utc.strftime('%Y%m%d')
       doc_start_time = @document.at_xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/
         cda:entry/cda:act[./cda:templateId[@root='2.16.840.1.113883.10.20.17.3.8']]/
         cda:effectiveTime/cda:low/@value")
@@ -35,7 +35,7 @@ module Validators
     end
 
     def validate_end
-      measure_end = Cypress::AppConfig['effective_date']['year'].to_s + '1231'
+      measure_end = Time.at(@options['test_execution'].task.bundle.effective_date).utc.strftime('%Y%m%d')
       doc_end_time = @document.at_xpath("/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/
         cda:entry/cda:act[./cda:templateId[@root='2.16.840.1.113883.10.20.17.3.8']]/
         cda:effectiveTime/cda:high/@value")

--- a/test/models/c1_task_test.rb
+++ b/test/models/c1_task_test.rb
@@ -89,19 +89,19 @@ class C1TaskTest < ActiveSupport::TestCase
     perform_enqueued_jobs do
       te = task.execute(zip, User.first, nil)
       te.reload
-      assert_equal 18, te.execution_errors.by_file('0_Dental_Peds_A.xml').count
+      assert_equal 20, te.execution_errors.by_file('0_Dental_Peds_A.xml').count
       assert_equal 5, te.execution_errors.by_file('0_Dental_Peds_A.xml').where(validator: 'QRDA Cat 1 R3 Validator').count
       assert_equal 1, te.execution_errors.by_file('0_Dental_Peds_A.xml').where(:message => '["2.16.840.1.113883.10.20.22.4.49:", '\
         '"2.16.840.1.113883.10.20.24.3.23:"] are not valid Patient Data Section QDM entries for this QRDA Version', :msg_type => :error).count
       assert_equal 1, te.execution_errors.by_file('0_Dental_Peds_A.xml').where(:message => 'File appears to contain data criteria outside that '\
         'required by the measures. Valuesets in file not in measures tested 2.16.840.1.113883.3.464.1003.101.12.1023\'', :msg_type => :warning).count
-      assert_equal 28, te.execution_errors.by_file('1_HIV_Peds_A.xml').count
+      assert_equal 30, te.execution_errors.by_file('1_HIV_Peds_A.xml').count
       assert_equal 4, te.execution_errors.by_file('1_HIV_Peds_A.xml').where(:message => '["2.16.840.1.113883.10.20.22.4.49:", '\
         '"2.16.840.1.113883.10.20.24.3.23:"] are not valid Patient Data Section QDM entries for this QRDA Version', :msg_type => :error).count
-      assert_equal 37, te.execution_errors.by_file('2_GP_Peds_B.xml').count
+      assert_equal 39, te.execution_errors.by_file('2_GP_Peds_B.xml').count
       # 5 errors for templates ["2.16.840.1.113883.10.20.22.4.49:", "2.16.840.1.113883.10.20.24.3.23:"] are not valid Patient Data Section QDM entries for this QRDA Version', :msg_type => :error).count
       # 3 errors for templates ["2.16.840.1.113883.10.20.22.4.2:", "2.16.840.1.113883.10.20.24.3.57:"] are not valid Patient Data Section QDM entries for this QRDA Version', :msg_type => :error).count
-      assert_equal 35, te.execution_errors.by_file('3_GP_Peds_C.xml').count
+      assert_equal 37, te.execution_errors.by_file('3_GP_Peds_C.xml').count
       assert_equal 2, te.execution_errors.by_file('3_GP_Peds_C.xml').where(:message => '["2.16.840.1.113883.10.20.22.4.49:", '\
         '"2.16.840.1.113883.10.20.24.3.23:"] are not valid Patient Data Section QDM entries for this QRDA Version', :msg_type => :error).count
       # 1 additional error for templates ["2.16.840.1.113883.10.20.24.3.11:", "2.16.840.1.113883.10.20.22.4.4:"]

--- a/test/models/c3_cat3_task_test.rb
+++ b/test/models/c3_cat3_task_test.rb
@@ -11,6 +11,10 @@ class C3Cat3TaskTest < ActiveSupport::TestCase
     @test.product.c3_test = true
     @test.product.c2_test = true
     @task = @test.tasks.create({}, C3Cat3Task)
+    @bundle = Bundle.find('4fdb62e01d41c820f6000001')
+    @bundle.measure_period_start = 1_420_070_400
+    @bundle.effective_date = 1_451_520_000
+    @bundle.save!
   end
 
   def test_task_should_include_c3_cat3_validators

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -3,6 +3,7 @@ require 'fileutils'
 
 class DemographicsRandomizerTest < ActiveSupport::TestCase
   setup do
+    collection_fixtures('bundles')
     @first = 'Xyntash'
     @last = 'Zygadoo'
     @race = { 'code' => 'NA', 'name' => 'NA', 'codeSystem' => 'NA' }
@@ -33,6 +34,7 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
       addresses: [@address],
       insurance_providers: [@insurance_provider]
     )
+    @record.bundle_id = Bundle.find('4fdb62e01d41c820f6000001').id
     @prng = Random.new(Random.new_seed)
   end
 

--- a/test/unit/lib/validators/measure_period_validator_test.rb
+++ b/test/unit/lib/validators/measure_period_validator_test.rb
@@ -3,19 +3,25 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
   include ::Validators
 
   def setup
+    collection_fixtures('bundles', 'product_tests', 'products', 'tasks', 'test_executions')
     @validator = MeasurePeriodValidator.new
+    @test_execution = TestExecution.find('4f5900981d41c851eb000482')
   end
 
   def test_file_with_good_mp
     file = File.new(File.join(Rails.root, 'test/fixtures/qrda/ep_test_qrda_cat3_missing_measure.xml')).read
 
-    @validator.validate(file)
+    @test_execution.task.bundle.measure_period_start = Time.new(2015, 01, 01).utc.to_i
+    @test_execution.task.bundle.effective_date = Time.new(2015, 12, 31).utc.to_i
+    @validator.validate(file, 'test_execution' => @test_execution)
     assert_empty @validator.errors
   end
 
   def test_file_with_bad_mp
     file = File.new(File.join(Rails.root, 'test/fixtures/qrda/ep_test_qrda_cat3_bad_mp.xml')).read
-    @validator.validate(file)
+    @test_execution.task.bundle.measure_period_start = Time.new(2015, 01, 01).utc.to_i
+    @test_execution.task.bundle.effective_date = Time.new(2015, 12, 31).utc.to_i
+    @validator.validate(file, 'test_execution' => @test_execution)
     errors = @validator.errors
 
     assert_equal 2, errors.length, 'should have 2 errors for the invalid reporting period'


### PR DESCRIPTION
Remove `effective_date` from the `cypress.yml`/`AppConfig`; and rework places it's used to use the `bundle` value instead.

Also had to add effective dates to some elements, and change bundle effective dates to match those of the XML being used, to make some tests pass.