### PR TITLE
An ATL can view all expected results for a C4 Tests

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -1,5 +1,5 @@
 class RecordsController < ApplicationController
-  before_action :set_record_source, only: [:index, :show, :by_measure]
+  before_action :set_record_source, only: [:index, :show, :by_measure, :by_filter_task]
 
   respond_to :js, only: [:index]
 
@@ -41,6 +41,10 @@ class RecordsController < ApplicationController
       @measure = @source.measures.find_by(hqmf_id: params[:measure_id], sub_id: params[:sub_id])
       expires_in 1.week, public: true
     end
+  end
+
+  def by_filter_task
+    @records = @product_test.filtered_records
   end
 
   def download_mpl

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -43,7 +43,6 @@ module RecordsHelper
 
   def records_by_measure(records, measure)
     # Returns array of records that have at least one calculation result for the given measure id
-
     records.select { |r| !r.calculation_results.where('value.measure_id' => measure.hqmf_id).where('value.sub_id' => measure.sub_id).empty? }
   end
 
@@ -71,7 +70,8 @@ module RecordsHelper
   end
 
   def coverage_for_measure(measure)
-    QueryCache.where(measure_id: measure.measure_id, sub_id: measure.sub_id, bundle_id: measure.bundle_id, test_id: nil).first['bonnie_coverage']
+    query_cache_first = QueryCache.where(measure_id: measure.measure_id, sub_id: measure.sub_id, bundle_id: measure.bundle_id, test_id: nil).first
+    query_cache_first ? query_cache_first['bonnie_coverage'] : nil
   end
 
   def hide_patient_calculation?

--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -25,6 +25,17 @@ module RecordsHelper
     record.first + ' ' + record.last if record
   end
 
+  def pop_sum(records, measure, population)
+    records.reduce(0) do |sum, r|
+      result_value = get_result_value(r.calculation_results, measure, population)
+      if result_value
+        sum + result_value
+      else
+        sum
+      end
+    end
+  end
+
   def get_result_value(results, measure, population)
     result_value = results.where('value.measure_id' => measure.hqmf_id).where('value.sub_id' => measure.sub_id)
     result_value.first.value[population].to_i if result_value.first

--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -20,6 +20,23 @@
       <% end %>
     </tr>
   </thead>
+  <% if @measure && !(@product_test && hide_patient_calculation?) %>
+  <tfoot style="border-top: 2px solid #ddd;">
+      <!-- will show aggregate record populations -->
+      <tr>
+        <th scope="row">Total</th>
+        <td></td>
+        <td></td>
+        <td></td>
+        <!-- will show calculation results for product test records -->
+          <% @measure.population_ids.keys().each do |population| %>
+            <td class="text-center">
+              <%= render partial: 'calculation_result_icon', locals: { result: pop_sum(@records, @measure, population), episode_of_care: @measure.episode_of_care } %>
+            </td>
+          <% end %>
+      </tr>
+  </tfoot>
+  <% end %>
   <tbody>
     <!-- Only show records that are part of the measures IPP-->
     <% if measure && !product_test %>

--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -25,7 +25,9 @@
       <!-- will show aggregate record populations -->
       <tr>
         <th scope="row">Total</th>
-        <td></td>
+        <% if product_test && (current_user.user_role?('atl') || current_user.user_role?('admin'))%>
+          <td></td>
+        <%end%>
         <td></td>
         <td></td>
         <!-- will show calculation results for product test records -->

--- a/app/views/records/by_filter_task.html.erb
+++ b/app/views/records/by_filter_task.html.erb
@@ -20,43 +20,7 @@
 <% cache [@records, @measure, hide_patient_calculation?] do %>
   <div class="row">
     <div id="records_list" class="col-sm-12">
-      <%= render partial: 'records_list', locals: { records: @records } %>
+      <%= render 'records_list', :records => @records, :measure => @measure, :product_test => @product_test, :bundle => @bundle, :task => @task %>
     </div>
   </div>
 <% end #cache records %>
-
-<script type="text/javascript">
-  // initialize jQueryUI Autocomplete for searching measures
-  $('#search_measures').autocomplete({
-    delay: 500,
-    source: <%= @measure_dropdown %>, // autocomplete suggestions
-    select: function(event, data) {  // fired on item select
-      // gets records by measure via AJAX and rerender the records list.
-      // data.item.value provides the URL for the selected measure
-      $.get(data.item.value);
-      // autocomplete's default action is to populate the input with the selected value
-      // prevent the user from seeing an ugly URL in their search box here
-      event.preventDefault();
-    },
-    focus: function(event, data) { event.preventDefault(); } // fired on item focus
-  });
-
-  // add and remove some classes from the generated autocomplete widget
-  $('#search_measures').data('ui-autocomplete')._renderItem = function(ul, item) {
-    return $('<li class="list-group-item">').append(item.label).appendTo(ul);
-  }
-  $('#search_measures').data('ui-autocomplete')._renderMenu = function(ul, items) {
-    var that = this;
-    $.each(items, function(index, item) {
-      that._renderItemData(ul, item);
-    });
-    $(ul).removeClass('ui-widget ui-widget-content').addClass('list-group');
-  }
-
-  // rerender the records list to show records from all measures if no value searched
-  $('#search_measures').on('blur', function() {
-    if (!$(this).val()) {
-      $("#records_list").html("<%= escape_javascript(render partial: 'records_list', locals: { records: @records } ) %>");
-    }
-  })
-</script>

