### PR TITLE
Added inflections for the remaining two irregular inflections in Record::Sections

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -16,5 +16,5 @@
 # end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.uncountable %w( medical_equipment )
+  inflect.uncountable %w( medical_equipment family_history social_history )
 end


### PR DESCRIPTION
Cypress's Clinical Randomizer relies on `ActiveSupport::Inflector` to pluralize things so we can query the DB for them. Family History (and Social History) pluralize incorrectly for our purposes as `family_histories`, when they're actually stored in Cypress's DB as their singular form. This PR makes it so the `ActiveSupport::Inflector` knows we want to have the plurals for these section names be the same as their singular names.