### PR TITLE
Master Patient Ids are not necessarily patients

### DIFF
--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -43,17 +43,13 @@ class FilteringTest < ProductTest
     return unless options && options['filters']
     # select a random patient
     prng = Random.new(rand_seed.to_i)
-    random_mrn = ''
-    until ApplicationController.helpers.mpl_id?(random_mrn)
-      random_mrn = master_patient_ids.sample(random: prng)
-    end
-    rand_record = records.find_by(original_medical_record_number: random_mrn)
+    mpl_ids = master_patient_ids
+    rand_record = records.select { |r| r.original_medical_record_number.in?(mpl_ids) }.sample
     # iterate over the filters and assign random codes
     params = { measures: measures, records: records, incl_addr: incl_addr, effective_date: created_at, prng: prng }
     options['filters'].each do |k, _v|
       options['filters'][k] = Cypress::CriteriaPicker.send(k, rand_record, params)
     end
-
     save!
   end
 


### PR DESCRIPTION
As a result, C4 Filter tests were having a lot of internal errors

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] NA Internal ticket for this PR:
- [x] NA Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Louis Ades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code