### PR TITLE
Enforce 2014 certification edition settings in the model

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -127,7 +127,6 @@ function UpdateMeasureSet(bundle_id) {
 // as the second parameter. True means disabled and false means enabled.
 function setCheckboxDisabled(element, state) {
   $(element).prop("disabled", state);
-
   if (state) {
     $(element).parent().addClass('disabled');
     $(element).prop("checked", false);
@@ -269,6 +268,7 @@ ready_run_once = function() {
       }
       else if (edition == '2015') {
         setCheckboxDisabled('#product_duplicate_records', false);
+        $('#product_duplicate_records').prop("checked", true);
         setCheckboxDisabled('#product_c4_test', false);
       }
     }

--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -126,13 +126,15 @@ function UpdateMeasureSet(bundle_id) {
 // Allows the enabling or disabling of a checkbox by passing true or false
 // as the second parameter. True means disabled and false means enabled.
 function setCheckboxDisabled(element, state) {
-  $(element).prop("disabled", state);
+  var children = $(element).closest('div.checkbox').find('*').addBack();
   if (state) {
-    $(element).parent().addClass('disabled');
-    $(element).prop("checked", false);
+    $(children).addClass('disabled');
+    $(children).prop('disabled', true);
+    $(element).prop('checked', false);
   }
   else {
-    $(element).parent().removeClass('disabled');
+    $(children).removeClass('disabled');
+    $(children).prop('disabled', false);
   }
 }
 
@@ -268,8 +270,20 @@ ready_run_once = function() {
       }
       else if (edition == '2015') {
         setCheckboxDisabled('#product_duplicate_records', false);
-        $('#product_duplicate_records').prop("checked", true);
         setCheckboxDisabled('#product_c4_test', false);
+        $('.btn-checkbox input[name="product[c2_test]"]').trigger('change');
+      }
+    }
+  });
+
+  // Check Duplicate Records on C2 Test check
+  $('.btn-checkbox input[name="product[c2_test]"]').on('change', function() {
+    if ($(this).attr('disabled') != true) {
+      var edition = $('.btn-checkbox input[name="product[cert_edition]"]:checked').val();
+      var c2_checked = $(this).prop('checked');
+      if (edition == '2015') {
+        setCheckboxDisabled('#product_duplicate_records', !c2_checked);
+        $('.btn-checkbox input[name="product[duplicate_records]"]').prop('checked', c2_checked);
       }
     }
   });

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -18,12 +18,11 @@ class Product
   field :version, type: String
   field :description, type: String
   field :cert_edition, type: String, default: '2015'
-  field :c1_test, type: Boolean
-  field :c2_test, type: Boolean
-  field :c3_test, type: Boolean
-  field :c4_test, type: Boolean
+  %i(c1_test c2_test c3_test c4_test).each do |test|
+    field test, type: Boolean, default: false
+  end
   field :randomize_records, type: Boolean, default: true
-  field :duplicate_records, type: Boolean, default: true
+  field :duplicate_records, type: Boolean
   field :shift_records, type: Boolean, default: false
   field :allow_duplicate_names, type: Boolean, default: false
   field :measure_selection, type: String
@@ -158,6 +157,8 @@ class Product
     if cert_edition.eql? '2014'
       self.duplicate_records = false
       self.c4_test = false
+    elsif (cert_edition.eql? '2015') && duplicate_records.nil?
+      self.duplicate_records = c2_test
     end
 
     true

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -1,3 +1,5 @@
+# rubocop:disable ClassLength
+
 class Product
   include Mongoid::Document
   include Mongoid::Attributes::Dynamic

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -54,7 +54,7 @@
               <legend class="control-label">Records Options</legend>
               <%= f.form_group help: "Recommended for most robust testing." do %>
                 <%= f.check_box :randomize_records, label: 'Randomize Records', label_class: "btn btn-checkbox", checked: product.new_record? ? true : product.randomize_records, disabled: !product.new_record? %>
