### PR TITLE
Fix time displayed in Most Recent executions dropdown on tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,7 +153,7 @@ GEM
       carrierwave (>= 0.8.0, < 0.12.0)
       mongoid (>= 3.0, < 6.0)
       mongoid-grid_fs (>= 1.3, < 3.0)
-    childprocess (0.5.9)
+    childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
     coderay (1.1.1)
@@ -233,7 +233,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.8.6)
     ice_nine (0.11.2)
-    iniparse (1.4.2)
+    iniparse (1.4.4)
     jasny-bootstrap-rails (3.1.3)
       railties (>= 3.0)
     jbuilder (2.5.0)
@@ -311,8 +311,8 @@ GEM
     origin (2.3.1)
     orm_adapter (0.5.0)
     os (0.9.6)
-    overcommit (0.34.2)
-      childprocess (~> 0.5.8)
+    overcommit (0.40.0)
+      childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
     parallel (1.9.0)
     parallel_tests (2.6.0)
@@ -537,4 +537,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.15.2
+   1.15.3

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -4,7 +4,7 @@ module TestExecutionsResultsHelper
   def get_select_history_message(execution, is_most_recent)
     msg = ''
     msg << 'Most Recent - ' if is_most_recent
-    msg << execution.created_at.in_time_zone.strftime('%B %e, %Y %l:%M%P')
+    msg << local_time(execution.created_at)
     case execution.status_with_sibling
     when 'passing' then msg << ' (passing)'
     when 'incomplete' then msg << ' (in progress)'

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -68,7 +68,7 @@
         <div class = 'pull-right'>
           <select id="select_execution" aria-label="View test execution">
             <% @task.test_executions.sort_by { |obj| obj.created_at }.reverse.each_with_index do |execution, i| %>
-              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i == 0) %></option>
+              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i == 0).html_safe %></option>
             <% end %>
           </select>
           <button id="view_execution" class="btn btn-xs btn-<%= execution_status_class(@test_execution) %>">Refresh View</button>

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
+include LocalTimeHelper
 
-class TestExecutionHelper < ActiveSupport::TestCase
+class TestExecutionHelperTest < ActionView::TestCase
   include TestExecutionsHelper
   include ActiveJob::TestHelper
 


### PR DESCRIPTION
Currently everywhere else uses the local_time gem except for this dropdown, adding to the dropdown as well to standardize.