### PR TITLE
Shift dates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'os'
 
 gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patientapi', branch: 'better_codes_and_scalar_error'
 gem 'cqm-converter'
-gem 'cqm-models', :git => 'https://github.com/projecttacoma/cqm-models', :branch => 'shift_dates'
+gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'results_object'
 
 gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'r5'
 # gem 'health-data-standards', '~> 3.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -54,8 +54,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-models
-  revision: 476ec2a97b885ba793bb8bc5c85399c581ed1535
-  branch: shift_dates
+  revision: 024f6158416665207ba11c0986a6ea842435b881
+  branch: results_object
   specs:
     cqm-models (0.7.4)
 

--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -7,10 +7,7 @@ class ProductTestSetupJob < ApplicationJob
     # TODO: R2P: records to patients name
     product_test.generate_patients(@job_id) if product_test.patients.count.zero?
     # product_test.pick_filter_criteria if product_test.is_a? FilteringTest #TODO R2P: priority 4
-    calc_job = Cypress::JsEcqmCalc.new({ 'correlation_id': product_test._id.to_s,
-                                         'effective_date': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number) } )
-    calc_job.sync_job(product_test.patients.map { |rec| rec._id.to_s }, product_test.measures.map { |mes| mes._id.to_s })
-    calc_job.stop
+    do_calculation(product_test)
     # TODO: support calculation for a filtered test deck
     # if product_test.respond_to? :patient_cache_filter
     #   MeasureEvaluationJob.perform_now(product_test, 'filters' => product_test.patient_cache_filter)
@@ -24,5 +21,12 @@ class ProductTestSetupJob < ApplicationJob
     product_test.status_message = e.message
     product_test.errored
     product_test.save!
+  end
+
+  def do_calculation(product_test)
+    calc_job = Cypress::JsEcqmCalc.new('correlation_id': product_test._id.to_s,
+                                       'effective_date': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number))
+    calc_job.sync_job(product_test.patients.map { |rec| rec._id.to_s }, product_test.measures.map { |mes| mes._id.to_s })
+    calc_job.stop
   end
 end


### PR DESCRIPTION
Same as previous pull request- adds gemfile updates and rubocop fixes


Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code