### PR TITLE
Checklist test can utilize a Data Element's attributes

### DIFF
--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -22,9 +22,7 @@ module ChecklistTestsHelper
       dc_hash[dc.description] = dc_key
       # Store the original data source criteria and display string, makes sure you can reselect the orignal criteria
       # This is important for when the same criteria is used in multiple ways in the same measure
-      if dc.source_data_criteria == criteria.source_data_criteria
-        og_string = dc.description
-      end
+      og_string = dc.description if dc.source_data_criteria == criteria.source_data_criteria
     end
     dc_hash[og_string] = original_sdc
     Hash[dc_hash.sort]
@@ -63,6 +61,6 @@ module ChecklistTestsHelper
   end
 
   def direct_reference_code?(valueset)
-    valueset[0, 3] == 'drc' ? true : false
+    valueset[0, 3] == 'drc'
   end
 end

--- a/app/models/checklist_source_data_criteria.rb
+++ b/app/models/checklist_source_data_criteria.rb
@@ -62,9 +62,7 @@ class ChecklistSourceDataCriteria
     if attribute_code
       measure = Measure.find_by(_id: measure_id)
       criteria = measure[:source_data_criteria].select { |key| key == source_data_criteria }.values.first
-      valueset = if criteria[:attributes]
-                   [criteria[:attributes][attribute_index].attribute_valueset]
-                 end
+      valueset = [criteria[:attributes][attribute_index].attribute_valueset] if criteria[:attributes]
       self.attribute_complete = code_in_valuesets(valueset, attribute_code, measure.bundle_id)
     end
   end

--- a/app/models/checklist_source_data_criteria.rb
+++ b/app/models/checklist_source_data_criteria.rb
@@ -112,7 +112,7 @@ class ChecklistSourceDataCriteria
 
   # data_criteria is from the measure defintion, criteria is for the specific checklist test
   def compare_attributes(data_criteria, criteria)
-    return false if data_criteria['attributes'].nil?
+    return false unless data_criteria['attributes']
     data_criteria.attributes.include? criteria.attributes[attribute_index]
   end
 

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -66,9 +66,7 @@ class ChecklistTest < ProductTest
     code_indexes = []
     time_indexes = []
     attributes.each_with_index do |attribute, index|
-      if attribute['attribute_name'] == 'negationRationale'
-        code_indexes << index
-      elsif %(authorDatetime prevalencePeriod relevantPeriod).include? attribute['attribute_name']
+      if %(authorDatetime prevalencePeriod relevantPeriod).include? attribute['attribute_name']
         time_indexes << index
       else
         code_indexes << index

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -55,8 +55,27 @@ class ChecklistTest < ProductTest
     pass_count == criterias.count ? 'passed' : 'failed'
   end
 
-  def negate_valueset?(measure, criteria_key)
-    measure.hqmf_document[:data_criteria].select { |key| key == criteria_key }.values.first.negation
+  def negate_valueset?(measure, criteria_key, att_index)
+    return false unless att_index
+    measure[:source_data_criteria].select { |key| key == criteria_key }.values.first.attributes[att_index]['attribute_name'] == 'negationRationale'
+  end
+
+  def attribute_index?(measure, criteria_key)
+    attributes = measure[:source_data_criteria].select { |key| key == criteria_key }.values.first['attributes']
+    return nil if attributes.blank?
+    code_indexes = []
+    time_indexes = []
+    attributes.each_with_index do |attribute, index|
+      if attribute['attribute_name'] == 'negationRationale'
+        code_indexes << index
+      elsif %(authorDatetime prevalencePeriod relevantPeriod).include? attribute['attribute_name']
+        time_indexes << index
+      else
+        code_indexes << index
+      end
+    end
+    return code_indexes.sample unless code_indexes.empty?
+    return time_indexes.sample unless time_indexes.empty?
   end
 
   def create_checked_criteria
@@ -64,7 +83,6 @@ class ChecklistTest < ProductTest
     checklist_measures = []
     prng = Random.new(rand_seed.to_i)
 
-    # TODO: CQL: access criteria for measure using new measure model (throughout checklist_test below)
     # For each measure selected iterate on finding interesting data criteria
     measure_criteria_map, measure_ranks = criteria_map_and_measure_ranks(prng)
 
@@ -72,14 +90,15 @@ class ChecklistTest < ProductTest
     measure_ranks, max_num_checklist_measures = shuffle_top_measures(measure_ranks, prng)
 
     # create checked criteria
