### PR TITLE
Instead of relying on luck, pass in original source data criteria

### DIFF
--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -27,9 +27,8 @@ module ChecklistTestsHelper
     end
   end
 
-  def available_data_criteria(measure, criteria)
+  def available_data_criteria(measure, criteria, original_sdc)
     dc_hash = {}
-    og_dsc = ''
     og_string = ''
     measure.data_criteria.each do |dc|
       next if substituable_data_criteria?(dc)
@@ -38,11 +37,10 @@ module ChecklistTestsHelper
       # Store the original data source criteria and display string, makes sure you can reselect the orignal criteria
       # This is important for when the same criteria is used in multiple ways in the same measure
       if dc[dc.keys[0]].source_data_criteria == criteria.source_data_criteria
-        og_dsc = dc.keys[0]
         og_string = dc_string
       end
     end
-    dc_hash[og_string] = og_dsc
+    dc_hash[og_string] = original_sdc
     Hash[dc_hash.sort]
   end
 

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -111,7 +111,7 @@
                             <td/>
                           <% end %>
                           <td class='show-me' style='display: none;'>
-                            <%= criteria_field.select :replacement_data_criteria, available_data_criteria(measure, criteria), :selected => criteria_field.object.source_data_criteria, class: 'show-me' %>
+                            <%= criteria_field.select :replacement_data_criteria, available_data_criteria(measure, criteria, criteria_field.object.source_data_criteria), :selected => criteria_field.object.source_data_criteria, class: 'show-me' %>
                           <td>
                         </tr>
                       <% end %>


### PR DESCRIPTION
When multiple Data Criteria share the same Source Data Criteria, original approach runs the risk of not selecting the same one as the one in the test.  This solves the issue by passing in the SDC you are looking for.

This could happen before
 
![screen shot 2017-06-28 at 3 58 00 pm](https://user-images.githubusercontent.com/8173551/27657655-6b80ae28-5c1b-11e7-9234-f8ed06456cd8.png)
 
Now it won't

![screen shot 2017-06-28 at 3 59 57 pm](https://user-images.githubusercontent.com/8173551/27657676-81b4e74a-5c1b-11e7-8a8e-f310d1b0af61.png)
