### PR TITLE
Added support for generating MPL download bundle as a background job on MPL page load

### DIFF
--- a/app/jobs/bundle_upload_job.rb
+++ b/app/jobs/bundle_upload_job.rb
@@ -22,6 +22,6 @@ class BundleUploadJob < ActiveJob::Base
     else
       Cypress::AppConfig['default_bundle'] = @bundle.version
     end
-    MplDownloadCreateJob.perform_later(@bundle.id.to_s)
+    @bundle.mpl_prepare
   end
 end

--- a/app/jobs/mpl_download_create_job.rb
+++ b/app/jobs/mpl_download_create_job.rb
@@ -2,12 +2,12 @@ class MplDownloadCreateJob < ActiveJob::Base
   include Job::Status
   after_enqueue do |job|
     tracker = job.tracker
-    tracker.options['original_filename'] = job.arguments[1]
+    tracker.options['bundle_id'] = job.arguments[0]
     tracker.save
   end
   def perform(bundle_id)
     tracker.log('Creating Download')
-    bundle = Bundle.find(BSON::ObjectId.from_string(bundle_id))
+    bundle = Bundle.find(bundle_id)
     path = File.join(Rails.root, 'tmp', 'cache', 'bundle_download', bundle.id.to_s)
     Cypress::CreateDownloadZip.bundle_directory(bundle, path)
     zfg = ZipFileGenerator.new(path, bundle.mpl_path)

--- a/app/views/records/_mpl_download.html.erb
+++ b/app/views/records/_mpl_download.html.erb
@@ -1,6 +1,28 @@
-<div class="radio download-btn" style="">
+<% current_mpl_status = bundle.mpl_prepare %>
+<% if current_mpl_status == :ready %>
   <span class="sr-only">Download <%= bundle.title %></span>
   <%= link_to download_mpl_records_path(bundle), :method => :get, :class => "btn btn-xs btn-default" do %>
     Download <span class="sr-only"><%= bundle.title %></span>
   <% end %>
+<% else %>
+  <span class="sr-only">Preparing download for <%= bundle.title %></span>
+  <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i> Preparing Download
+<% end %>
 </div>
+<% unless current_mpl_status == :ready %>
+  <script>
+    $(document).ready(function() {
+      $.ajax({
+        url: "<%= request.env['PATH_INFO'] %>",
+        type: "GET",
+        dataType: 'script',
+        data: { partial: 'mpl_download', mpl_bundle_id: '<%= bundle.id %>' },
+        complete: function(data) {
+          if(data.status != 200) {
+            $('.download-btn#<%= bundle.id %>').html('<b>Error:</b> Please reload webpage')
+          }
+        }
+      });
+    });
+  </script>
+<% end %>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -39,7 +39,9 @@
           <div class="radio" style="padding: 6px 12px; display: inline-block">
             <!-- label --> <%= @bundle.title %>
           </div>
-          <%= render partial: "mpl_download", locals: { bundle: @bundle } %>
+          <div class="radio download-btn" id=<%= @bundle.id %>>
+            <%= render partial: "mpl_download", locals: { bundle: @bundle } %>
+          </div>
           <% else %>
             <!-- loop through bundles & use radio buttons -->
             <%= bootstrap_form_tag do |f| %>
@@ -49,7 +51,9 @@
                   <%= f.radio_button :bundle_id, bundle.id, label: bundle.title, label_class: "btn btn-checkbox",
                                      checked: bundle == @bundle %>
                 </div>
-                <%= render partial: "mpl_download", locals: { bundle: bundle } %>
+                <div class="radio download-btn" id='<%= bundle.id %>'>
+                  <%= render partial: "mpl_download", locals: { bundle: bundle } %>
+                </div>
                 <% end # bundle loop %>
               <% end # form_group %>
             <% end # form tag %>

