### PR TITLE
Added supplement test artifact upload

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ Metrics/LineLength:
     - 'test/**/*'
 Metrics/BlockLength:
   Exclude:
+    - 'config/routes.rb'
     - 'test/factories/*'
 Metrics/MethodLength:
   CountComments: false  # count full line comments?

--- a/app/assets/stylesheets/cypress/_buttons.scss
+++ b/app/assets/stylesheets/cypress/_buttons.scss
@@ -76,3 +76,8 @@ $background-color: rgba(#000, .00);
   box-shadow: none;
   border-color: $background-color;
 }
+
+// Do not round file upload buttons on upload fields
+.input-group-addon.btn-file {
+  border-radius: 0 !important;
+}

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -47,10 +47,4 @@ class AdminController < ApplicationController
                             default_role: settings['default_role'] == 'None' ? '' : settings['default_role'].underscore.to_sym,
                             enable_debug_features: settings['debug_features'] == 'enable')
   end
-
-  private
-
-  def require_admin
-    raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.user_role? :admin
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,14 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def require_admin
+    raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.user_role? :admin
+  end
+
+  def require_admin_atl
+    raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.user_role?(:admin) || current_user.user_role?(:atl)
+  end
+
   private
 
   DEFAULT_AUTH_MAPPING = { :read => %w[show index], :manage => %w[new create update destroy delete edit] }.freeze

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,6 +4,7 @@ class ProductsController < ApplicationController
   before_action :set_product, except: %i[index new create]
   before_action :set_measures, only: %i[new edit update report]
   before_action :authorize_vendor
+  before_action :require_admin_atl, only: %i[report supplemental_test_artifact]
   before_action :check_bundle_deprecated, only: %i[show edit]
   add_breadcrumb 'Dashboard', :vendors_path
 
@@ -84,7 +85,7 @@ class ProductsController < ApplicationController
   end
 
   def supplemental_test_artifact
-    redirect_to :back, alert: 'Supplement Test Artifact does not exist for this product' if @product.supplemental_test_artifact.file.nil?
+    redirect_to(:back, alert: 'Supplement Test Artifact does not exist for this product') && return if @product.supplemental_test_artifact.file.nil?
     send_file @product.supplemental_test_artifact.file.path, disposition: 'attachment'
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -83,6 +83,11 @@ class ProductsController < ApplicationController
     send_data file.read, type: 'application/zip', disposition: 'attachment', filename: "#{@product.name}_#{@product.id}_report.zip".tr(' ', '_')
   end
 
+  def supplemental_test_artifact
+    redirect_to :back, alert: 'Supplement Test Artifact does not exist for this product' if @product.supplemental_test_artifact.file.nil?
+    send_file @product.supplemental_test_artifact.file.path, disposition: 'attachment'
+  end
+
   # always responds with a zip file of (.qrda.zip files of (qrda category I documents))
   def patients
     crit_exists = !@product.product_tests.checklist_tests.empty?
@@ -122,12 +127,14 @@ class ProductsController < ApplicationController
 
   def product_params
     params[:product][:name]&.strip!
-    params.require(:product).permit(:name, :version, :description, :randomize_records, :duplicate_records, :shift_records, :bundle_id,
-                                    :measure_selection, :cert_edition, :c1_test, :c2_test, :c3_test, :c4_test, measure_ids: [])
+    params.require(:product).permit(:name, :version, :description, :randomize_records, :duplicate_records, :shift_records,
+                                    :bundle_id, :measure_selection, :cert_edition, :c1_test, :c2_test, :c3_test, :c4_test,
+                                    :supplemental_test_artifact, :remove_supplemental_test_artifact, measure_ids: [])
   end
 
   def edit_product_params
     params[:product][:name]&.strip!
-    params.require(:product).permit(:name, :version, :description, :measure_selection, measure_ids: [])
+    params.require(:product).permit(:name, :version, :description, :measure_selection, :supplemental_test_artifact,
+                                    :remove_supplemental_test_artifact, measure_ids: [])
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -7,6 +7,8 @@ class Product
 
   before_save :enforce_cert_edition_settings
 
+  mount_uploader :supplemental_test_artifact, SupplementUploader
+
   scope :by_updated_at, -> { order(:updated_at => :desc) }
   scope :ordered_for_vendors, -> { by_updated_at.order_by(:state => 'desc') }
 