-    measure_ranks.reverse_each do |value|
-      next if checklist_measures.include? value[0].hqmf_id # skip submeasures
+    measure_ranks.reverse_each do |measure, _rank|
+      measure.reload
+      next if checklist_measures.include? measure.hqmf_id # skip submeasures
       next if checklist_measures.size > max_num_checklist_measures - 1 # skip if four checklist measures already exist
-      checklist_measures << value[0].hqmf_id
-      measure_criteria_map[value[0]].each do |criteria_key|
-        checked_criterias.push(measure_id: value[0].id.to_s,
-                               source_data_criteria: criteria_key,
-                               negated_valueset: negate_valueset?(value[0], criteria_key))
+      checklist_measures << measure.hqmf_id
+      measure_criteria_map[measure].each do |criteria_key|
+        att_index = attribute_index?(measure, criteria_key)
+        checked_criterias.push(measure_id: measure.id.to_s, source_data_criteria: criteria_key, attribute_index: att_index,
+                               negated_valueset: negate_valueset?(measure, criteria_key, att_index))
       end
     end
 

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -37,7 +37,7 @@
             <tbody>
               <% product_test.checked_criteria.all(measure_id: measure.id).each.with_index do |checked_criteria,index| %>
                 <%= f.fields_for :checked_criteria, checked_criteria do |criteria_field| %>