--- a/app/views/records/index.js.erb
+++ b/app/views/records/index.js.erb
@@ -1,0 +1,13 @@
+<% if params[:partial] == 'mpl_download' %>
+  <% # Can't pass this as bundle_id since bundle_id refers to the active bundle in this context %>
+  <% bundle = Bundle.find(params[:mpl_bundle_id]) %>
+  <% if bundle.mpl_status == :ready %>
+    <% # don't wait. just load the MPL download %>
+    $('.download-btn#<%= bundle.id %>').html("<%= escape_javascript render partial: 'mpl_download', locals: { bundle: bundle } %>");
+  <% else %>
+    <% # wait 2 seconds. then reload the partial %>
+    setTimeout(function(){
+      $('.download-btn#<%= bundle.id %>').html("<%= escape_javascript render partial: 'mpl_download', locals: { bundle: bundle } %>");
+    }, 2000);
+  <% end %>
+<% end %>

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -20,6 +20,25 @@ Scenario: View Master Patient List Page, Single Bundle
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
+Scenario: Download MPL from Master Patient List Page
+  When the user visits the records page
+  And the Master Patient List zip is not already built
+  Then the user should see Preparing Download for all MPL downloads
+  When the Master Patient List zip is ready for download
+  Then the user should see a Download button
+  When the user clicks a Download button
+  Then a zip file should be downloaded
+
+Scenario: Download MPL from Master Patient List Page, Single Bundle
+  When the user visits the records page
+  And there is only 1 bundle installed
+  And the Master Patient List zip is not already built
+  Then the user should see Preparing Download for all MPL downloads
+  When the Master Patient List zip is ready for download
+  Then the user should see a Download button
+  When the user clicks a Download button
+  Then a zip file should be downloaded
+
 Scenario: Successful switch bundles
   When the user visits the records page
   And the user selects a bundle

--- a/lib/tasks/tmp.rake
+++ b/lib/tasks/tmp.rake
@@ -12,8 +12,8 @@ namespace :tmp do
     task mpl_download_rebuild: [:environment] do
       puts 'Rebuilding all MPL Downloads...'
       Bundle.all.each do |bundle|
-        puts "\tBuilding MPL download for bundle #{bundle.version}"
-        MplDownloadCreateJob.perform_now(bundle.id)
+        puts "\tEnqueuing MPL download for bundle #{bundle.version}"
+        bundle.mpl_prepare
       end
       puts 'done'
     end

--- a/test/jobs/mpl_download_create_job_test.rb
+++ b/test/jobs/mpl_download_create_job_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class MplDownloadCreateJobTest < ActiveJob::TestCase
+  setup do
+    collection_fixtures('bundles', 'products')
+
+    @bundle = Bundle.find('4fdb62e01d41c820f6000001')
+    # Clean up MPL before and after running for consistency
+    FileUtils.rm_rf(@bundle.mpl_path)
+  end
+
+  teardown do
+    FileUtils.rm_rf(@bundle.mpl_path)
+  end
+
+  def test_enqueue_mpl_create_job
+    assert_enqueued_jobs 0
+
+    assert_enqueued_jobs 1 do
+      assert :building, @bundle.mpl_prepare
+    end
+  end
+
+  def test_running_mpl_job_success
+    perform_enqueued_jobs do
+      assert :building, @bundle.mpl_prepare
+      assert_performed_jobs 1
+      assert :ready, @bundle.mpl_status
+      assert File.exist?(@bundle.mpl_path)
+    end
+  end
+
+  def test_multiple_enqueue_does_not_create_multiple_jobs
+    assert_enqueued_jobs 0
+    assert :building, @bundle.mpl_prepare
+    assert_enqueued_jobs 1
+    assert :building, @bundle.mpl_prepare
+    assert_enqueued_jobs 1
+  end
+end


### PR DESCRIPTION
Sometimes users manage to get to the MPL download page before the download zip has actually been generated. This adds automatic refreshing while the bundle is generated as well as kicking off the generation if it was not generated on initial bundle load.