### PR TITLE
MPL Download Rebuild task enhancements

### DIFF
--- a/lib/tasks/tmp.rake
+++ b/lib/tasks/tmp.rake
@@ -8,7 +8,7 @@ namespace :tmp do
       Vendor.each(&:status)
     end
 
-    desc "Rebuilds the MPL Download .zip for all installed bundles"
+    desc 'Rebuilds the MPL Download .zip for all installed bundles'
     task mpl_download_rebuild: [:environment] do
       puts 'Rebuilding all MPL Downloads...'
       Bundle.all.each do |bundle|

--- a/lib/tasks/tmp.rake
+++ b/lib/tasks/tmp.rake
@@ -8,6 +8,7 @@ namespace :tmp do
       Vendor.each(&:status)
     end
 
+    desc "Rebuilds the MPL Download .zip for all installed bundles"
     task mpl_download_rebuild: [:environment] do
       puts 'Rebuilding all MPL Downloads...'
       Bundle.all.each do |bundle|
@@ -21,5 +22,9 @@ end
 
 Rake::Task['tmp:cache:clear'].enhance do
   Rake::Task['tmp:cache:rebuild'].invoke
+  Rake::Task['tmp:cache:mpl_download_rebuild'].invoke
+end
+
+Rake::Task['bundle:download_and_install'].enhance do
   Rake::Task['tmp:cache:mpl_download_rebuild'].invoke
 end


### PR DESCRIPTION
Add a description to the `tmp:cache:mpl_download_rebuild` task, so it shows up in the `rake -T` list.

add the `tmp:cache:mpl_download_rebuild` task to the `bundle:download_and_install` task after bundle installation, so new bundles installed by the command line get MPL downloads just like ones installed by the Admin panel.

Note: the `enhance` method for `Rake::Task` runs items in the block (e.g. the `tmp:cache:mpl_download_rebuild` task) _after_ the original task, so the new bundle MPL zip will be built.