-                  <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
+                  <% criteria = measure[:source_data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
                   <% if criteria.key?('description') %>
                     <tr>
                       <td rowspan="3" class='data-criteria hide-me'>
@@ -73,7 +73,7 @@
                                 <ul class="value-set-list">
                                   <% valuessets.each do |vs| %>
                                   <li class="value-set-item-header"><%= "#{lookup_valueset_name(vs)}" %></li>
-                                  <li class="value-set-item-oid"><%= vs %></li>
+                                  <li class="value-set-item-oid"><%= direct_reference_code?(vs) ? '' : vs %></li>
                                   <% end %>
                                 </ul>
                               </div>
@@ -98,7 +98,7 @@
                               <%= criteria_field.text_field :code, hide_label: false, class: 'hide-me' %>
                             <% end %>
                           </td>
-                          <% if criteria.negation %>
+                          <% if checked_criteria.attribute_index && criteria['attributes'][checked_criteria.attribute_index]['attribute_name'] == "negationRationale" %>
                           <td class='show-me' style='display: none;'>
                             <%= criteria_field.check_box :negated_valueset, label_class: 'label toggle', onclick: "lookupLabelFunction(#{criteria_field.index})" do %>
                               <div class="toggle-control"></div>
@@ -120,11 +120,11 @@
                       <% end %>
                       <tr>
                         <td> <strong> Attributes </strong> </td>
-                        <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
+                        <td><%= checklist_test_criteria_attribute(criteria, checked_criteria.attribute_index) %></td>
                         <td>
-                          <%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value'], product_test: product_test, index: criteria_field.index, disable_modal: false } if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %>
+                          <%= render partial: 'checklist_tests/field_values', locals: { attribute: criteria['attributes'][checked_criteria.attribute_index], result: criteria['value'], product_test: product_test, index: criteria_field.index, disable_modal: false } if criteria['attributes'] || criteria['value'] %>
                         </td>
-                        <% if coded_attribute?(criteria) %>
+                        <% if coded_attribute?(criteria, checked_criteria.attribute_index) %>
                           <td class='hide-me'>
                             <% if criteria_field.object.complete?.nil? %>
                               <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
@@ -135,7 +135,7 @@
                             <% end %>
                             <%= criteria_field.text_field :attribute_code, hide_label: false, class: 'hide-me' %>
                           </td>
-                        <% elsif criteria['value'] && criteria['value'].type != 'CD' || criteria['field_values'] %>
+                        <% elsif criteria['value'] && criteria['value'].type != 'CD' || criteria['attributes'] %>
                           <td class='hide-me'>
                             <% if criteria_field.object.complete?.nil? %>
                               <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>

--- a/app/views/checklist_tests/_field_values.html.erb
+++ b/app/views/checklist_tests/_field_values.html.erb
@@ -2,69 +2,50 @@
 
 # local variables
 #
-#   field_values   (Hash)
+#   attributes   (Hash)
 #   product_test (ChecklistTest)
 
 %>
 <% if disable_modal %>
-  <% if negation %>
-    <%= "#{lookup_valueset_name(negation)}" %>
-  <% elsif result %>
+  <% if result %>
     <% if result.type == 'CD' && result['code_list_id'] %>
       <%= "#{lookup_valueset_name(result.code_list_id)}" %>
     <% end %>
   <% else %>
-    <% field_values.each do |fv_key, fv_val| %>
-      <% case fv_val['type'] %>
-      <% when 'CD' %>
-        <%= "#{fv_val['title']}: #{fv_val['code_list_id']}" %>
-      <% when 'IVL_PQ' %>
-        <%= raw length_of_stay_string(fv_val) %>
+      <% if attribute['attribute_valueset'] %>
+        <%= "#{attribute['attribute_name']}: #{attribute['attribute_valueset']}" %>
+      <% else %>
+        <%= attribute['attribute_name'] %>
       <% end %>
-    <%end%>
   <% end %>
 <% else %>
-  <% if negation %>
-  <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal-negation#{index}" %>">
-    <ul class="value-set-list">
-     <li class="value-set-item-header"><%= "#{lookup_valueset_name(negation)}" %></li>
-     <li class="value-set-item-oid"><%= negation %> </li>
-   </ul>
-  </div>
-  <div id="<%= "lookupModal-negation#{index}" %>" class="modal fade" role="dialog">
-    <%= render 'checklist_modal', :valuessets => [negation], :product_test => product_test, :index => index, :is_attribute => true %>
-  </div>
-  <% elsif result %>
-  <% if result.type == 'CD' && result['code_list_id'] %>
-  <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal-result#{index}" %>">
-    <ul class="value-set-list">
-     <li class="value-set-item-header"><%= "#{lookup_valueset_name(result.code_list_id)}" %></li>
-     <li class="value-set-item-oid"><%= result.code_list_id %></li>
-   </ul>
-  </div>
-  <div id="<%= "lookupModal-result#{index}" %>" class="modal fade" role="dialog">
-    <%= render 'checklist_modal', :valuessets => [result.code_list_id], :product_test => product_test, :index => index, :is_attribute => true %>
-  </div>
-  <% end %>
+  <% if result %>
+    <% if result.type == 'CD' && result['code_list_id'] %>
+    <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal-result#{index}" %>">
+      <ul class="value-set-list">
+       <li class="value-set-item-header"><%= "#{lookup_valueset_name(result.code_list_id)}" %></li>
+       <li class="value-set-item-oid"><%= result.code_list_id %></li>
+     </ul>
+    </div>
+    <div id="<%= "lookupModal-result#{index}" %>" class="modal fade" role="dialog">
+      <%= render 'checklist_modal', :valuessets => [result.code_list_id], :product_test => product_test, :index => index, :is_attribute => true %>
+    </div>
+    <% end %>
   <% else %>
-  <% field_values.each do |fv_key, fv_val| %>
-  <% case fv_val['type'] %>
-  <% when 'CD' %>
-  <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal-fieldvalues#{index}" %>">
-   <ul class="value-set-list">
-    <li class="value-set-item-header"><%= "#{fv_val['title']}" %></li>
-    <li class="value-set-item-oid"><%= "#{fv_val['code_list_id']}" %></li>
-  </ul>
-  </div>
-  <div id="<%= "lookupModal-fieldvalues#{index}" %>" class="modal fade" role="dialog">
-    <%= render 'checklist_modal', :valuessets => [fv_val['code_list_id']], :product_test => product_test, :index => index, :is_attribute => true %>
-  </div>
-
-  <% when 'IVL_PQ' %>
-  <ul class="value-set-list">
-    <li class="value-set"><%= raw length_of_stay_string(fv_val) %></li>
-  </ul>
-  <% end %>
-  <%end%>
+      <% if  attribute['attribute_valueset'] %>
+        <div type="button" class="value-set-group set-menu" data-toggle="modal" data-target="<%= "#lookupModal-fieldvalues#{index}" %>">
+         <ul class="value-set-list">
+          <li class="value-set-item-header"><%= "#{attribute['attribute_name']}" %></li>
+          <li class="value-set-item-oid"><%= "#{attribute['attribute_valueset']}" %></li>
+        </ul>
+        </div>
+        <div id="<%= "lookupModal-fieldvalues#{index}" %>" class="modal fade" role="dialog">
+          <%= render 'checklist_modal', :valuessets => [attribute['attribute_valueset']], :product_test => product_test, :index => index, :is_attribute => true %>
+        </div>
+      <% else %>
+        <ul class="value-set-list">
+          <li class="value-set"><%= attribute['attribute_name'] %></li>
+        </ul>
+      <% end %>
   <% end %>
 <% end %>

--- a/app/views/checklist_tests/print_criteria.html.erb
+++ b/app/views/checklist_tests/print_criteria.html.erb
@@ -44,7 +44,7 @@
                             </ul>
                           </span></td>
                         <% end %>
-                        <td style="vertical-align:top"><%= checklist_test_criteria_attribute(criteria, checked_criteria.attribute_index) %></td>
+                        <td style="vertical-align:top"><%= checklist_test_criteria_attribute(criteria, criteria_field.object.attribute_index) %></td>
                         <td style="vertical-align:top"><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], result: criteria['value'], disable_modal: true } if criteria['attributes'] || criteria['value'] %></td>
                       </tr>
                     <% end %>

