### PR TITLE
Misc UI Fixes for settings and users

### DIFF
--- a/app/controllers/registrations_controller.rb
+++ b/app/controllers/registrations_controller.rb
@@ -4,6 +4,7 @@ class RegistrationsController < Devise::RegistrationsController
   add_breadcrumb 'Cancel Account', :cancel_user_registration_path, only: [:cancel]
 
   before_action :configure_permitted_parameters
+  before_action :load_test_executions, only: [:edit, :update]
 
   def new
     @title = 'Create Account'
@@ -12,13 +13,14 @@ class RegistrationsController < Devise::RegistrationsController
 
   def edit
     @title = 'Edit User'
-    # @test_executions = TestExecution.accessible_by(current_user)#.order(:updated_at => :desc)
-
-    @test_executions = current_user.test_executions
     super
   end
 
   protected
+
+  def load_test_executions
+    @test_executions = current_user.test_executions
+  end
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:terms_and_conditions])

--- a/app/views/admin/_show_settings.html.erb
+++ b/app/views/admin/_show_settings.html.erb
@@ -1,7 +1,7 @@
 <%
   # local variables:
   #
-  #   banner, banner_message, smtp_settings, default_url_options mode, mode_settings, debug_features
+  #   banner, banner_message, smtp_settings, default_url_options mode, mode_settings, debug_features, server_needs_restart
 %>
 <div class="inline-block pull-right">
   <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-default" do %>
@@ -28,6 +28,9 @@
   <div class="col-sm-6">
     <legend>Mailer</legend>
     <dl class="dl-horizontal configured-mailer">
+      <% if server_needs_restart %>
+        <%= render :partial => 'alert', locals: { alert_type: 'warning', messages: 'You have changed the following settings however you have not reloaded Cypress. Any emails sent before reload will still use the following settings.' } %>
+      <% end %>
       <dt>Cypress URL</dt><dd><%= default_url_options.host.present? ? default_url_options.host : 'not configured' %></dd>
       <dt>Cypress Port</dt><dd><%= default_url_options.port.present? ? default_url_options.port : 'not configured' %></dd>
       <dt>SMTP Server</dt><dd><%= smtp_settings.address.present? ? smtp_settings.address : 'not configured' %></dd>

--- a/app/views/admin/show.html.erb
+++ b/app/views/admin/show.html.erb
@@ -15,7 +15,7 @@
   </ul>
 
   <div id="application_settings">
-    <%= render partial: "show_settings", locals: { banner_message: banner_message, warning_message: warning_message, banner: banner, smtp_settings: smtp_settings, default_url_options: default_url_options, mode: mode, mode_settings: mode_settings, debug_features: debug_features } %>
+    <%= render partial: "show_settings", locals: { banner_message: banner_message, warning_message: warning_message, banner: banner, smtp_settings: smtp_settings, default_url_options: default_url_options, mode: mode, mode_settings: mode_settings, debug_features: debug_features, server_needs_restart: server_needs_restart } %>
   </div>
 
   <div id="user_management" >


### PR DESCRIPTION
While testing the deploy scripts on the latest version I ran into 2 bugs that were very minor. 

The first issue wasn't even really a bug, more of a point of confusion. When you change application settings that require a server restart a banner message is now not only shown on the admin page but also right above the settings that are out of date.

For the second bug, there was a problem with the registrations_controller update method not loading the text executions as it should. I have now broken it out into a before_action so it is loaded for both edit and update.