### PR TITLE
Use an older SHA algorithm to avoid problems with Vsphere 6.5 VM import

### DIFF
--- a/contrib/scripts/vmx_to_ova.sh
+++ b/contrib/scripts/vmx_to_ova.sh
@@ -22,7 +22,7 @@ fi
 
 for vmx in "output-${PACKER_BUILD_NAME}"/*.vmx; do
   name=$(basename "${vmx}" .vmx).ova
-  ovftool --compress=9 -o "${vmx}" "output-${PACKER_BUILD_NAME}/${name}"
+  ovftool --shaAlgorithm=sha1 --compress=9 -o "${vmx}" "output-${PACKER_BUILD_NAME}/${name}"
 done
 
 # Cleanup all files that are not the ova


### PR DESCRIPTION
There is a bug with ovftool and vmware 6.5. Vmware Ovftool builds images with SHA256 checksums by default even though Vmware Vsphere doesn't support SHA256 checksums. This means in order to support Vsphere 6.5 we need to pass an argument to ovftool in order to tell it to use SHA1 checksums.

More information: https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1279

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-124
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases (N/A: We do not have automated tests for verifying that VM import works correctly)
- [x] Tests have been run locally and pass (N/A)

**Reviewer 1:**

Name: Louis Ades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases

**Reviewer 2:**

Name: Michael O'Keefe
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases (N/A)
- [x] You have tried to break the code 