--- a/app/views/checklist_tests/print_criteria.html.erb
+++ b/app/views/checklist_tests/print_criteria.html.erb
@@ -27,7 +27,7 @@
                 </thead>
                 <tbody>
                   <%= f.fields_for :checked_criteria, checklist_test.checked_criteria.all(measure_id: measure.id) do |criteria_field| %>
-                    <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
+                    <% criteria = measure[:source_data_criteria].select { |key, value| key == criteria_field.object.source_data_criteria }.values.first %>
                     <% if criteria.key?('description') %>
                       <tr>
                         <% valuessets = criteria_field.object.get_all_valuesets_for_dc(measure) %>
@@ -44,8 +44,8 @@
                             </ul>
                           </span></td>
                         <% end %>
-                        <td style="vertical-align:top"><%= checklist_test_criteria_attribute(measure, criteria) %></td>
-                        <td style="vertical-align:top"><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], negation: criteria['negation_code_list_id'], result: criteria['value'], disable_modal: true } if criteria['field_values'] || criteria['negation_code_list_id'] || criteria['value'] %></td>
+                        <td style="vertical-align:top"><%= checklist_test_criteria_attribute(criteria, checked_criteria.attribute_index) %></td>
+                        <td style="vertical-align:top"><%= render partial: 'checklist_tests/field_values', locals: { field_values: criteria['field_values'], result: criteria['value'], disable_modal: true } if criteria['attributes'] || criteria['value'] %></td>
                       </tr>
                     <% end %>
                   <% end %>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -115,11 +115,11 @@
           <tbody>
             <% # check_crit is an individual checked criteria %>
             <% check_test.checked_criteria.all(measure_id: measure.id).each do |check_crit| %>
-              <% criteria = measure.hqmf_document[:data_criteria].select { |key, value| key == check_crit.source_data_criteria }.values.first %>
+              <% criteria = measure[:source_data_criteria].select { |key, value| key == check_crit.source_data_criteria }.values.first %>
               <tr>
                 <td><%= render partial: 'products/report/status_icon', locals: { passing: check_crit.complete? } %></td>
                 <td><%= criteria[:description].chomp(': ' + criteria[:title]) %></td>
-                <td><%= checklist_test_criteria_attribute(check_crit.attribute_index, criteria) %></td>
+                <td><%= checklist_test_criteria_attribute(criteria, check_crit.attribute_index) %></td>
               </tr>
             <% end %>
           </tbody>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -119,7 +119,7 @@
               <tr>
                 <td><%= render partial: 'products/report/status_icon', locals: { passing: check_crit.complete? } %></td>
                 <td><%= criteria[:description].chomp(': ' + criteria[:title]) %></td>
-                <td><%= checklist_test_criteria_attribute(measure, criteria) %></td>
+                <td><%= checklist_test_criteria_attribute(check_crit.attribute_index, criteria) %></td>
               </tr>
             <% end %>
           </tbody>

--- a/lib/cypress/data_criteria_selector.rb
+++ b/lib/cypress/data_criteria_selector.rb
@@ -3,19 +3,21 @@ module Cypress
     def data_criteria_selector(measure, prng)
       # Criterias to be used in C1 checklist
       criterias = []
-      # Possible data criterias that don't have attributes or negations
+      # Possible data criterias that don't have attributes
       data_criteria_without_att = {}
       # Criteria types in C1 checklist
       criteria_types = []
-      all_data_criteria = measure.all_data_criteria.shuffle(random: prng)
-      dcs_with_attribute = all_data_criteria.clone.keep_if(&:field_values)
+      # Clone and strip out data criteria with the negation field.  Negations are now tracked with attributes
+      all_data_criteria = measure[:source_data_criteria].clone.keep_if { |_key, sdc| sdc['negation'] == false }
+      dcs_with_attribute = measure[:source_data_criteria].clone
+      dcs_with_attribute.keep_if { |_k, data_criteria| coded_attributes?(data_criteria) }
       # Loads list of value sets for the measure in question
       measure.oids.each do |oid|
         currnet_count = dcs_with_attribute.size
