### PR TITLE
record sample now populates input with code value

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -56,7 +56,9 @@ rules:
   max-len: 'off'
   max-nested-callbacks: error
   max-params: error
-  max-statements: error
+  max-statements: 
+    - error
+    - 20
   max-statements-per-line: 'off'
   new-parens: error
   newline-after-var: 'off'

--- a/app/assets/javascripts/checklist_measures.js
+++ b/app/assets/javascripts/checklist_measures.js
@@ -51,7 +51,7 @@ ready_run_once = function() {
     if (attribute_value == true){
       input_box_type ="attribute_code";
       document.getElementById("product_test_checked_criteria_attributes_" + index_value + "_" + input_box_type).value = code_string;
-      $('#lookupModal-negation' + index_value).modal('hide');
+      $('#lookupModal-negation' + index_value).modal('hide') && $('#lookupModal-fieldvalues' + index_value).modal('hide') && $('#lookupModal-result' + index_value).modal('hide');
     }
   });
 };

--- a/app/assets/javascripts/checklist_measures.js
+++ b/app/assets/javascripts/checklist_measures.js
@@ -35,6 +35,25 @@ ready_run_once = function() {
     $('.hide-me').hide();
     $('.show-me').show();
   });
+
+  $(document).on('click', 'button.modal-btn', function(event) {
+    event.preventDefault();
+    var currentTarget = event.currentTarget;
+    var index_value = $(currentTarget).data("index-value");
+    var attribute_value = $(currentTarget).data("attribute-value");
+    var code_string = $(currentTarget).data("code-string");
+    var input_box_type
+    if (attribute_value == false){
+      input_box_type = "code";
+      document.getElementById("product_test_checked_criteria_attributes_" + index_value + "_" + input_box_type).value = code_string;
+      $('#lookupModal' + index_value).modal('hide');
+    }
+    if (attribute_value == true){
+      input_box_type ="attribute_code";
+      document.getElementById("product_test_checked_criteria_attributes_" + index_value + "_" + input_box_type).value = code_string;
+      $('#lookupModal-negation' + index_value).modal('hide');
+    }
+  });
 };
 
 $(document).ready(ready_run_once);

--- a/app/assets/stylesheets/cypress/_buttons.scss
+++ b/app/assets/stylesheets/cypress/_buttons.scss
@@ -1,3 +1,5 @@
+$background-color: rgba(#000, .00);
+
 @mixin darker-hover($border-color, $name) {
   $darker-border-color: darken($border-color, 15%);
   border-color: darken($border-color, 5%);
@@ -68,4 +70,9 @@
 .download-btn {
   padding: 6px 12px;
   display: inline-block;
+}
+
+.modal-btn {
+  box-shadow: none;
+  border-color: $background-color;
 }

--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -94,6 +94,7 @@ module ChecklistTestsHelper
   def lookup_codevalues(oid, bundle)
     vs = HealthDataStandards::SVS::ValueSet.where(oid: oid, bundle_id: bundle)
     return [] unless vs && vs.first
-    vs.first.concepts.map { |con| "#{con.display_name}: #{con.code}" }
+    # vs.first.concepts.map { |con| con.display_name + ":" + con.code }
+    vs.first.concepts.map { |con| [con.display_name, con.code] }
   end
 end

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -11,7 +11,7 @@
 <% if !hide_patient_calculation? %>
   <div id='modify_record'><button class='btn btn-default' type='button' id="modifyrecord">Edit Test</button></div>
 <% end %>
-<% measures.sort_by(&:cms_int).each.with_index do |measure, measure_index| %>
+<% @measures.sort_by(&:cms_int).each do |measure, measure_index| %>
   <div class = 'panel-group' id = '<%= measure.cms_id %>' disabled = true>
     <div class = 'panel panel-default'>
       <div class = 'panel-heading'>
@@ -69,8 +69,7 @@
                             <% if criteria_field.object.negated_valueset %>
                                <%= 'Negate entire Valueset' %>
                             <% else %>
-                              <% modal_index = "#{measure.cms_id}_#{index}" %>
-                              <div type = "button" class ="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal#{modal_index}" %>">
+                              <div type = "button" class ="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal#{criteria_field.index}" %>">
                                 <ul class="value-set-list">
                                   <% valuessets.each do |vs| %>
                                   <li class="value-set-item-header"><%= "#{lookup_valueset_name(vs)}" %></li>
@@ -78,8 +77,8 @@
                                   <% end %>
                                 </ul>
                               </div>
-                              <div id="<%= "lookupModal#{modal_index}" %>" class="modal fade" role="dialog">
-                                <%= render 'checklist_modal', :valuessets => valuessets, :product_test => product_test, :index => modal_index, :is_attribute => false %>
+                              <div id="<%= "lookupModal#{criteria_field.index}" %>" class="modal fade" role="dialog">
+                                <%= render partial: 'checklist_modal', locals: { valuessets: valuessets, product_test: product_test, index: criteria_field.index, is_attribute: false } %>
                               </div>
                             <% end %>
                           </td>

--- a/app/views/checklist_tests/_checklist_modal.html.erb
+++ b/app/views/checklist_tests/_checklist_modal.html.erb
@@ -8,8 +8,8 @@
         <input type="text" id="<%= "lookupFilter#{index}#{is_attribute}" %>" onkeyup="<%= "lookupFunction('#{index}',#{is_attribute})" %>" onkeydown="if (event.keyCode == 13) {return false;}" placeholder="Filter codes">
         <ul class='list-unstyled' id="<%= "lookup_codes#{index}#{is_attribute}" %>">
          <% valuessets.each do |vs| %>
-         <% lookup_codevalues(vs, product_test.bundle).each do |pair_string| %>
-         <li class="value-set-list" id="vs_pair_list"><i><%= pair_string %></i></li>
+         <% lookup_codevalues(vs, product_test.bundle).each do |pair_array| %>
+         <li class="value-set-list" id="vs_pair_list"><i><button data-code-string="<%= pair_array[1] %>" data-index-value = "<%= "#{index}" %>" data-attribute-value= "<%= "#{is_attribute}" %>" class="modal-btn" onClick><%= "#{pair_array[0]}: #{pair_array[1]}" %></button></i></li>
          <% end %>
          <% end %>
        </ul>


### PR DESCRIPTION
On the record sample form user can now click on a code from the record sample modal that pops up when code set button is clicked and that code will be populated in the input box associated with that value set. 

**Submitter:** Laura Clark
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:** Michael O'Keefe

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code