### PR TITLE
Cache two different versions of the patient index page

### DIFF
--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -65,7 +65,7 @@
 
 <% end %>
 
-<% cache [@records, @measure] do %>
+<% cache [@records, @measure, hide_patient_calculation?] do %>
   <div class="row">
     <div id="records_list" class="col-sm-12">
       <%= render partial: 'records_list', locals: { records: @records } %>


### PR DESCRIPTION
 based on whether the user should see patient calculations or not