### PR TITLE
Bump VM RAM to 8GB and bump VM disk size to 100GB

### DIFF
--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -135,11 +135,11 @@
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "4096",
+        "memsize": "8192",
         "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
       },
-      "disk_size": "20000"
+      "disk_size": "100000"
     },
     {
       "name": "cypress.cvu.vmware",
@@ -193,11 +193,11 @@
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "4096",
+        "memsize": "8192",
         "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
       },
-      "disk_size": "20000"
+      "disk_size": "100000"
     },
     {
       "name": "cvu.vmware",
@@ -251,11 +251,11 @@
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "4096",
+        "memsize": "8192",
         "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
       },
-      "disk_size": "20000"
+      "disk_size": "100000"
     }
   ],
 


### PR DESCRIPTION
This PR is to help work around users running out of RAM and disk space.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-60
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases (N/A)
- [x] Tests have been run locally and pass (N/A)

**Reviewer 1:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases (N/A)
- [x] You have tried to break the code