### PR TITLE
Add languge to indicate that filtered codes need to be SNOMEDCT codes

### DIFF
--- a/app/helpers/filtering_tests_helper.rb
+++ b/app/helpers/filtering_tests_helper.rb
@@ -35,7 +35,7 @@ module FilteringTestsHelper
   end
 
   def problems_val(val)
-    ["#{HealthDataStandards::SVS::ValueSet.where(oid: val[:oid].first).first.display_name} (code: #{val[:oid].first})"]
+    ["SNOMEDCT codes in #{HealthDataStandards::SVS::ValueSet.where(oid: val[:oid].first).first.display_name} (code: #{val[:oid].first})"]
   end
 
   def providers_val(val)

--- a/test/helpers/filtering_tests_helper_test.rb
+++ b/test/helpers/filtering_tests_helper_test.rb
@@ -31,7 +31,7 @@ class FilteringTestsHelperTest < ActiveSupport::TestCase
     assert_equal display_filter_val('ethnicities', @filters.ethnicities), ['Hispanic or Latino (code: 2135-2)']
     assert_equal display_filter_val('genders', @filters.genders), ['F']
     assert_equal display_filter_val('payers', @filters.payers), ['Medicare']
-    assert_equal display_filter_val('problems', @filters.problems), ['Preventive Care- Initial Office Visit, 0 to 17 (code: 2.16.840.1.113883.3.464.1003.101.12.1022)']
+    assert_equal display_filter_val('problems', @filters.problems), ['SNOMEDCT codes in Preventive Care- Initial Office Visit, 0 to 17 (code: 2.16.840.1.113883.3.464.1003.101.12.1022)']
   end
 
   def test_display_filter_val_age


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: Cypress 119
- [x] Internal ticket links to this PR:  Cypress 119
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Robert Clark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Louis Ades
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] N/A You have tried to break the code - Not really much to break here.