-        match_field_values(dcs_with_attribute, oid, criterias, data_criteria_without_att, criteria_types)
+        match_attributes(dcs_with_attribute, oid, criterias, data_criteria_without_att, criteria_types)
         # If a DC with attribute is found, go to next
         next if dcs_with_attribute.size > currnet_count
-        match_data_criteria(all_data_criteria, oid, criterias, data_criteria_without_att, criteria_types)
+        match_data_criteria(all_data_criteria, oid, data_criteria_without_att, criteria_types)
       end
       # number of data criteria with attributes or negations
       interesting_criteria = criterias.size
@@ -24,30 +26,32 @@ module Cypress
       [criterias, interesting_criteria]
     end
 
+    def coded_attributes?(data_criteria)
+      if data_criteria['attributes']
+        data_criteria['attributes'].keep_if { |av| av['attribute_valueset'] }.empty? ? false : true
+      else
+        false
+      end
+    end
+
     # Matches a data criteria coded field value with provided data_criteria_value
-    def match_field_values(data_criterias, data_criteria_value, selected_dc, data_criteria_without_att, criteria_types)
-      data_criterias.each do |dc|
-        key = dc.field_values.keys[0]
-        next unless dc.field_values[key].type == 'CD' && dc.field_values[key].code_list_id == data_criteria_value && criteria_types.exclude?(dc.type)
-        selected_dc << dc.id
-        criteria_types << dc.type
-        data_criteria_without_att.delete(dc.type) if data_criteria_without_att.key?(dc.type)
+    def match_attributes(data_criterias, data_criteria_value, selected_dc, data_criteria_without_att, criteria_types)
+      data_criterias.each do |dc_key, dc_value|
+        next unless dc_value['attributes']
+        next if dc_value['attributes'].map { |av| av['attribute_valueset'] == data_criteria_value ? true : nil }.compact.empty?
+        next if criteria_types.include? dc_value.type
+        selected_dc << dc_key
+        criteria_types << dc_value.type
+        data_criteria_without_att.delete(dc_value.type) if data_criteria_without_att.key?(dc_value.type)
       end
     end
 
     # Matches a data criteria code set or negation code set
-    def match_data_criteria(data_criterias, data_criteria_value, selected_dc, data_criteria_without_att, criteria_types)
-      data_criterias.each do |dc|
+    def match_data_criteria(data_criterias, data_criteria_value, data_criteria_without_att, criteria_types)
+      data_criterias.each do |dc_key, dc_value|
         # If the criterias being tested do not already include the current data criteria type
-        next unless criteria_types.exclude?(dc.type) && (dc.code_list_id == data_criteria_value || dc.negation_code_list_id == data_criteria_value)
-        # If the criteria has a negation or field_value, it is selected
-        # If not, it is put in a hash for possible inclusion in data criteria
-        if dc.negation_code_list_id == data_criteria_value || dc.field_values
-          selected_dc << dc.id
-          criteria_types << dc.type
-        else
-          data_criteria_without_att[dc.type] = dc.id
-        end
+        next unless criteria_types.exclude?(dc_value.type) && (dc_value['code_list_id'] == data_criteria_value)
+        data_criteria_without_att[dc_value.type] = dc_key
       end
     end
   end

--- a/lib/validators/attribute_extractor.rb
+++ b/lib/validators/attribute_extractor.rb
@@ -1,15 +1,11 @@
 module Validators
   module AttributeExtractor
     XPATH_CONSTS = {
-      'ADMISSION_DATETIME' => './cda:effectiveTime/cda:low',
-      'CUMULATIVE_MEDICATION_DURATION' => './../../../cda:doseQuantity or ./../../../cda:repeatNumber',
-      'DISCHARGE_DATETIME' => './cda:effectiveTime/cda:high or ./../../../cda:effectiveTime/cda:high',
-      'FACILITY_LOCATION_ARRIVAL_DATETIME' => "./cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]/cda:time/cda:low",
-      'FACILITY_LOCATION_DEPARTURE_DATETIME' => "./cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]/cda:time/cda:high",
-      'FLFS' => "./sdtc:inFulfillmentOf1/sdtc:templateId[@root='2.16.840.1.113883.10.20.24.3.126']",
-      'INCISION_DATETIME' => "./cda:entryRelationship/cda:procedure[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.89']]/cda:effectiveTime",
-      'LENGTH_OF_STAY' => './cda:effectiveTime[./cda:low and ./cda:high]',
-      'START_DATETIME' => "./cda:author[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.119']]/cda:time"
+      'relevantPeriod' => './cda:effectiveTime/cda:low',
+      'prevalencePeriod' => './cda:effectiveTime/cda:low',
+      'authorDatetime' => "../../..//cda:author[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.155']]/cda:time",
+      'relatedTo' => "./sdtc:inFulfillmentOf1/sdtc:templateId[@root='2.16.840.1.113883.10.20.24.3.126']",
+      'resultDatetime' => "./cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.2']]/cda:effectiveTime"
     }.freeze
 
     # does a node need to be checked for an atttibute value
