### PR TITLE
Clinical Randomization: split by a given date or types

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -107,6 +107,8 @@ class ProductTest
     car = ::Validators::CalculatingAugmentedRecords.new(measures, [], id)
     dups = records.find(ids)
 
+    recs, dups = randomize_clinical_data(recs, dups, random)
+
     (random.rand(3) + 1).times do
       prng_repeat = Random.new(rand_seed.to_i)
       dup_rec, rec_augments, old_rec = dups.sample(random: random).duplicate_randomization(random: prng_repeat)
@@ -120,6 +122,14 @@ class ProductTest
       end
     end
     recs
+  end
+
+  def randomize_clinical_data(recs, dups, random)
+    # Pic a record to clinically randomize, then delete it from dups (so it doesn't get duplicated also)
+    # And delete it from recs so we don't return the whole patient too
+    clinical_record = dups.shuffle(random: random).pop
+    recs.delete(clinical_record)
+    [recs.concat(Cypress::ClinicalRandomizer.randomize(clinical_record, random: random)), dups]
   end
 
   def calculate

--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -1,0 +1,122 @@
+module Cypress
+  class ClinicalRandomizer
+    def self.randomize(record, random: Random.new)
+      case random.rand(2)
+      when 0
+        split_by_date(record, random)
+      when 1
+        split_by_type(record, random)
+      end
+    end
+
+    def self.split_by_date(record, random)
+      record_1 = record.clone
+      record_2 = record.clone
+
+      # Find a date that splits the entries such that at least 1 is in each record
+      split_date = find_split_date(record, random)
+
+      # Sort the entries from earliest to latest so we can split them more easily
+      entries = sort_by_start_time(record.entries)
+
+      Record::Sections.reject { |s| s == :insurance_providers }.each do |section|
+        record_1.send section.to_s + '=', []
+        record_2.send section.to_s + '=', []
+      end
+      if split_date
+        entries.take_while { |ent| ent_before_split_date(ent, split_date) }.each do |ent|
+          record_1.send(get_entry_type(ent._type)).push ent
+        end
+        entries.drop_while { |ent| ent_before_or_equals_split_date(ent, split_date) }.each do |ent|
+          record_2.send(get_entry_type(ent._type)).push ent
+        end
+      end
+
+      [record_1, record_2]
+    end
+
+    def self.ent_before_split_date(ent, split_date)
+      (ent.start_time && ent.start_time < split_date) || (ent.time && ent.time < split_date)
+    end
+
+    def self.ent_before_or_equals_split_date(ent, split_date)
+      (ent.start_time && ent.start_time <= split_date) || (ent.time && ent.time <= split_date)
+    end
+
+    def self.get_entry_type(entry_type)
+      if entry_type == 'LabResult'
+        'results'
+      else
+        entry_type.tableize
+      end
+    end
+
+    def self.split_by_type(record, random)
+      # Collect unique entry types from the record with populated entries
+      entry_types = record.entries.collect(&:_type).uniq.shuffle(random: random)
+      entry_types.delete('InsuranceProvider')
+
+      # If there's only 1 entry type, split by date instead
+      return split_by_date(record, random) if entry_types.count < 2
+
+      record_1 = record.clone
+      record_2 = record.clone
+
+      # Find a split point so each cloned record gets at least one entry type (hence, at least one entry)
+      split_point = random.rand(1..(entry_types.size - 1))
+
+      record_1 = set_record_sections_for_type(record_1, record, entry_types, split_point)
+      record_2 = set_record_sections_for_type(record_2, record, entry_types, split_point)
+
+      [record_1, record_2]
+    end
+
+    def self.set_record_sections_for_type(new_record, old_record, entry_types, split_point)
+      Record::Sections.each do |section|
+        new_record.send section.to_s + '=', [] unless section == :insurance_providers
+      end
+
+      entry_types.take(split_point).each do |elem|
+        type = get_entry_type(elem)
+        new_record.send(type).push old_record.send(type)
+      end
+      new_record
+    end
+
+    def self.sort_by_start_time(entries)
+      entries.delete_if { |e| e._type == 'InsuranceProvider' }.sort do |x, y|
+        if x.start_time.nil? && x.time.nil?
+          -1
+        elsif y.start_time.nil? && x.time.nil?
+          1
+        else
+          x_time = x.start_time ? x.start_time : x.time
+          y_time = y.start_time ? y.start_time : y.time
+          x_time <=> y_time
+        end
+      end
+    end
+
+    def self.find_split_date(record, random)
+      entries = sort_by_start_time(record.entries)
+      first_date = find_first_date_after(entries, record.bundle.measure_period_start)
+      last_date = find_last_date_before(entries, record.bundle.effective_date)
+      if first_date && last_date
+        return (last_date - first_date) * random.rand + first_date
+      end
+      nil
+    end
+
+    def self.find_first_date_after(entries, date)
+      ents = entries.detect { |ent| (ent.start_time && ent.start_time > date) || (ent.time && ent.time > date) }
+      ents.try(:start_time) ? ents.try(:start_time) : ents.try(:time)
+    end
+
+    def self.find_last_date_before(entries, date)
+      entries.each_cons(2) do |ents|
+        return ents[0].start_time if (ents[1].start_time && ents[1].start_time > date) || (ents[1].time && ents[1].time > date)
+      end
+      entries.last.try(:start_time) ? entries.last.try(:start_time) : entries.last.try(:time)
+    end
+  end
+end

