### PR TITLE
If a filtering test for a product already has an archive, use it and …

### DIFF
--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -54,6 +54,7 @@ module FilteringTestsHelper
     return unless filter_tests
     test = filter_tests.pop
     test.generate_records
+    test.archive_records
     test.save
     test.queued
     ProductTestSetupJob.perform_later(test)

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -15,8 +15,12 @@ class FilteringTest < ProductTest
   def archive_records
     # If a filtering test for this product already has an archive, use it and copy the augmented records.
     # Otherwise, create them.
-    if !product.product_tests.filtering_tests.where(:patient_archive.ne => nil).empty?
-      first_filter_test = product.product_tests.filtering_tests.find_by(:patient_archive.ne => nil)
+    first_filter_test = begin
+                          product.product_tests.filtering_tests.find_by(:patient_archive.ne => nil)
+                        rescue
+                          nil
+                        end
+    if first_filter_test
       self.augmented_records = first_filter_test.augmented_records
       self.patient_archive = first_filter_test.patient_archive
     else

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -12,6 +12,18 @@ class FilteringTest < ProductTest
     save
   end
 
+  def archive_records
+    # If a filtering test for this product already has an archive, use it and copy the augmented records.
+    # Otherwise, create them.
+    if !product.product_tests.filtering_tests.where(:patient_archive.ne => nil).empty?
+      first_filter_test = product.product_tests.filtering_tests.find_by(:patient_archive.ne => nil)
+      self.augmented_records = first_filter_test.augmented_records
+      self.patient_archive = first_filter_test.patient_archive
+    else
+      super
+    end
+  end
+
   def cat1_task
     cat1_tasks = tasks.select { |task| task.is_a? Cat1FilterTask }
     if cat1_tasks.empty?

--- a/test/models/filtering_test_test.rb
+++ b/test/models/filtering_test_test.rb
@@ -30,6 +30,34 @@ class FilteringTestTest < ActiveJob::TestCase
     options_assertions(ft)
   end
 
+  def test_consistency_of_augmented_records_between_filter_tests
+    criteria = %w(races ethnicities genders payers providers problems age)
+    options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
+    ft = FilteringTest.new(name: 'test_for_measure_1a', product: @product, incl_addr: true, options: options,
+                           measure_ids: ['8A4D92B2-397A-48D2-0139-C648B33D5582'])
+    augmented_record = { 'medical_record_number' => '1507738392_3',
+                         'first' => %w(Joseph Joseph), 'last' => %w(Freeman F), 'gender' => %w(M F) }
+    ft.save!
+    ft.generate_records
+    ft.reload
+    ft.pick_filter_criteria
+    ft.augmented_records = [augmented_record]
+    ft.archive_records
+    ft2 = created_second_ft
+    assert_equal ft.augmented_records, ft2.augmented_records
+  end
+
+  def created_second_ft
+    criteria = %w(races ethnicities genders payers providers problems age)
+    options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
+    ft2 = FilteringTest.new(name: 'test_for_measure_1b', product: @product, incl_addr: true, options: options,
+                            measure_ids: ['8A4D92B2-397A-48D2-0139-C648B33D5582'])
+    ft2.save!
+    ft2.reload
+    ft2.archive_records
+    ft2
+  end
+
   def test_problem_filter
     criteria = %w(problems)
     options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }


### PR DESCRIPTION
…copy the augmented records.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1226
- [x] Internal ticket links to this PR https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1226
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code