--- a/app/views/records/by_filter_task.html.erb
+++ b/app/views/records/by_filter_task.html.erb
@@ -1,0 +1,62 @@
+<h1>Expected Result Patient List</h1>
+<div class="pull-right button-row">
+  <% if @measure && @measure.sub_id %>
+    <div class="btn-group">
+      <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">Sub measures <span class="caret"></span>
+      </button>
+      <ul class="dropdown-menu">
+        <% submeasures = HealthDataStandards::CQM::Measure.where(hqmf_id: @measure.hqmf_id).sort_by(&:sub_id) %>
+        <% submeasures.each do |submeasure| %>
+          <li><%= link_to "#{submeasure.display_name} - #{submeasure.subtitle}", product_test_task_by_filter_task_path(@task.product_test, @task, sub_id: submeasure.sub_id),  method: :get %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= button_to good_results_task_path(@task), :method => :get, :class => "btn btn-default" do %>
+    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download HTML Patients
+  <% end %>
+</div>
+
+<% cache [@records, @measure, hide_patient_calculation?] do %>
+  <div class="row">
+    <div id="records_list" class="col-sm-12">
+      <%= render partial: 'records_list', locals: { records: @records } %>
+    </div>
+  </div>
+<% end #cache records %>
+
+<script type="text/javascript">
+  // initialize jQueryUI Autocomplete for searching measures
+  $('#search_measures').autocomplete({
+    delay: 500,
+    source: <%= @measure_dropdown %>, // autocomplete suggestions
+    select: function(event, data) {  // fired on item select
+      // gets records by measure via AJAX and rerender the records list.
+      // data.item.value provides the URL for the selected measure
+      $.get(data.item.value);
+      // autocomplete's default action is to populate the input with the selected value
+      // prevent the user from seeing an ugly URL in their search box here
+      event.preventDefault();
+    },
+    focus: function(event, data) { event.preventDefault(); } // fired on item focus
+  });
+
+  // add and remove some classes from the generated autocomplete widget
+  $('#search_measures').data('ui-autocomplete')._renderItem = function(ul, item) {
+    return $('<li class="list-group-item">').append(item.label).appendTo(ul);
+  }
+  $('#search_measures').data('ui-autocomplete')._renderMenu = function(ul, items) {
+    var that = this;
+    $.each(items, function(index, item) {
+      that._renderItemData(ul, item);
+    });
+    $(ul).removeClass('ui-widget ui-widget-content').addClass('list-group');
+  }
+
+  // rerender the records list to show records from all measures if no value searched
+  $('#search_measures').on('blur', function() {
+    if (!$(this).val()) {
+      $("#records_list").html("<%= escape_javascript(render partial: 'records_list', locals: { records: @records } ) %>");
+    }
+  })
+</script>

--- a/app/views/test_executions/_expected_results.html.erb
+++ b/app/views/test_executions/_expected_results.html.erb
@@ -1,13 +1,4 @@
-<% if task.is_a? Cat1FilterTask %>
-  <h1>Expected Patient Records (<%= task.records.count %>)</h1>
-  <p>
-    <% task.records.all.each_with_index do |r, index| %>
-      <% link_text = index < task.records.all.size - 1 ? full_name(r) + ',' : full_name(r) %>
-      <%= link_to link_text, record_path(r, task_id: task._id) %>
-    <% end %>
-  </p>
-
-<% elsif task.product_test_expected_results %>
+<% if task.product_test_expected_results %>
 <h1>Expected Aggregate Results</h1>
 <table class="table table-condensed table-hover">
   <thead>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -31,7 +31,7 @@
     <%= link_to 'View Patients', { controller: 'records', task_id: task.id}, method: :get %>
     <% if (task.is_a?(Cat1FilterTask) || task.is_a?(Cat3FilterTask)) && should_display_expected_results(task) %>
       <br/>
-      <%= link_to 'View Expected Result Patients', product_test_task_by_filter_task_path(task.product_test, task),  method: :get %>
+      <%= link_to 'View Expected Result', product_test_task_by_filter_task_path(task.product_test, task),  method: :get %>
     <% end %>
     <% if Settings.current.enable_debug_features %>
       <br/>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -26,11 +26,16 @@
   <% end %>
 
   <br/>
+
   <% unless task.is_a? C1ChecklistTask %>