-                <%= f.check_box :duplicate_records, label: 'Duplicate Records', label_class: "btn btn-checkbox", checked: product.new_record? ? true : product.duplicate_records, disabled: !product.new_record? %>
+                <%= f.check_box :duplicate_records, label: 'Duplicate Records', label_class: "btn btn-checkbox disabled", checked: product.duplicate_records, disabled: true %>
               <% end %>
             </fieldset>
           <%end%>

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -35,6 +35,27 @@ Scenario: Unsuccessful Create Product Because No Task Type Selected
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
+Scenario: Successful Create Product with debug mode off and C2 Type selected
+  When debug mode is false
+  When a user creates a 2015 product with c1, c2 certifications and visits that product page
+  Then the product value for randomize_records should be true
+  Then the product value for duplicate_records should be true
+  Then the product value for cert_edition should be 2015
+
+Scenario: Successful Create Product with debug mode off and C1 Type selected
+  When debug mode is false
+  When a user creates a 2015 product with c1 certifications and visits that product page
+  Then the product value for randomize_records should be true
+  Then the product value for duplicate_records should be false
+  Then the product value for cert_edition should be 2015
+
+Scenario: Successful Create Product with debug mode off in 2014 cert mode and C2 Type selected
+  When debug mode is false
+  When a user creates a 2014 product with c1, c2 certifications and visits that product page
+  Then the product value for randomize_records should be true
+  Then the product value for duplicate_records should be false
+  Then the product value for cert_edition should be 2014
+
 Scenario: Successful Create Product with Multiple Measures From Different Groups
   When the user creates a product with multiple measures from different groups
   Then the user should see a notification saying the product was created
@@ -94,7 +115,24 @@ Scenario: Changing certification type back and forth updates options appropriate
   And the user chooses the "2014" Certification Edition
   And the user chooses the "2015" Certification Edition
   Then "C4 Test" checkbox should be enabled
+  Then "C4 Test" checkbox should be unchecked
+
+Scenario: Checking C2 Test updates Duplidate Records appropriately on 2015 cert edition
+  When the user navigates to the create product page
+  And the user chooses the "2015" Certification Edition
+  And the user chooses the "c2" Certification Type
   Then "Duplicate Records" checkbox should be enabled
+  Then "Duplicate Records" checkbox should be checked
+  Then "C4 Test" checkbox should be enabled
+  Then "C4 Test" checkbox should be unchecked
+
+Scenario: Checking C2 Test updates Duplidate Records appropriately on 2015 cert edition
+  When the user navigates to the create product page
+  And the user chooses the "2014" Certification Edition
+  And the user chooses the "c2" Certification Type
+  Then "Duplicate Records" checkbox should be disabled
+  Then "Duplicate Records" checkbox should be unchecked
+  Then "C4 Test" checkbox should be disabled
 
 Scenario: Successful Cancel Create Product
   When the user cancels creating a product

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -5,43 +5,43 @@ Background:
   And the user has created a vendor with a product
 
 Scenario: Successful Select C1 and View Tabs
-  When a user creates a product with c1 certifications and visits that product page
+  When a user creates a 2015 product with c1 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and View Tabs
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C3 and View Tabs
-  When a user creates a product with c1, c3 certifications and visits that product page
+  When a user creates a 2015 product with c1, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C4 and View Tabs
-  When a user creates a product with c1, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and C3 and View Tabs
-  When a user creates a product with c2, c3 certifications and visits that product page
+  When a user creates a 2015 product with c2, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and C4 and View Tabs
-  When a user creates a product with c2, c4 certifications and visits that product page
+  When a user creates a 2015 product with c2, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C3 and View Tabs
-  When a user creates a product with c1, c2, c3 certifications and visits that product page
+  When a user creates a 2015 product with c1, c2, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C4 and View Tabs
-  When a user creates a product with c1, c2, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c2, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C3 and C4 and View Tabs
-  When a user creates a product with c1, c2, c3, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c2, c3, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Download All Patients
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should be able to download all patients
@@ -49,7 +49,7 @@ Scenario: Successful Download All Patients
   Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot View Download All Patients
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   And all product tests do not have a state of ready
   And the user visits the product page
   Then the user should not be able to download all patients
