### PR TITLE
Correct issue where measure filtering was not working when only 1 bundle was imported

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -124,8 +124,11 @@ function UpdateMeasureSet(bundle_id) {
 }
 
 function HookupProductSearch() {
+  // Get all bundles listed on the page
+  var bundles = $('input[name="product[bundle_id]"]')
   // Fetch the currently selected bundle from the list on the top of the page.
-  var bundle_id = $('input[name="product[bundle_id]"]:checked').val()
+  // If there are multiple bundles then grab only the one that is checked.
+  var bundle_id = bundles.filter(':checked').val() || bundles.val()
   // Remove or urlencode any special characters from the search query
   var current_search = encodeURIComponent($('#product_search_measures').val().replace(/[!'()*]/g, ""))
   // Searchbox is #product_search_measures which is currently the parent.


### PR DESCRIPTION
We were assuming that when there is only 1 bundle imported that we would still be able to grab the currently checked bundle to figure out which measures are currently available, however this is not correct. We can instead try to grab any checked bundles and if none are checked assume that there is only 1 and then grab it instead.

To reproduce this just attempt to filter measures on the product creation page when you only have 1 bundle installed.