### PR TITLE
Fix measure search filtering

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -37,7 +37,9 @@ $(function() {
   $('.breadcrumb').breadcrumb();
 
   $(document).on('ajaxComplete',function(e){
-    $(e.delegateTarget.activeElement).blur();
+    if(e.delegateTarget.activeElement.tagName.toLowerCase() == 'button') {
+      $(e.delegateTarget.activeElement).blur();
+    }
   });
 
   $(document).on('submit',function(e){

--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -131,15 +131,22 @@ function HookupProductSearch() {
   // Searchbox is #product_search_measures which is currently the parent.
   var searchbox = $(this)
 
-  $.ajax({
-    url: "/bundles/" + bundle_id + "/measures/filtered/" + current_search,
-    type: "GET",
-    dataType: "json",
-    success: function(data, textStatus, xhr) {
-      filterVisibleMeasures(searchbox, data.measures)
-      filterVisibleMeasureTabs(searchbox, data.measure_tabs)
-    }
-  });
+  var ajaxReq, timer
+  clearTimeout(timer)
+  if (ajaxReq) ajaxReq.abort();
+
+  timer = setTimeout(function(){
+    ajaxReq = $.ajax({
+      url: "/bundles/" + bundle_id + "/measures/filtered/" + current_search,
+      type: "GET",
+      dataType: "json",
+      success: function(data, textStatus, xhr) {
+        ajaxReq = null
+        filterVisibleMeasures(searchbox, data.measures)
+        filterVisibleMeasureTabs(searchbox, data.measure_tabs)
+      }
+    });
+  }, 200);
 }
 
 // these pieces need to run every time the bundle is changed


### PR DESCRIPTION
Currently the measure search loses focus after every ajax query. This change was made in order to fix the favorite buttons from holding focus. This filters those buttons down to only remove focus if the active element is a button. Also I have added some checks to stop multiple AJAX queries from happening at once.