@@ -57,7 +57,7 @@ Scenario: Cannot View Download All Patients
   Then the page should be accessible according to: wcag2aa
 
 Scenario: Can Download Report
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should be able to download the report
@@ -66,13 +66,13 @@ Scenario: Cannot Download Report when not an ATL
   Given the user is signed in as a non admin
   Given the user has created a vendor
   Given the user is owner of the vendor
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should not be able to download the report
 
 Scenario: Can Multi Upload Cat I
-  When a user creates a product with c1, c2 certifications and visits that product page
+  When a user creates a 2015 product with c1, c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
   And the user visits the product page
@@ -81,14 +81,14 @@ Scenario: Can Multi Upload Cat I
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload Cat III
-  When a user creates a product with c2 certifications and visits that product page
+  When a user creates a 2015 product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   And the user uploads a cat III document to product test 1
   Then the user should see a cat III test testing for product test 1
 
 Scenario: Can Multi Upload To Filtering Test
-  When a user creates a product with c1, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c4 certifications and visits that product page
   And the user adds a product test
   And filtering tests are added to product
   And all product tests have a state of ready
@@ -100,7 +100,7 @@ Scenario: Can Multi Upload To Filtering Test
   And the user should see a cat III test testing for filtering test 1
 
 Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times
-  When a user creates a product with c1 certifications and visits that product page
+  When a user creates a 2015 product with c1 certifications and visits that product page
   And the user adds a product test
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
@@ -114,7 +114,7 @@ Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times with page reload before test completion
-  When a user creates a product with c1 certifications and visits that product page
+  When a user creates a 2015 product with c1 certifications and visits that product page
   And the user adds a product test
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
@@ -131,7 +131,7 @@ Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times wit
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload to the Same Task on a Filtering Test Multiple Times
-  When a user creates a product with c1, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c4 certifications and visits that product page
   And the user adds a product test
   And filtering tests are added to product
   And all product tests have a state of ready
@@ -145,7 +145,7 @@ Scenario: Can Multi Upload to the Same Task on a Filtering Test Multiple Times
   Then the user should see a cat III test testing for filtering test 1
 
 Scenario: Can Multi Upload to the Same Task on a Filtering Test Multiple Times with page reload before test completion
-  When a user creates a product with c1, c4 certifications and visits that product page
+  When a user creates a 2015 product with c1, c4 certifications and visits that product page
   And the user adds a product test
   And filtering tests are added to product
   And all product tests have a state of ready

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -37,12 +37,17 @@ end
 #   W H E N   #
 # # # # # # # #
 
+When(/^debug mode is (.*)$/) do |debug_mode_value|
+  Settings.current.update(enable_debug_features: debug_mode_value.to_boolean)
+end
+
 # certs argument stands for certifications and should be a comma separated list of some of these values: c1, c2, c3, c4
