### PR TITLE
Fix admin auto approve option to apply right away instead of just on restart

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,7 +48,7 @@ class User
   index(invitation_token: 1)
   index(invitation_by_id: 1)
 
-  field :approved, type: Boolean, default: Settings.current.auto_approve || false
+  field :approved, type: Boolean, default: proc { Settings.current.auto_approve || false }
 
   validates :terms_and_conditions, :acceptance => true, :on => :create, :allow_nil => false
 


### PR DESCRIPTION
There is currently an issue where the auto approve option is not wrapped in a proc and therefore is only evaluated on server startup. By wrapping it in a proc it will now be evaluated every time a user is created. This means if the admin turns off the setting it will apply right away instead of after a server restart.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-120
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code