### PR TITLE
update default versions in update script

### DIFF
--- a/contrib/upgrade_cypress_32.sh
+++ b/contrib/upgrade_cypress_32.sh
@@ -6,8 +6,8 @@ if [[ $EUID -ne 0 ]]; then
    exit 1
 fi
 
-CYPRESS_VERSION='v3.2.1'
-CVU_VERSION='v3.2.1'
+CYPRESS_VERSION='v3.2.2'
+CVU_VERSION='v3.2.2'
 
 if [[ ! -z "$1" ]]; then
     CYPRESS_VERSION="$1"


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] NA Internal ticket for this PR:
- [x] NA Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] NA Tests are included and test edge cases
- [x] Tests have been run locally and pass (performed an update on a 3.2.1 VM)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] N/A The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code