### PR TITLE
Placeholder schematron updates until CMS issues a new one.

### DIFF
--- a/resources/schematron/2017.0.0/EH/EH_CAT_I.sch
+++ b/resources/schematron/2017.0.0/EH/EH_CAT_I.sch
@@ -2913,7 +2913,7 @@ Mon Jul 10 08:11:34 MDT 2017
       <sch:assert id="a-CMS_0010-error" test="@code='en'">This languageCode SHALL contain exactly one [1..1] @code="en" (CONF:CMS_0010).</sch:assert>
     </sch:rule>
     <sch:rule id="QRDA_Category_I_Report_CMS-recordTarget-patientRole-errors" context="cda:ClinicalDocument[cda:templateId[@root='2.16.840.1.113883.10.20.24.1.3'][@extension='2017-07-01']]/cda:recordTarget/cda:patientRole">
-      <sch:assert id="a-CMS_0009-error" test="count(cda:id[@root!='2.16.840.1.113883.4.572'][@extension] or cda:id[@root!='2.16.840.1.113883.4.927'][@extension])=1">This patientRole SHALL contain exactly one [1..1] id (CONF:CMS_0009) such that it SHALL contain exactly one [1..1] @root (CONF:CMS_0053). SHALL contain exactly one [1..1] @extension (CONF:CMS_0103).</sch:assert>
+      <sch:assert id="a-CMS_0009-error" test="count(cda:id[@root!='2.16.840.1.113883.4.572' and @root!='2.16.840.1.113883.4.927'][@extension])=1">This patientRole SHALL contain exactly one [1..1] id (CONF:CMS_0009) such that it SHALL contain exactly one [1..1] @root (CONF:CMS_0053). SHALL contain exactly one [1..1] @extension (CONF:CMS_0103).</sch:assert>
     </sch:rule>
     <sch:rule id="QRDA_Category_I_Report_CMS-recordTarget-patientRole-patient-errors" context="cda:ClinicalDocument[cda:templateId[@root='2.16.840.1.113883.10.20.24.1.3'][@extension='2017-07-01']]/cda:recordTarget/cda:patientRole/cda:patient">
       <sch:assert id="a-1198-5284_C01-error" test="count(cda:name)=1">This patient SHALL contain exactly one [1..1] US Realm Person Name (PN.US.FIELDED) (identifier: urn:oid:2.16.840.1.113883.10.20.22.5.1.1) (CONF:1198-5284_C01).</sch:assert>


### PR DESCRIPTION
This line in the schematron is breaking the udpated libxslt library

count(cda:id[@root!='2.16.840.1.113883.4.572'][@extension] or cda:id[@root!='2.16.840.1.113883.4.927'][@extension])=1"

It should be updated to something like

count(cda:id[@root!='2.16.840.1.113883.4.572' and @root!='2.16.840.1.113883.4.927'][@extension])=1

there should be a root with an extension that does not have a root of 2.16.840.1.113883.4.572 or 2.16.840.1.113883.4.927. 

For example, this should pass
```
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.572" />
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.927" />
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="1.3.6.1.4.1.115" />
```

This should pass 
```
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.927" />
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="1.3.6.1.4.1.115" />
```

This should pass 
```
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.572" />
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="1.3.6.1.4.1.115" />
```

This should not pass 
```
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.572" />
<id extension="4ec45d6b-4b3b-4bd6-9161-e72525578a81_4" root="2.16.840.1.113883.4.927" />
```

This should also be updated in the CMS published version.  However, if that isn't ready by Thursday, use this PR.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] NA The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code