@@ -19,32 +15,35 @@ module Validators
       cc = checked_criteria
       # don't check for an attribute if there isn't a attribute or result, or there is a reason
       # check for an attribute, if there is an attribute or result, and there isn't a reason
-      if (cc.attribute_complete.nil? && cc.result_complete.nil?) || source_criteria_has_reason(sc)
+      if (cc.attribute_complete.nil? && cc.result_complete.nil?) || source_criteria_has_reason(sc, checked_criteria.attribute_index)
         false
-      elsif (!cc.attribute_complete.nil? || !cc.result_complete.nil?) && !source_criteria_has_reason(sc)
+      elsif (!cc.attribute_complete.nil? || !cc.result_complete.nil?) && !source_criteria_has_reason(sc, checked_criteria.attribute_index)
         true
       end
     end
 
     # searches a node for the existance of the attribute criteria, each field_value has a xpath relative to the template root
-    def find_attribute_values(node, code, source_criteria)
+    def find_attribute_values(node, code, source_criteria, index)
       # xpath expressions with codes
       xpath_map = {
-        'DIAGNOSIS' => "./cda:entryRelationship/cda:act[./cda:code[@code='29308-4']]/cda:entryRelationship
-                       /cda:observation/cda:value[@code='#{code}']", 'ORDINALITY' => "./cda:priorityCode[@code='#{code}']",
-        'DISCHARGE_STATUS' => "./sdtc:dischargeDispositionCode[@code='#{code}']", # CMS31v5
-        'FACILITY_LOCATION' => "./cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]
-                               /cda:participantRole/cda:code[@code='#{code}']", 'ROUTE' => "../../../cda:routeCode[@code='#{code}']",
-        'LATERALITY' => "./cda:value/cda:qualifier[./cda:name/@code='182353008']/cda:value[@code='#{code}']",
-        'ORDINAL' => "./cda:entryRelationship/cda:observation[./cda:code[@code='260870009']]/cda:value[@code='#{code}']
-                     or ./cda:priorityCode[@code='#{code}']", 'ANATOMICAL_LOCATION_SITE' => "./cda:targetSiteCode[@code='#{code}']",
-        'PRINCIPAL_DIAGNOSIS' => "./cda:entryRelationship/cda:observation[./cda:code[@code='8319008']]/cda:value[@code='#{code}']", # CMS188v6
-        'SEVERITY' => "./cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.8']]/cda:value[@code='#{code}']"
+        'components' => "./cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.149]/cda:code[@code='#{code}']",
+        'diagnoses' => "./cda:entryRelationship/cda:act[./cda:code[@code='29308-4']]/cda:entryRelationship
+                       /cda:observation/cda:value[@code='#{code}']",
+        'dischargeDisposition' => "./sdtc:dischargeDispositionCode[@code='#{code}']", # CMS31v5
+        'facilityLocations' => "./cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]
+                               /cda:participantRole/cda:code[@code='#{code}']",
+        'admissionSource' => "./cda:participant/cda:participantRole[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.151']]
+                             /cda:code[@code='#{code}']",
+        'route' => "../../../cda:routeCode[@code='#{code}']",
+        'ordinality' => "./cda:entryRelationship/cda:observation[./cda:code[@code='260870009']]/cda:value[@code='#{code}']
+                     or ./cda:priorityCode[@code='#{code}']", 'anatomicalLocationSite' => "./cda:targetSiteCode[@code='#{code}']",
+        'principalDiagnosis' => "./cda:entryRelationship/cda:observation[./cda:code[@code='8319008']]/cda:value[@code='#{code}']", # CMS188v6
+        'severity' => "./cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.8']]/cda:value[@code='#{code}']"
       }
       # XPATH_CONSTS are the expressions without codes
       xpath_map.merge!(XPATH_CONSTS)
-      if source_criteria['field_values']
-        return node.xpath(xpath_map[source_criteria.field_values.keys[0]]).blank? ? false : true
+      if source_criteria['attributes']
+        return node.xpath(xpath_map[source_criteria.attributes[index].attribute_name]).blank? ? false : true
       end
       false
     end

