### PR TITLE
Remove I18n settings from settings model since it is not working properly with rake tasks

### DIFF
--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -11,8 +11,8 @@ class Settings
   field :enable_logging, type: Boolean, default: false
   # set to true to enable a banner at the top of every page with the "banner_message" text from below
   field :banner, type: Boolean, default: false
-  field :banner_message, type: String, default: I18n.t('settings.messages.banner')
-  field :warning_message, type: String, default: I18n.t('settings.messages.warning')
+  field :banner_message, type: String, default: APP_CONSTANTS['default_banner_message']
+  field :warning_message, type: String, default: APP_CONSTANTS['default_warning_message']
   # ignore roles completely -- this is essentially the same as everyone in the system being an admin, default true
   field :ignore_roles, type: Boolean, default: (ENV['IGNORE_ROLES'].nil? ? true : ENV['IGNORE_ROLES'].to_boolean)
   # enable the "debug features" such as allowing QA testers to produce known good results for a task, default true

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -6,6 +6,11 @@ bundle_file_path: 'temp/bundles'
 file_upload_root: 'data/upload/'
 pid_dir: './tmp/delayed_pids'
 
+# These were initially in I18n however for some reason I18n is not loaded when rake tasks are run, which means we often
+# end up getting translation missing errors.
+default_banner_message: 'This server is for demonstration purposes; data on it will be removed every Saturday at 11:59 PM Eastern Time'
+default_warning_message: 'This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes all devices/storage media attached to this system. This system is provided for Government-authorized use only. Unauthorized or improper use of this system is prohibited and may result in disciplinary action and/or civil and criminal penalties. At any time, and for any lawful Government purpose, the government may monitor, record, and audit your system usage and/or intercept, search and seize any communication or data transiting or stored on this system. Therefore, you have no reasonable expectation of privacy. Any communication or data transiting or stored on this system may be disclosed or used for any lawful Government purpose.'
+
 # Specify the folder to look for the schematron files in based on bundle version these folders are in ./resources/schematron/
 # Schematron files need to be named:
   # EP_CAT_1.sch

--- a/config/locales/settings.en.yml
+++ b/config/locales/settings.en.yml
@@ -1,7 +1,0 @@
-en:
-  settings:
-    messages:
-      banner:
-        'This server is for demonstration purposes; data on it will be removed every Saturday at 11:59 PM Eastern Time'
-      warning:
-         'This warning banner provides privacy and security notices consistent with applicable federal laws, directives, and other federal guidance for accessing this Government system, which includes all devices/storage media attached to this system. This system is provided for Government-authorized use only. Unauthorized or improper use of this system is prohibited and may result in disciplinary action and/or civil and criminal penalties. At any time, and for any lawful Government purpose, the government may monitor, record, and audit your system usage and/or intercept, search and seize any communication or data transiting or stored on this system. Therefore, you have no reasonable expectation of privacy. Any communication or data transiting or stored on this system may be disclosed or used for any lawful Government purpose.'


### PR DESCRIPTION
It seems that rake tasks do not properly load I18n so instead store it in APP_CONSTANTS

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: (N/A)
- [x] Internal ticket links to this PR: (N/A)
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases: (N/A)
- [x] Tests have been run locally and pass: (N/A)

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code