-  <%= link_to 'View Patients', { controller: 'records', task_id: task.id}, method: :get %>
-  <% if Settings.current.enable_debug_features %>
-  <br/>
-  <%= link_to 'Get Known Good Result', good_results_task_path(task), data: { no_turbolink: true } %>
-  <% end %>
+    <%= link_to 'View Patients', { controller: 'records', task_id: task.id}, method: :get %>
+    <% if (task.is_a?(Cat1FilterTask) || task.is_a?(Cat3FilterTask)) && should_display_expected_results(task) %>
+      <br/>
+      <%= link_to 'View Expected Result Patients', product_test_task_by_filter_task_path(task.product_test, task),  method: :get %>
+    <% end %>
+    <% if Settings.current.enable_debug_features %>
+      <br/>
+      <%= link_to 'Get Known Good Result', good_results_task_path(task), data: { no_turbolink: true } %>
+    <% end %>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,13 @@ Rails.application.routes.draw do
       get :html_patients
     end
     resources :tasks, only: [:index, :show]
-    resources :records, only: [:index, :show]
+    resources :records, only: [:index] do
+      collection do
+        resources :tasks, controller: :records, only: [:by_filter_task] do
+          get :by_filter_task
+        end
+      end
+    end
   end
 
   resources :tasks, only: [:show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
     resources :tasks, only: [:index, :show]
     resources :records, only: [:index] do
       collection do
-        resources :tasks, controller: :records, only: [:by_filter_task] do
+        resources :tasks, :controller => :records, :only => [:by_filter_task] do
           get :by_filter_task
         end
       end

--- a/features/filtering_tests/show.feature
+++ b/features/filtering_tests/show.feature
@@ -30,3 +30,15 @@ Scenario: Successful Upload CAT 3 XML File to Filter Task
   When the user views the CAT 3 test for the first filter task
   And the user uploads a CAT 3 XML file
   Then the user should see test results
+
+Scenario: Successful hide View Expected Result for Filter Task for non admin
+  When the user is not an admin
+  And the user has viewed the CAT 1 test for the first filter task
+  Then the user should not see the View Expected Result option
+
+Scenario: Successful View Expected Result for Filtering Test for admin
+  When the user is changed to an admin
+  And the user has viewed the CAT 1 test for the first filter task
+  And the user views the Expected Result Patient List page
+  Then the user should see a list of expected patients
+  Then the user should see a Total row

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -21,6 +21,7 @@ And(/^the user has created a vendor with a product selecting C4 testing$/) do
   @f_test_1.generate_records
   @f_test_1.reload
   @f_test_1.pick_filter_criteria
+  @f_test_1.calculate
 
   criteria = %w(genders age)
   options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
@@ -33,6 +34,8 @@ And(/^the user has created a vendor with a product selecting C4 testing$/) do
 
   checklist_test = @product.product_tests.create!({ name: 'my checklist test', measure_ids: measure_ids }, ChecklistTest)
   checklist_test.tasks.create!({}, C1ChecklistTask)
+
+  wait_for_all_delayed_jobs_to_run
 end
 
 And(/^the user visits the product show page with the filter test tab selected$/) do
@@ -49,6 +52,10 @@ end
 #   W H E N   #
 # # # # # # # #
 
+When(/^the user is changed to an admin$/) do
+  @user.add_role :admin
+end
+
 When(/^the user views the CAT 1 test for the first filter task$/) do
   find(:xpath, "//a[@href='/tasks/#{@f_test_1.cat1_task.id}/test_executions/new']").click
 end
@@ -61,6 +68,17 @@ end
 
 And(/^the user views the CAT 3 test from the CAT 1 page$/) do
   find(:xpath, "//a[@href='/tasks/#{@f_test_1.cat3_task.id}/test_executions/new']").trigger('click')
+end
+
+And(/^the user has viewed the CAT 1 test for the first filter task$/) do
+  wait_for_all_delayed_jobs_to_run
+  steps %(
+    When the user views the CAT 1 test for the first filter task
+  )
+end
+
+And(/^the user views the Expected Result Patient List page$/) do
+  find('a', text: 'View Expected Result').trigger('click')
 end
 
 # 'And the user uploads a CAT 1 zip file' included in step_definitions/measure_test.rb
@@ -86,6 +104,23 @@ Then(/^the user should not see provider information$/) do
   page.assert_no_text 'Provider NPI'
   page.assert_no_text 'Provider TIN'
 end
+
+Then(/^the user should not see the View Expected Result option$/) do
+  sleep(0.5)
+  assert !page.has_content?('View Expected Result')
+end
+
+Then(/^the user should see a list of expected patients$/) do
+  page.assert_text 'Expected Result Patient List'
+  assert page.has_selector?('table tbody tr', count: @f_test_1.filtered_records.length), 'different count'
+end
+
+Then(/^the user should see a Total row$/) do
+  page.assert_text 'Expected Result Patient List'
+  assert page.has_selector?('table tfoot tr', count: 1), 'different count'
+end
+
+# 'Then the user should see a list of patients' included in step_definitions/record.rb
 
 # 'Then the user should be able to download a CAT 1 zip file' included in step_definitions/measure_test.rb
 


### PR DESCRIPTION
A new link on a product test, "View Expected Result Patients", allows an ATL to view expected results for C4 Tests with the same depth as the "View Patients" link.

Totals for populations also now appear at the footer of a table for a measure and test.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-110
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Robert Clark
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Lauren DiCristofaro
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code