--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -28,18 +28,16 @@ module Validators
 
     def validate_criteria(checked_criteria)
       measure = Measure.find_by(_id: checked_criteria.measure_id)
-      sdc = measure.hqmf_document[:data_criteria].select { |key| key == checked_criteria.source_data_criteria }.values.first
+      sdc = measure[:source_data_criteria].select { |key| key == checked_criteria.source_data_criteria }.values.first
       hqmf_oid = HQMF::DataCriteria.template_id_for_definition(sdc['definition'], sdc['status'], sdc['negation'])
       hqmf_oid ||= HQMF::DataCriteria.template_id_for_definition(sdc['definition'], sdc['status'], sdc['negation'], 'r2')
       # demographics do not have an associated template
       if ['2.16.840.1.113883.3.560.1.406', '2.16.840.1.113883.3.560.1.403', '2.16.840.1.113883.3.560.1.402'].include?(hqmf_oid)
         validate_demographics(hqmf_oid, checked_criteria)
       else
-        template = HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_oid(hqmf_oid, 'r3_1').split('_').first
-        # find valuesets relevant to the data criteria
-        valuesets = checked_criteria.get_all_valuesets_for_dc(checked_criteria.measure_id)
+        template = HealthDataStandards::Export::QRDA::EntryTemplateResolver.qrda_oid_for_hqmf_oid(hqmf_oid, 'r5').split('_').first
         # find all nodes that fulfill the data criteria, this is defined in checklist result extractor
-        find_dc_node(template, valuesets, checked_criteria, sdc)
+        find_dc_node(template, checked_criteria, sdc)
       end
     end
 

--- a/lib/validators/checklist_result_extractor.rb
+++ b/lib/validators/checklist_result_extractor.rb
@@ -3,27 +3,19 @@ module Validators
     include Validators::AttributeExtractor
 
     # find all nodes that fulfill the data criteria
-    def find_dc_node(template, valuesets, checked_criteria, source_criteria)
+    def find_dc_node(template, checked_criteria, source_criteria)
       passing = false
       # find nodes to search for the criteria
       reason_template, nodes = template_nodes(source_criteria, checked_criteria)
       # if the checked criteria has a code, the code and attributes will be checked
       # if the checked criteria does not have a code (e.g. Transfers), on the attiributes will be checked
       if checked_criteria.code || checked_criteria.negated_valueset
-        # a codenode is a node, that includes the appropriate code
-        codenodes = []
-        # looks through every valueset associated with the source data criteria
-        valuesets.each do |valueset|
-          # once you find a matching node, you can stop
-          next unless codenodes.empty?
-          # If there is a negation, search for the code within the template
-          codenodes = find_template_with_code(nodes, template, valueset, checked_criteria, reason_template)
-          # When you get nodes that include a code, determine if it meets additinal criteria
-          passing = passing_dc?(codenodes, source_criteria, checked_criteria)
-        end
+        neg_vs = checked_criteria.negated_valueset ? checked_criteria['selected_negated_valueset'] : nil
+        codenodes = find_template_with_code(nodes, template, checked_criteria, reason_template, neg_vs)
+        # When you get nodes that include a code, determine if it meets additinal criteria
+        passing = passing_dc?(codenodes, source_criteria, checked_criteria)
       elsif checked_criteria.attribute_code # CMS188v6
-        valueset = source_criteria[:field_values].values[0].code_list_id
-        codenodes = find_template_with_attribute([@file], template, valueset, checked_criteria.attribute_code)
+        codenodes = find_template_with_attribute([@file], template, checked_criteria.attribute_code)
         passing = true unless codenodes.empty?
       end
       if passing
@@ -50,22 +42,22 @@ module Validators
       # if the attribute is a result that isn't a code
       # if the attribute is a result that is a code
       # if the attribute is defined as a field value
-      if source_criteria['value'] && source_criteria['value']['type'] != 'CD'
-        node.xpath('./cda:value').blank? ? false : true
-      elsif source_criteria['value'] && source_criteria['value']['type'] == 'CD'
-        result_xpath = "./cda:value[@code='#{checked_criteria.attribute_code}'] or ./cda:entryRelationship[@typeCode='REFR']" \
-                       "/cda:observation/cda:value[@code='#{checked_criteria.attribute_code}']"
-        node.xpath(result_xpath).blank? ? false : true
+      if source_criteria.attributes[checked_criteria.attribute_index]['attribute_name'] == 'result'
+        if source_criteria.attributes[checked_criteria.attribute_index]['attribute_valueset']
+          result_xpath = "./cda:value[@code='#{checked_criteria.attribute_code}'] or ./cda:entryRelationship[@typeCode='REFR']" \
+                         "/cda:observation/cda:value[@code='#{checked_criteria.attribute_code}']"
+          node.xpath(result_xpath).blank? ? false : true
+        else
+          node.xpath('./cda:value').blank? ? false : true
+        end
       else