-When(/^a user creates a product with (.*) certifications and visits that product page$/) do |certs|
+When(/^a user creates a (.*) product with (.*) certifications and visits that product page$/) do |cert_edition, certs|
   certs = certs.split(', ')
   steps %( When the user navigates to the create product page for vendor #{@vendor.name} )
   product_name = "mp #{rand}"
   page.fill_in 'Name', with: product_name
+  page.choose("#{cert_edition} Edition")
   page.find('#product_c1_test').click if certs.include? 'c1'
   page.find('#product_c2_test').click if certs.include? 'c2'
   page.find('#product_c3_test').click if certs.include? 'c3'
@@ -309,6 +314,10 @@ end
 
 And(/^the user chooses the "(.*)" Certification Edition$/) do |certification_edition|
   page.find("#product_cert_edition_#{certification_edition}").click
+end
+
+And(/^the user chooses the "(.*)" Certification Type$/) do |certification_type|
+  page.find("#product_#{certification_type}_test").click
 end
 
 When(/^all test executions for product test (.*) have the state of (.*)$/) do |product_test_number, execution_state|
@@ -591,6 +600,10 @@ end
 
 Then(/^the user should not see the Measures Options heading$/) do
   page.assert_no_text 'Measures Options'
+end
+
+Then(/^the product value for (.*) should be (.*)$/) do |method, value|
+  assert_equal value.to_s, @product.send(method).to_s
 end
 
 def task_status_to_execution_status_message(task_status)

--- a/test/fixtures/products/product1.json
+++ b/test/fixtures/products/product1.json
@@ -6,6 +6,7 @@
   "name" : "Vendor 1 Product 1",
   "description" : "first product",
   "randomize_records" : true,
+  "duplicate_records" : false,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/fixtures/products/product2.json
+++ b/test/fixtures/products/product2.json
@@ -5,6 +5,7 @@
   "description" : "second product",
   "name" : "vendor2 product1",
   "randomize_records" : true,
+  "duplicate_records" : false,
   "vendor_id" : {"$oid" : "4f636aba1d41c851eb00048c"}
 }
 

--- a/test/fixtures/products/product2_with_shift.json
+++ b/test/fixtures/products/product2_with_shift.json
@@ -5,6 +5,7 @@
   "description" : "second product",
   "name" : "vendor2 product1",
   "randomize_records" : true,
+  "duplicate_records" : false,
   "shift_records" : true,
   "vendor_id" : {"$oid" : "4f636aba1d41c851eb00048c"}
 }

--- a/test/fixtures/products/product3.json
+++ b/test/fixtures/products/product3.json
@@ -6,6 +6,7 @@
   "cert_edition": "2015",
   "c2_test": false,
   "randomize_records" : true,
+  "duplicate_records" : true,
   "bundle_id" : {"$oid" : "4fdb62e01d41c820f6000001"} ,
   "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"}
 }

--- a/test/fixtures/products/product4_with_mapped_measures.json
+++ b/test/fixtures/products/product4_with_mapped_measures.json
@@ -9,6 +9,7 @@
  "bundle_id" : {"$oid" : "4fdb62e01d41c820f6000001"} ,
  "user_ids" : ["4def93dd4f85cf8968000010"],
  "randomize_records" : true,
-  "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"}
+ "duplicate_records" : false,
+ "vendor_id" : {"$oid" : "4f57a8791d41c851eb000002"}
 }
 

--- a/test/fixtures/products/product5.json
+++ b/test/fixtures/products/product5.json
@@ -7,6 +7,7 @@
   "description" : "fifth product",
   "bundle_id" : {"$oid" : "4fdb62e01d41c820f6000001"} ,
   "randomize_records" : true,
+  "duplicate_records" : false,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/fixtures/products/product6.json
+++ b/test/fixtures/products/product6.json
@@ -8,6 +8,7 @@
   "c2_test": true,
   "description" : "fifth product",
   "randomize_records" : true,
+  "duplicate_records" : false,
    "user_ids" : ["4def93dd4f85cf8968000010"]
 
 }

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -94,7 +94,7 @@ class MeasureTestTest < ActiveJob::TestCase
       pt.reload
       assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
       assert_not_nil pt.html_archive, 'Product test should have archived patient HTMLs'
-      assert pt.records.count < count_zip_entries(pt.patient_archive.file.path), 'Archive should contain more files than the test'
+      assert_equal pt.records.count, count_zip_entries(pt.patient_archive.file.path), 'Archive should contain more files than the test'
       assert count_zip_entries(pt.html_archive.file.path) == count_zip_entries(pt.patient_archive.file.path), 'QRDA Archive and HTML archive should have same # files'
       assert_not_nil pt.expected_results, 'Product test should have expected results'
     end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -19,7 +19,7 @@ class ProducTest < ActiveSupport::TestCase
     drop_database
   end
 
