### PR TITLE
Fix patient demo view

### DIFF
--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -8,12 +8,12 @@
   <thead>
     <tr>
       <th scope="col">Patient Name</th>
-      <% if product_test && (current_user.user_role?('atl') || current_user.user_role?('admin'))%>
+      <% if product_test && !hide_patient_calculation? %>
         <th scope="col">Template Name</th>
       <%end%>
       <th scope="col">DOB</th>
       <th scope="col">Gender</th>
-      <% if measure && (current_user.user_role?('admin') || current_user.user_role?('atl'))%>
+      <% if measure && !hide_patient_calculation?%>
         <% measure.population_ids.keys().each do |population| %>
           <th scope="col" class="text-center"><%= population_label(bundle, population) %></th>
         <% end %>
@@ -25,7 +25,7 @@
       <!-- will show aggregate record populations -->
       <tr>
         <th scope="row">Total</th>
-        <% if product_test && (current_user.user_role?('atl') || current_user.user_role?('admin'))%>
+        <% if product_test && !hide_patient_calculation? %>
           <td></td>
         <%end%>
         <td></td>
@@ -63,7 +63,7 @@
           <% else %>
             <td><%= link_to full_name(r), bundle_record_path(bundle, r) %></td>
           <% end %>
-          <% if product_test && (current_user.user_role?('atl') || current_user.user_role?('admin')) %>
+          <% if product_test && !hide_patient_calculation? %>
             <% original_patient = r.bundle.records.find_by(medical_record_number: r.original_medical_record_number) %>
             <td> <%="#{original_patient.first} #{original_patient.last}"%> </td>
           <%end%>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -73,6 +73,7 @@
   </div>
 <% end #cache records %>
 
+<% if !@task || !@product_test %>
 <script type="text/javascript">
   // initialize jQueryUI Autocomplete for searching measures
   $('#search_measures').autocomplete({
@@ -108,3 +109,4 @@
     }
   })
 </script>
+<% end %>

--- a/features/measure_tests/records_list.feature
+++ b/features/measure_tests/records_list.feature
@@ -6,7 +6,7 @@ Background:
   And the user has selected a measure
 
 Scenario: Admin should be able to view calculation results
-  When the user creates a product with tasks c1, c2, c3, c4
+  When the user creates a product with records with tasks c1, c2, c3, c4
   And the user is an admin
   And the user views task c1
   And the user views the task records

--- a/features/measure_tests/records_list.feature
+++ b/features/measure_tests/records_list.feature
@@ -1,0 +1,13 @@
+Feature: Measure Test Records list
+
+Background:
+  Given the user is signed in
+  And the user has created a vendor
+  And the user has selected a measure
+
+Scenario: Admin should be able to view calculation results
+  When the user creates a product with tasks c1, c2, c3, c4
+  And the user is an admin
+  And the user views task c1
+  And the user views the task records
+  Then the user should see calculation results

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -22,7 +22,7 @@ When(/^the user creates a product with records with tasks (.*)$/) do |tasks|
   @product = Product.new(vendor: @vendor, name: 'Product 1', measure_ids: measure_ids, c1_test: tasks.include?('c1'),
                          c2_test: tasks.include?('c2'), c3_test: tasks.include?('c3'), c4_test: tasks.include?('c4'), bundle_id: bundle_id)
   @product.save!
-  @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids }, MeasureTest)
+  @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids, cms_id: @measure.cms_id }, MeasureTest)
 
   @product_test.generate_provider
   @product_test.generate_records

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -14,6 +14,21 @@ end
 #   W H E N   #
 # # # # # # # #
 
+# Use this when you create a test that requires execution results
+When(/^the user creates a product with records with tasks (.*)$/) do |tasks|
+  measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+  bundle_id = Bundle.default._id
+  tasks = tasks.split(', ')
+  @product = Product.new(vendor: @vendor, name: 'Product 1', measure_ids: measure_ids, c1_test: tasks.include?('c1'),
+                         c2_test: tasks.include?('c2'), c3_test: tasks.include?('c3'), c4_test: tasks.include?('c4'), bundle_id: bundle_id)
+  @product.save!
+  @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids }, MeasureTest)
+
+  @product_test.generate_provider
+  @product_test.generate_records
+  MeasureEvaluationJob.perform_now(@product_test, {})
+end
+
 When(/^the user creates a product with tasks (.*)$/) do |tasks|
   measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
   bundle_id = Bundle.default._id
@@ -97,7 +112,7 @@ And(/^the user uploads an invalid file$/) do
 end
 
 And(/^the user should see no execution results$/) do
-  page.assert_no_text 'Results'
+  page.assert_no_text 'results_panel'
 end
 
 And(/^the user changes the selected bundle$/) do

