### PR TITLE
Fix a bug related to clinical randomization by 'type'

### DIFF
--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -65,21 +65,22 @@ module Cypress
       # Find a split point so each cloned record gets at least one entry type (hence, at least one entry)
       split_point = random.rand(1..(entry_types.size - 1))
 
-      record_1 = set_record_sections_for_type(record_1, record, entry_types, split_point)
-      record_2 = set_record_sections_for_type(record_2, record, entry_types, split_point)
+      record_1 = set_record_sections_for_type(record_1, record, entry_types, 0, split_point)
+      record_2 = set_record_sections_for_type(record_2, record, entry_types, split_point, entry_types.size)
 
       [record_1, record_2]
     end
 
-    def self.set_record_sections_for_type(new_record, old_record, entry_types, split_point)
+    def self.set_record_sections_for_type(new_record, old_record, entry_types, start_point, end_point)
       Record::Sections.each do |section|
         new_record.send section.to_s + '=', [] unless section == :insurance_providers
       end
 
-      entry_types.take(split_point).each do |elem|
+      entry_types[start_point...end_point].each do |elem|
         type = get_entry_type(elem)
         new_record.send(type).push old_record.send(type)
       end
+
       new_record
     end
 

--- a/test/unit/lib/clinical_randomizer_test.rb
+++ b/test/unit/lib/clinical_randomizer_test.rb
@@ -53,6 +53,10 @@ class ClinicalRandomizerTest < ActiveSupport::TestCase
 
     assert record_1.entries.count > 0, 'Record_1 should have at least 1 entry'
     assert record_2.entries.count > 0, 'Record_2 should have at least 1 entry'
+    # This gets the unique set of types for each record's entries, then gets the intersection of them.
+    # Ideally the arrays would be completely distinct, e.g. the intersection would be an empty set.
+    assert_equal record_1.entries.collect(&:_type).uniq & record_2.entries.collect(&:_type).uniq, [], 'Records contain elements of the same type'
+    assert_equal @record_2.entries.collect(&:_type).uniq.sort, (record_1.entries.collect(&:_type).uniq + record_2.entries.collect(&:_type).uniq).sort, 'Records should contain all the types in the parent record'
 
     record_1, record_2 = Cypress::ClinicalRandomizer.split_by_type(@record, Random.new)
     assert_equal record_1.entries.length, 1, 'First split record should have 1 entry if it falls back to split_by_date'


### PR DESCRIPTION
Bug was that both `Record`s would get assigned the same type, and wouldn't get some types assigned. 
Also added new tests to ensure that both `Record`s get different types