-  def test_create
+  def test_create_2015_certification
     pt = Product.new(vendor: @vendor, name: 'test_product', c1_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001')
     pt.product_tests.build(name: 'test_product_test_name',
                            measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
@@ -29,14 +29,16 @@ class ProducTest < ActiveSupport::TestCase
     assert_equal pt.cert_edition, '2015'
   end
 
-  def test_create_2014ce
-    pt = Product.new(vendor: @vendor, name: 'test_product', cert_edition: '2014', c1_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001')
+  def test_create_2014_certification
+    pt = Product.new(vendor: @vendor, name: 'test_product', c1_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001', cert_edition: '2014')
     pt.product_tests.build(name: 'test_product_test_name',
                            measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
                            bundle_id: '4fdb62e01d41c820f6000001').save!
     assert pt.valid?, 'record should be valid'
     assert pt.save, 'Should be able to create and save a 2014 cert edition Product'
     assert_equal pt.cert_edition, '2014'
+    assert_equal pt.randomize_records, true
+    assert_equal pt.duplicate_records, false
   end
 
   def test_offset

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -19,26 +19,52 @@ class ProducTest < ActiveSupport::TestCase
     drop_database
   end
 
-  def test_create_2015_certification
+  def test_create_2015_certification_no_c2
     pt = Product.new(vendor: @vendor, name: 'test_product', c1_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001')
     pt.product_tests.build(name: 'test_product_test_name',
                            measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
                            bundle_id: '4fdb62e01d41c820f6000001').save!
     assert pt.valid?, 'record should be valid'
     assert pt.save, 'Should be able to create and save a Product'
-    assert_equal pt.cert_edition, '2015'
+    assert_equal '2015', pt.cert_edition
+    assert_equal true, pt.randomize_records
+    assert_equal false, pt.duplicate_records
   end
 
-  def test_create_2014_certification
+  def test_create_2015_certification_with_c2
+    pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001')
+    pt.product_tests.build(name: 'test_product_test_name',
+                           measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
+                           bundle_id: '4fdb62e01d41c820f6000001').save!
+    assert pt.valid?, 'record should be valid'
+    assert pt.save, 'Should be able to create and save a Product'
+    assert_equal '2015', pt.cert_edition
+    assert_equal true, pt.randomize_records
+    assert_equal true, pt.duplicate_records
+  end
+
+  def test_create_2014_certification_no_c2
     pt = Product.new(vendor: @vendor, name: 'test_product', c1_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001', cert_edition: '2014')
     pt.product_tests.build(name: 'test_product_test_name',
                            measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
                            bundle_id: '4fdb62e01d41c820f6000001').save!
     assert pt.valid?, 'record should be valid'
     assert pt.save, 'Should be able to create and save a 2014 cert edition Product'
-    assert_equal pt.cert_edition, '2014'
-    assert_equal pt.randomize_records, true
-    assert_equal pt.duplicate_records, false
+    assert_equal '2014', pt.cert_edition
+    assert_equal true, pt.randomize_records
+    assert_equal false, pt.duplicate_records
+  end
+
+  def test_create_2014_certification_with_c2
+    pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'], bundle_id: '4fdb62e01d41c820f6000001', cert_edition: '2014')
+    pt.product_tests.build(name: 'test_product_test_name',
+                           measure_ids: ['8A4D92B2-3887-5DF3-0139-0D01C6626E46'],
+                           bundle_id: '4fdb62e01d41c820f6000001').save!
+    assert pt.valid?, 'record should be valid'
+    assert pt.save, 'Should be able to create and save a Product'
+    assert_equal '2014', pt.cert_edition
+    assert_equal true, pt.randomize_records
+    assert_equal false, pt.duplicate_records
   end
 
   def test_offset


### PR DESCRIPTION
This includes the changes required to get debug_mode working properly when the 2014 certification edition is selected. In the model we now check if the 2014 cert_edition is selected and if it is then we use a before_save hook to force the values to be false for duplicate_records and c4_test.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: Still related to https://jira.mitre.org/browse/CYPRESS-107
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code