--- a/app/uploaders/supplement_uploader.rb
+++ b/app/uploaders/supplement_uploader.rb
@@ -9,6 +9,6 @@ class SupplementUploader < CarrierWave::Uploader::Base
   end
 
   def extension_white_list
-    %w[doc docx xls xlsx ppt pptx jpg jpeg png]
+    %w[doc docx xls xlsx ppt pptx jpg jpeg pdf png zip]
   end
 end

--- a/app/uploaders/supplement_uploader.rb
+++ b/app/uploaders/supplement_uploader.rb
@@ -1,0 +1,14 @@
+class SupplementUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MimeTypes
+
+  storage :file
+  process :set_content_type
+
+  def store_dir
+    "#{APP_CONSTANTS['file_upload_root']}/products/#{model.id}"
+  end
+
+  def extension_white_list
+    %w[doc docx xls xlsx ppt pptx jpg jpeg png]
+  end
+end

--- a/app/views/application/_header_product.html.erb
+++ b/app/views/application/_header_product.html.erb
@@ -1,3 +1,12 @@
+<%
+
+# inputs:
+#
+#   task (c1task or c2task)
+#   disable
+
+%>
+
 <div class="panel panel-primary">
   <div class="panel-body">
     <div class="panel-actions pull-right">
@@ -5,6 +14,11 @@
         <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Product
       <% end %>
       <% if current_user.user_role?(:atl) || current_user.user_role?(:admin) %>
+        <% unless product.supplemental_test_artifact.file.nil? %>
+          <%= button_to supplemental_test_artifact_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
+            <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Supplemental Test Artifact
+          <% end %>
+        <% end %>
         <%= button_to report_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
           <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Report
         <% end %>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -50,7 +50,7 @@
             <legend class="control-label">Supplemental Test Artifact</legend>
             <br />
             <% supplement_file_errors = product.errors[:supplemental_test_artifact].empty? %>
-            <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product" do %>
+            <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product. Allowed filetypes are #{product.supplemental_test_artifact.extension_white_list.join(', ')}." do %>
               <div class="fileinput fileinput-new input-group" data-provides="fileinput">
                 <div class="form-control" data-trigger="fileinput">
                   <i class="fa fa-fw fa-file fileinput-exists"></i>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -46,6 +46,32 @@
               <% end %>
             <% end %>
           </fieldset>
+          <fieldset id="certification_options">
+            <legend class="control-label">Supplemental Test Artifact</legend>
+            <br />
+            <% supplement_file_errors = product.errors[:supplemental_test_artifact].empty? %>
+            <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product" do %>
+              <div class="fileinput fileinput-new input-group" data-provides="fileinput">
+                <div class="form-control" data-trigger="fileinput">
+                  <i class="fa fa-fw fa-file fileinput-exists"></i>
+                  <span class="fileinput-filename"></span>
+                </div>
+                  <span class="input-group-addon btn btn-info btn-file active">
+                  <span class="fileinput-new" data-trigger="fileinput"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</span>
+                  <span class="fileinput-exists" data-trigger="fileinput"><i class="fa fa-fw fa-refresh"></i> Change</span>
+                  <span style="display:none;">
+                    <%= f.file_field :supplemental_test_artifact, class: 'upload-results hidden', :aria => { label: 'supplemental_test_artifact_label' } %>
+                  </span>
+                </span>
+              </div>
+              <% unless supplement_file_errors %>
+                <span class='help-block'>
+                  <%= product.errors[:supplemental_test_artifact].join(', ') %>
+                </span>
+              <% end %>
+              <%= f.check_box :remove_supplemental_test_artifact, label: 'Remove supplement artifact' unless product.supplemental_test_artifact.file.nil? %>
+            <% end %>
+          </fieldset>
         </div>
 
         <div class="col-md-6">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
       member do
         get :patients
         get :report
+        get :supplemental_test_artifact
       end
     end
   end
@@ -105,59 +106,4 @@ Rails.application.routes.draw do
   end
 
   get 'terms_and_conditions' => 'static_pages#terms_and_conditions'
