### PR TITLE
Use a slim test deck for 2014 certification, and 2015 certification without C2

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -126,11 +126,8 @@ class Product
   end
 
   def test_deck_max
-    if slim_test_deck?
-      5
-    else
-      50
-    end
+    return 5 if slim_test_deck?
+    50
   end
 
   # - - - - - - - - - #

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -121,6 +121,18 @@ class Product
     super
   end
 
+  def slim_test_deck?
+    cert_edition == '2014' || !c2_test
+  end
+
+  def test_deck_max
+    if slim_test_deck?
+      5
+    else
+      50
+    end
+  end
+
   # - - - - - - - - - #
   #   P R I V A T E   #
   # - - - - - - - - - #

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -89,7 +89,8 @@ class MeasureTestTest < ActiveJob::TestCase
     perform_enqueued_jobs do
       assert pt.save, 'should be able to save valid product test'
       assert_performed_jobs 1
-      assert pt.records.count > 0, 'product test creation should have created random number of test records'
+      assert pt.records.count.positive?, 'product test creation should have created random number of test records'
+      assert pt.records.count < 10, 'product tests for 2014 editions should have fewer than 10 records'
       pt.reload
       assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
       assert_not_nil pt.html_archive, 'Product test should have archived patient HTMLs'


### PR DESCRIPTION
2014 Certification and 2015 certification without C2 do not require automated entry of QRDA documents, so we want to "slim down" the test deck to <10 records to ease manual entry.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:** Michael O'Keefe
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-109
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Louis Ades
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code