### PR TITLE
Calculate query cache continuous variable values if present

### DIFF
--- a/lib/cypress/expected_results_calculator.rb
+++ b/lib/cypress/expected_results_calculator.rb
@@ -43,7 +43,7 @@ module Cypress
 
         observ_values.concat get_observ_values(ir.episode_results)
       end
-      @measure_result_hash[measure.key]['OBSERV'] = median(observ_values)
+      @measure_result_hash[measure.key]['OBSERV'] = median(observ_values.reject(&:nil?))
       @measure_result_hash[measure.key]['measure_id'] = measure.hqmf_id
       @measure_result_hash[measure.key]['population_ids'] = measure.population_ids
       create_query_cache_object(@measure_result_hash[measure.key], measure)


### PR DESCRIPTION
This pull request adds functionality to `ExpectedResultsCalculator` to calculate `OBSERV` values for Continuous Variable measures.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-234
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code