-
-  # The priority is based upon order of creation: first created -> highest priority.
-  # See how all your routes lay out with "rake routes".
-
-  # You can have the root of your site routed with "root"
-  # root 'welcome#index'
-
-  # Example of regular route:
-  #   get 'products/:id' => 'catalog#view'
-
-  # Example of named route that can be invoked with purchase_url(id: product.id)
-  #   get 'products/:id/purchase' => 'catalog#purchase', as: :purchase
-
-  # Example resource route (maps HTTP verbs to controller actions automatically):
-  #   resources :products
-
-  # Example resource route with options:
-  #   resources :products do
-  #     member do
-  #       get 'short'
-  #       post 'toggle'
-  #     end
-  #
-  #     collection do
-  #       get 'sold'
-  #     end
-  #   end
-
-  # Example resource route with sub-resources:
-  #   resources :products do
-  #     resources :comments, :sales
-  #     resource :seller
-  #   end
-
-  # Example resource route with more complex sub-resources:
-  #   resources :products do
-  #     resources :comments
-  #     resources :sales do
-  #       get 'recent', on: :collection
-  #     end
-  #   end
-
-  # Example resource route with concerns:
-  #   concern :toggleable do
-  #     post 'toggle'
-  #   end
-  #   resources :posts, concerns: :toggleable
-  #   resources :photos, concerns: :toggleable
-
-  # Example resource route within a namespace:
-  #   namespace :admin do
-  #     # Directs /admin/products/* to Admin::ProductsController
-  #     # (app/controllers/admin/products_controller.rb)
-  #     resources :products
-  #   end
 end

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -84,7 +84,7 @@ Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   When the user creates a product with tasks c1
   And the user views task c1
   And the user uploads an invalid file
-  Then the user should see an error message saying the upload was invalid
+  Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
@@ -93,7 +93,7 @@ Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type
   When the user creates a product with tasks c2
   And the user views task c2
   And the user uploads an invalid file
-  Then the user should see an error message saying the upload was invalid
+  Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
@@ -204,7 +204,7 @@ Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type on Deprecate
   And the user views task c1
   Then the user should see a notification saying the product was deprecated
   And the user uploads an invalid file
-  Then the user should see an error message saying the upload was invalid
+  Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
@@ -215,7 +215,7 @@ Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type on Deprecate
   And the user views task c2
   Then the user should see a notification saying the product was deprecated
   And the user uploads an invalid file
-  Then the user should see an error message saying the upload was invalid
+  Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -23,9 +23,21 @@ Scenario: Unsuccessful Create Product Because No Name
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
+Scenario: Successful create Product with Supplemental Test Artifact
+  When the user creates a product with a correct supplemental test artifact
+  Then the user should see a notification saying the product was created
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
+
+Scenario: Successful create Product with Supplemental Test Artifact
+  When the user creates a product with a incorrect supplemental test artifact
+  Then the user should see an error message saying "You are not allowed to upload"
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
+
 Scenario: Unsuccessful Create Product Because Name Taken
   When the user creates two products with the same name
-  Then the user should see an error message saying the product name has been taken
+  Then the user should see an error message saying "name was already taken"
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -71,6 +71,25 @@ Scenario: Cannot Download Report when not an ATL
   And the user visits the product page
   Then the user should not be able to download the report
 
+Scenario: Cannot Download Supplemental Test Artifact when not an ATL
+  Given the user is signed in as a non admin
+  Given the user has created a vendor
+  Given the user is owner of the vendor
+  When a user creates a 2015 product with c2 certifications and a supplemental artifact and visits that product page
+  And all product tests have a state of ready
+  And the user visits the product page
+  Then the user should not be able to download the supplemental test artifact
+
+Scenario: Can Download a Supplemental Test Artifact
+  When a user creates a 2015 product with c2 certifications and a supplemental artifact and visits that product page
+  And all product tests have a state of ready
+  Then the user should be able to download the supplemental test artifact
+
+Scenario: Cannot Download a Supplemental Test Artifact when not uploaded
+  When a user creates a 2015 product with c2 certifications and visits that product page
+  And all product tests have a state of ready
+  Then the user should not be able to download the supplemental test artifact
+
 Scenario: Can Multi Upload Cat I
   When a user creates a 2015 product with c1, c2 certifications and visits that product page
   And all product tests have a state of ready

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -159,10 +159,6 @@ Then(/^the user should see test results$/) do
   assert_text 'Results'
 end
 
-Then(/^the user should see an error message saying the upload was invalid$/) do
-  assert_text 'Invalid file upload'
-end
-
 Then(/^the user should see a link to view the the uploaded xml$/) do
   page.find(:xpath, "//input[@value='View Uploaded XML with Errors']")
 end


### PR DESCRIPTION
This PR adds the ability for ATLs to upload a custom "Supplemental Test Artifact" which can be downloaded from the product page by all other ATLs and admin.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-140
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @laclark22
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code