--- a/features/step_definitions/record_list.rb
+++ b/features/step_definitions/record_list.rb
@@ -1,0 +1,19 @@
+include TestExecutionsHelper
+
+# # # # # # # # #
+#   G I V E N   #
+# # # # # # # # #
+
+#   A N D   #
+
+And(/^the user views the task records$/) do
+  page.click_link 'View Patients'
+end
+
+#  T H E N #
+
+Then(/^the user should see calculation results$/) do
+  page.assert_text('Template Name')
+  page.assert_text('IPOP')
+  page.assert_selector('span.result-marker')
+end

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -27,6 +27,14 @@ module Admin
       end
     end
 
+    test 'should get index without bundle install' do
+      Bundle.destroy_all
+      for_each_logged_in_user([ADMIN]) do
+        get :index
+        assert_redirected_to %r{/admin#bundles}
+      end
+    end
+
     test 'admin user should import new bundle successfully' do
       for_each_logged_in_user([ADMIN]) do
         orig_bundle_count = Bundle.count

--- a/test/helpers/checklist_tests_helper_test.rb
+++ b/test/helpers/checklist_tests_helper_test.rb
@@ -23,4 +23,23 @@ class ChecklistTestsHelperTest < ActiveSupport::TestCase
     field_value_mixed['low'] = field_value_low['low']
     assert_equal '90 d < stay &#8804; 120 d', length_of_stay_string(field_value_mixed)
   end
+
+  def test_checklist_test_criteria_attribute
+    measure = FactoryGirl.create(:static_measure)
+    c1 = {}
+    c2 = {}
+    c3 = {}
+
+    c1[:negation] = true
+    assert_equal 'Negation Code', checklist_test_criteria_attribute(measure, c1)
+
+    c2[:value] = { type: 'IVL_PQ',
+                   high: { type: 'PQ',
+                           unit: 'mg/dL',
+                           value: '100' } }
+    assert_equal 'Result', checklist_test_criteria_attribute(measure, c2)
+
+    c3[:value] = { type: 'CD', system: 'Administrative Sex', code: 'F' }
+    assert_equal '', checklist_test_criteria_attribute(measure, c3)
+  end
 end

--- a/test/models/record_test.rb
+++ b/test/models/record_test.rb
@@ -33,26 +33,28 @@ class RecordTest < ActiveSupport::TestCase
   end
 
   def test_record_duplicate_randomization
-    random = Random.new_seed
-    prng1 = Random.new(random)
-    prng2 = Random.new(random)
+    10.times do
+      random = Random.new_seed
+      prng1 = Random.new(random)
+      prng2 = Random.new(random)
 
-    r1 = Record.new(
-      first: 'Robert', last: 'Johnson', gender: 'M', birthdate: '477542400',
-      race: APP_CONSTANTS['randomization']['races'].sample(random: prng1),
-      ethnicity: APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng1)
-    )
+      r1 = Record.new(
+        first: 'Robert', last: 'Johnson', gender: 'M', birthdate: '477542400',
+        race: APP_CONSTANTS['randomization']['races'].sample(random: prng1),
+        ethnicity: APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng1)
+      )
 
-    r2 = Record.new(
-      first: 'Robert', last: 'Johnson', gender: 'M', birthdate: '477542400',
-      race: APP_CONSTANTS['randomization']['races'].sample(random: prng2),
-      ethnicity: APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng2)
-    )
+      r2 = Record.new(
+        first: 'Robert', last: 'Johnson', gender: 'M', birthdate: '477542400',
+        race: APP_CONSTANTS['randomization']['races'].sample(random: prng2),
+        ethnicity: APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng2)
+      )
 
-    assert(record_demographics_equal?(r1, r2), 'The two records should be equal')
-    r1copy_set = r1.duplicate_randomization(random: prng1)
-    r2copy_set = r2.duplicate_randomization(random: prng2)
-    assert(record_demographics_equal?(r1copy_set[0], r2copy_set[0]), 'The two records should be equal')
-    assert(!record_demographics_equal?(r1, r1copy_set[0]), 'The two records should not be equal')
+      assert(record_demographics_equal?(r1, r2), 'The two records should be equal')
+      r1copy_set = r1.duplicate_randomization(random: prng1)
+      r2copy_set = r2.duplicate_randomization(random: prng2)
+      assert(record_demographics_equal?(r1copy_set[0], r2copy_set[0]), 'The two records should be equal')
+      assert(!record_demographics_equal?(r1, r1copy_set[0]), 'The two records should not be equal')
+    end
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

On the Cypress Demo server (or any other Cypress instance run in "demo mode"), users who are not admins cannot see the population keys (e.g. "IPP", "DENOM"), but can see the calculation results (e.g. the green circles with numbers inside them).

To reproduce: Set cypress to Demo Mode. Create a new product (in any vendor) with C1-C4 enabled, and use measure CMS68v7 (out of the 2017 bundle). Go to the C1 + C3 task, click into the CMS68-specific task, then click on "View Patients".

As admin: will be able to see population results and keys
As non-admin: will not be able to see population keys, but will be able to see population results

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR https://jira.mitre.org/browse/CYPRESS-132
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Laura
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code