### PR TITLE
New link

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -36,6 +36,11 @@ module ApplicationHelper
     cms_id[/#{start_marker}(.*?)#{end_marker}/m, 1].to_i
   end
 
+  # This will always return a three digit cms identifier, e.g., CMS9v3 => CMS009v3
+  def padded_cms_id(cms_id)
+    cms_id.sub(/(?<=cms)(\d{1,3})/i) { Regexp.last_match(1).rjust(3, '0') }
+  end
+
   # All "Master Patients" has medical records numbers that are UUIDs following this pattern "007f5da0-4d3a-0135-867f-20999b0ed66f".
   # These medical record numbers are set in the bundle. When patients are created for a test,
   # they have a medical record number like "757442430658921". This "keep_if" statement makes sure we only returning an id for a Master Patient.

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <strong>HQMF ID: </strong><span><%= task.measure_ids.join(',') %></span><br/>
   <% unless task.product_test.is_a? ChecklistTest %>
-    <strong>CMS ID: </strong><span><%= task.product_test_cms_id%></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{task.product_test_cms_id.sub(/(?<=cms)(\d{1,3})/i) { |s| $1.rjust(3,'0') } }", :target => "_blank", :id => "ecqm-link" %></span><br/>
+    <strong>CMS ID: </strong><span><%= task.product_test_cms_id%></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{padded_cms_id(task.product_test_cms_id)}", :target => "_blank", :id => "ecqm-link" %></span><br/>
   <% end %>
 
   <% # display provider information if the product test is a measure test %>

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -11,7 +11,7 @@
   <% end %>
   <strong>HQMF ID: </strong><span><%= task.measure_ids.join(',') %></span><br/>
   <% unless task.product_test.is_a? ChecklistTest %>
-    <strong>CMS ID: </strong><span><%= task.product_test_cms_id %></span><br/>
+    <strong>CMS ID: </strong><span><%= task.product_test_cms_id%></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{task.product_test_cms_id.sub(/(?<=cms)(\d{1,3})/i) { |s| $1.rjust(3,'0') } }", :target => "_blank", :id => "ecqm-link" %></span><br/>
   <% end %>
 
   <% # display provider information if the product test is a measure test %>

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -18,6 +18,7 @@ Scenario: View Only C1 Execution Page
   And the user views task c1
   Then the user should only see the c1 execution page
   Then the user should see provider information
+  And the user should be able to click eCQM Specification link
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
@@ -41,6 +42,7 @@ Scenario: View C1 and C3 And C2 and C3 Execution Pages
   When the user creates a product with tasks c1, c2, c3
   And the user views task c1
   And the user switches to c2 and c3 certification
+  And the user should be able to click eCQM Specification link
   Then the user should see the c2 and c3 execution page
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -15,7 +15,7 @@ And(/^the user has created a vendor with a product selecting C4 testing$/) do
 
   criteria = %w[races ethnicities]
   options = { 'filters' => Hash[criteria.map { |c| [c, []] }] }
-  @f_test1 = FilteringTest.new(name: 'test_for_measure_1a', product: @product, incl_addr: true, options: options,
+  @f_test1 = FilteringTest.new(name: 'test_for_measure_1a', cms_id: 'CMS31v3', product: @product, incl_addr: true, options: options,
                                measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
   @f_test1.save!
   @f_test1.generate_records

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -21,7 +21,7 @@ When(/^the user creates a product with tasks (.*)$/) do |tasks|
   @product = Product.new(vendor: @vendor, name: 'Product 1', measure_ids: measure_ids, c1_test: tasks.include?('c1'),
                          c2_test: tasks.include?('c2'), c3_test: tasks.include?('c3'), c4_test: tasks.include?('c4'), bundle_id: bundle_id)
   @product.save!
-  @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids }, MeasureTest)
+  @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids, cms_id: @measure.cms_id }, MeasureTest)
 
   # create record and assign provider for product test
   @product_test.generate_provider
@@ -67,6 +67,10 @@ end
 
 And(/^the user clicks the (.*) button$/) do |button_name|
   page.find('button', text: button_name).click
+end
+
+And(/^the user should be able to click eCQM Specification link/) do
+  page.find('#ecqm-link').click
 end
 
 And(/^the product test state is not set to ready$/) do

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TestExecutionHelper < ActiveSupport::TestCase
   include TestExecutionsHelper
+  include ApplicationHelper
   include ActiveJob::TestHelper
 
   # # # # # # # # #
@@ -186,5 +187,11 @@ class TestExecutionHelper < ActiveSupport::TestCase
     # checklist tests
     assert_equal [true, false, false, false], current_certifications('C1ChecklistTask', false)
     assert_equal [true, false, true, false], current_certifications('C1ChecklistTask', true)
+  end
+
+  def test_padding_cms_id
+    assert_equal 'CMS002v5', padded_cms_id('CMS2v5')
+    assert_equal 'CMS020v5', padded_cms_id('CMS20v5')
+    assert_equal 'CMS200v5', padded_cms_id('CMS200v5')
   end
 end


### PR DESCRIPTION
The cms id on the Measure Test Information page now has a link that will take you to the eCQM measure page associated with that measure. 
![screen shot 2018-03-30 at 7 32 48 am](https://user-images.githubusercontent.com/22615706/38136479-9970c184-33ec-11e8-92af-a25799a65459.png)


**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code