### PR TITLE
Add Codecov uploader to Cucumber tests

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,12 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+require 'simplecov'
+SimpleCov.start
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
+
 ENV['IGNORE_ROLES'] ||= 'false'
 
 require 'cucumber/rails'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,7 +5,7 @@
 # files.
 
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start 'rails'
 
 require 'codecov'
 SimpleCov.formatter = SimpleCov::Formatter::Codecov


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

This Pull Request adds Codecov.io uploaders to the Cucumber test suite, so it will be used in coverage calculations.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code