### PR TITLE
Pass in patient and measures ids when sync_job is called, not during …

### DIFF
--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -7,10 +7,9 @@ class ProductTestSetupJob < ApplicationJob
     #TODO R2P: records to patients name
     product_test.generate_patients(@job_id) if product_test.patients.count.zero?
     # product_test.pick_filter_criteria if product_test.is_a? FilteringTest #TODO R2P: priority 4
-    calc_job = Cypress::JsEcqmCalc.new(product_test.patients.map { |rec| rec._id.to_s },
-                                       product_test.measures.map { |mes| mes._id.to_s },
-                                       { 'correlation_id': product_test._id.to_s } )
-    calc_job.sync_job
+    calc_job = Cypress::JsEcqmCalc.new({ 'correlation_id': product_test._id.to_s })
+    calc_job.sync_job(product_test.patients.map { |rec| rec._id.to_s }, product_test.measures.map { |mes| mes._id.to_s })
+    calc_job.stop
     # TODO support calculation for a filtered test deck
     # if product_test.respond_to? :patient_cache_filter
     #   MeasureEvaluationJob.perform_now(product_test, 'filters' => product_test.patient_cache_filter)

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -69,8 +69,9 @@ module Validators
       record = parse_and_save_record(doc, te, options)
       return false unless record
       # This Logic will need to be updated with CQL calculations
-      calc_job = Cypress::JsEcqmCalc.new([record.id.to_s], @measures.map { |mes| mes._id.to_s }, { 'correlation_id': options.test_execution.id.to_s } )
-      calc_job.sync_job
+      calc_job = Cypress::JsEcqmCalc.new({ 'correlation_id': options.test_execution.id.to_s })
+      calc_job.sync_job([record.id.to_s], @measures.map { |mes| mes._id.to_s })
+      calc_job.stop
       @measures.each do |measure|
         original_results = QDM::IndividualResult.where('patient_id' => mrn, 'measure_id' => measure.id)
         new_results = QDM::IndividualResult.where('patient_id' => record.id, 'measure_id' => measure.id, 'extendedData.correlation_id' => options.test_execution.id.to_s)


### PR DESCRIPTION
…init



**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name: Robert
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code