--- a/test/unit/lib/clinical_randomizer_test.rb
+++ b/test/unit/lib/clinical_randomizer_test.rb
@@ -1,0 +1,80 @@
+require 'test_helper'
+
+class ClinicalRandomizerTest < ActiveSupport::TestCase
+  setup do
+    collection_fixtures('bundles', 'records')
+
+    @record = Record.new(first: 'Foo', last: 'Bar')
+    @bundle = Bundle.find('4fdb62e01d41c820f6000001')
+    @bundle.effective_date = 1_325_375_999
+    @bundle.save!
+    @record.bundle_id = @bundle.id
+
+    @record.encounters.push Encounter.new(start_time: 1_301_615_999)
+    @record.encounters.push Encounter.new(start_time: 1_317_513_599)
+    @record.save!
+
+    @record_2 = Record.new(first: 'Bar', last: 'Foo')
+    @record_2.bundle_id = @bundle.id
+    @record_2.encounters.push Encounter.new(start_time: 1_301_615_999)
+    @record_2.procedures.push Procedure.new(start_time: 1_317_513_599)
+    @record_2.conditions.push Condition.new(start_time: 1_317_513_600)
+    @record_2.save!
+
+    @record_3 = Record.new(first: 'Insurance', last: 'Test')
+    @record_3.bundle_id = @bundle.id
+    @record_3.encounters.push Encounter.new(start_time: 1_301_615_999)
+    @record_3.insurance_providers.push InsuranceProvider.new(start_time: @bundle.measure_period_start)
+    @record_3.save!
+  end
+
+  def test_split_by_date
+    date = Cypress::ClinicalRandomizer.find_split_date(@record, Random.new)
+    assert date > @bundle.measure_period_start, 'Split date must be during the measurement period'
+    assert date < @bundle.effective_date, 'Split date must be before the effective date'
+  end
+
+  def test_randomize_by_date
+    r1, r2 = Cypress::ClinicalRandomizer.split_by_date(@record, Random.new)
+
+    assert_equal r1.entries.length, 1, 'First split record should only have 1 entry'
+    assert_equal r2.entries.length, 1, 'Second split record should only have 1 entry'
+  end
+
+  def test_find_dates
+    detect_date = 1_301_615_999
+
+    assert_equal Cypress::ClinicalRandomizer.find_first_date_after(@record.entries, detect_date), 1_317_513_599, 'Should return the only entry after the detect_date'
+    assert_equal Cypress::ClinicalRandomizer.find_last_date_before(@record.entries, detect_date), 1_301_615_999, 'Should return the only entry before the detect_date'
+  end
+
+  def test_randomize_by_type
+    record_1, record_2 = Cypress::ClinicalRandomizer.split_by_type(@record_2, Random.new)
+
+    assert record_1.entries.count > 0, 'Record_1 should have at least 1 entry'
+    assert record_2.entries.count > 0, 'Record_2 should have at least 1 entry'
+
+    record_1, record_2 = Cypress::ClinicalRandomizer.split_by_type(@record, Random.new)
+    assert_equal record_1.entries.length, 1, 'First split record should have 1 entry if it falls back to split_by_date'
+    assert_equal record_2.entries.length, 1, 'Second split record should only have 1 entry if it falls back to split_by_date'
+  end
+
+  def test_randomize
+    record_1, record_2 = Cypress::ClinicalRandomizer.randomize(@record, random: Random.new)
+
+    assert_not_nil record_1, 'Records should not be nil'
+    assert_not_nil record_2, 'Records should not be nil'
+  end
+
+  def test_add_insurance_provider_split_by_date
+    record_1, record_2 = Cypress::ClinicalRandomizer.split_by_date(@record_3, Random.new)
+    assert_equal 1, record_1.insurance_providers.length, 'Record should have an insurance provider'
+    assert_equal 1, record_2.insurance_providers.length, 'Record should have an insurance provider'
+  end
+
+  def test_add_insurance_provider_split_by_type
+    record_1, record_2 = Cypress::ClinicalRandomizer.split_by_type(@record_3, Random.new)
+    assert_equal 1, record_1.insurance_providers.length, 'Record should have an insurance provider'
+    assert_equal 1, record_2.insurance_providers.length, 'Record should have an insurance provider'
+  end
+end


### PR DESCRIPTION
* Split by date: Randomizer picks a date that has at least 1 entry on
both sides of it, then splits on that date
* Split by type: Randomizer splits types between two records, so all of
one type are in one record

Continued work on clinical randomization

Initial tests for clinical randomization

Tests for clinical randomization complete

Fully tested clinical randomizer

Clean up/add comments, and add split_by_type

Integrate clinical randomizer with population duplication

remove the clinically duplicated patient from the test deck before duplication

Deal with record entries that aren't named the same thing as their embedded relations