### PR TITLE
Only export a single "HTML" archive for a filter test

### DIFF
--- a/lib/cypress/create_total_test_zip.rb
+++ b/lib/cypress/create_total_test_zip.rb
@@ -28,13 +28,15 @@ module Cypress
     def self.add_filtering_zips(z, filtering_tests, format, filtering_list)
       pt = filtering_tests.first
       CreateDownloadZip.add_file_to_zip(z, "filteringtest_#{pt.cms_id}_#{pt.id}.#{format}.zip".tr(' ', '_'), pt.patient_archive.read)
+      CreateDownloadZip.add_file_to_zip(z, "filteringtest_#{pt.cms_id}_#{pt.id}.html.zip".tr(' ', '_'),
+                                        pt.html_archive.read) unless pt.product.c2_test
       CreateDownloadZip.add_file_to_zip(z, 'filtering_criteria.html', filtering_list)
     end
 
     def self.add_html_files(z, tests)
       tests.each do |pt|
         CreateDownloadZip.add_file_to_zip(z, "#{pt.cms_id}_#{pt.id}.html.zip".tr(' ', '_'),
-                                          pt.html_archive.read) unless pt[:html_archive].nil?
+                                          pt.html_archive.read) unless pt[:html_archive].nil? || (pt.is_a? FilteringTest)
       end
     end
   end


### PR DESCRIPTION
This is a follow-up to the "Export HTML records when not C2" feature

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Lauren DiCristofaro
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Louis Ades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code