### PR TITLE
Product page fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,7 +102,7 @@ group :development, :test do
   gem 'capybara'
   gem 'capybara-accessible'
   gem 'axe-matchers'
-  gem 'selenium-webdriver', '2.48.0'
+  gem 'selenium-webdriver'
   gem 'parallel_tests'
   gem 'pry'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -399,11 +399,9 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    selenium-webdriver (2.48.0)
+    selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
-      multi_json (~> 1.0)
       rubyzip (~> 1.0)
-      websocket (~> 1.0)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -456,7 +454,6 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
-    websocket (1.2.3)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -525,7 +522,7 @@ DEPENDENCIES
   sass-rails (~> 5.0.4)
   scss_lint
   sdoc (~> 0.4.0)
-  selenium-webdriver (= 2.48.0)
+  selenium-webdriver
   simplecov
   turbolinks (= 2.5.3)
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -230,7 +230,7 @@ ready_run_once = function() {
     $(event.currentTarget).closest('alert').find('.close').click();
   });
 
-  $('.clear-measures-btn').on('click', function(event) {
+  $(document).on('click', '.clear-measures-btn', function(event) {
     $('.measure-group .measure-checkbox').prop('checked', false).change();
     this.blur();
     // $('clear-measures-btn').setAttribute("aria-pressed", false);

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -61,6 +61,21 @@ Scenario: Filtering does not clear selected measures
   And the user types "" into the measure filter box
   Then all measures should still be selected
 
+Scenario: Clear all button functions when bundle is changed
+  When the user navigates to the create product page
+  And the user changes the selected bundle
+  And the user changes the selected bundle
+  And the user chooses the custom measure option
+  And the user manually selects all measures
+  And the user clicks the Clear all button
+  Then there should be 0 measures selected
+
+Scenario: Filtering properly hides irrelevant measures and tabs when one bundle is installed
+  When the user has one bundle and navigates to the create product page
+  And the user chooses the custom measure option
+  And the user types "A fake measure" into the measure filter box
+  Then "A fake measure" is active on the screen
+
 Scenario: Filtering properly hides irrelevant measures and tabs
   When the user navigates to the create product page
   And the user chooses the custom measure option

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -57,6 +57,11 @@ When(/^a user creates a product with (.*) certifications and visits that product
   @product = Product.find_by(name: product_name)
 end
 
+When(/^the user has one bundle and navigates to the create product page$/) do
+  Bundle.where(active: nil).destroy_all
+  steps %( When the user navigates to the create product page for vendor #{@vendor.name} )
+end
+
 When(/^the user creates a product using appropriate information$/) do
   @product = build_product
   steps %( When the user creates a product with name #{@product.name} for vendor #{@vendor.name} )
@@ -420,7 +425,11 @@ end
 # V V V Measure Selection V V V
 
 Then(/^the group of measures should no longer be selected$/) do
-  page.has_unchecked_field?('input.measure-group-all')
+  assert_equal false, page.find('input.measure-group-all').checked?
+end
+
+Then(/^there should be (\d+) measures selected$/) do |selected_measure_count|
+  assert_equal selected_measure_count.to_i, page.all('.measure-checkbox:checked', visible: false).count
 end
 
 Then(/^all measures should still be selected$/) do

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -350,7 +350,7 @@ end
 
 # one indexed. ex.) mesure_test_number == 1 is the first measure test created
 def nth_measure_test(measure_test_number)
-  @product.product_tests.measure_tests.sort { |x, y| x.created_at <=> y.created_at }[measure_test_number.to_i - 1]
+  @product.product_tests.measure_tests.sort_by(&:created_at)[measure_test_number.to_i - 1]
 end
 
 def td_div_id_for_cat1_task_for_filtering_test(filtering_test_number)
@@ -362,14 +362,14 @@ def td_div_id_for_cat3_task_for_filtering_test(filtering_test_number)
 end
 
 def nth_filtering_test(filtering_test_number)
-  @product.product_tests.filtering_tests.sort { |x, y| x.created_at <=> y.created_at }[filtering_test_number.to_i - 1]
+  @product.product_tests.filtering_tests.sort_by(&:created_at)[filtering_test_number.to_i - 1]
 end
 
 def attach_zip_to_multi_upload(html_id)
   show_hidden_upload_field(html_id)
 
   # attach zip file to multi-upload field
-  zip_path = File.join(Rails.root, 'test/fixtures/product_tests/ep_qrda_test_good.zip')
+  zip_path = Rails.root.join 'test/fixtures/product_tests/ep_qrda_test_good.zip'
   page.find(html_id, visible: false).attach_file('test_execution[results]', zip_path, visible: false)
 end
 
@@ -377,7 +377,7 @@ def attach_xml_to_multi_upload(html_id)
   show_hidden_upload_field(html_id)
 
   # attach zip file to multi-upload field
-  xml_path = File.join(Rails.root, 'test/fixtures/product_tests/cms111v3_catiii.xml')
+  xml_path = Rails.root.join 'test/fixtures/product_tests/cms111v3_catiii.xml'
   page.find(html_id, visible: false).attach_file('test_execution[results]', xml_path, visible: false)
 end
 


### PR DESCRIPTION
The Clear all button binding was getting lost every time a user changed the selected bundle. This fixes it and also creates tests to make sure the filtering is working properly and also make sure filtering is working properly with 1 bundle.