-        find_attribute_values(node, checked_criteria.attribute_code, source_criteria)
+        find_attribute_values(node, checked_criteria.attribute_code, source_criteria, checked_criteria.attribute_index)
       end
     end
 
     # returns true if source criteria has a reason (or negation)
-    def source_criteria_has_reason(source_criteria)
-      if source_criteria['negation']
-        true
-      elsif source_criteria['field_values'] && source_criteria['field_values'].keys[0] == 'REASON'
+    def source_criteria_has_reason(source_criteria, index)
+      if source_criteria['attributes'] && (%w[reason negationRationale].include? source_criteria['attributes'][index].attribute_name)
         true
       else
         false
@@ -79,37 +71,36 @@ module Validators
       cc = checked_criteria
       # if the source criteria does not have a reason, the whole document is returned to search
       # if the source criteria has a reason, return the list of nodes with the correction reason value set
-      return false, [@file] unless source_criteria_has_reason(sc)
+      return false, [@file] unless source_criteria_has_reason(sc, checked_criteria.attribute_index)
       # get valueset from the negation code list or field_values
-      valueset = sc['negation'] ? sc['negation_code_list_id'] : sc.field_values['REASON'].code_list_id
       [true, @file.xpath("//cda:templateId[@root='2.16.840.1.113883.10.20.24.3.88']
-        /..//*[@sdtc:valueSet='#{valueset}' and @code='#{cc.attribute_code}']")]
+        /..//*[@code='#{cc.attribute_code}']")]
     end
 
     # searches all nodes to find ones with the correct template, valueset and code
     # cc is short for Checked_Criteria
-    def find_template_with_code(nodes, template, valueset, cc, reason_template)
-      return find_reason_code(nodes, template, valueset, cc) if reason_template
+    def find_template_with_code(nodes, template, cc, reason_template, negation_valueset = nil)
+      return find_reason_code(nodes, template, cc, negation_valueset) if reason_template
       # if it isn't a reason, the file node is the first
-      codenodes = nodes.first.xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @code='#{cc.code}']")
+      codenodes = nodes.first.xpath("//cda:templateId[@root='#{template}']/..//*[@code='#{cc.code}']")
       codenodes || []
     end
 
     # searches all nodes to find ones with the correct template, valueset and attribute code
-    def find_template_with_attribute(nodes, template, valueset, attribute_code)
-      codenodes = nodes.first.xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @code='#{attribute_code}']")
+    def find_template_with_attribute(nodes, template, attribute_code)
+      codenodes = nodes.first.xpath("//cda:templateId[@root='#{template}']/..//*[@code='#{attribute_code}']")
       codenodes || []
     end
 
     # cc is short for Checked_Criteria
-    def find_reason_code(nodes, template, valueset, cc)
+    def find_reason_code(nodes, template, cc, valueset)
       # Return node once a matching node is found
       nodes.each do |node|
-        cn = if cc.negated_valueset
-               node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @nullFlavor='NA']")
-             else
-               node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @code='#{cc.code}']")
-             end
+        if cc.negated_valueset
+          cn = node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @nullFlavor='NA']")
+        else
+          cn = node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@code='#{cc.code}']")
+        end
         return [cn] unless cn.nil?
       end
       []

--- a/lib/validators/checklist_result_extractor.rb
+++ b/lib/validators/checklist_result_extractor.rb
@@ -96,11 +96,11 @@ module Validators
     def find_reason_code(nodes, template, cc, valueset)
       # Return node once a matching node is found
       nodes.each do |node|
-        if cc.negated_valueset
-          cn = node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @nullFlavor='NA']")
-        else
-          cn = node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@code='#{cc.code}']")
-        end
+        cn = if cc.negated_valueset
+               node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@sdtc:valueSet='#{valueset}' and @nullFlavor='NA']")
+             else
+               node.parent.parent.parent.at_xpath("//cda:templateId[@root='#{template}']/..//*[@code='#{cc.code}']")
+             end
         return [cn] unless cn.nil?
       end
       []


### PR DESCRIPTION
The Checklist tests have been updated to longer rely on an elements "Field Values."  Moving foward, will use a Data Criteria's attributes (which will be in the measure bundle)

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code