### PR TITLE
Update cqm-parser version.  API measure evalutor limited to cat 1 upl…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: 0c7785a4b41ff91bb5a1faf0dc0b17d027c464c1
+  revision: df91818d9a51eb5a29a39800009f69edd8dbc98a
   branch: qrda
   specs:
     cqm-parsers (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: df91818d9a51eb5a29a39800009f69edd8dbc98a
+  revision: fe33d7c2a4b7b9bcf226ecadea920e752332fab0
   branch: qrda
   specs:
     cqm-parsers (1.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers
-  revision: fe33d7c2a4b7b9bcf226ecadea920e752332fab0
+  revision: a4ab5c6b5dbfa565970fa2aa358b8988efb754a5
   branch: qrda
   specs:
     cqm-parsers (1.0.0)

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -44,7 +44,7 @@ class ChecklistTest < ProductTest
       end
       Measure.where(:_id.in => m_ids)
     else
-      super
+      bundle.measures.in(:hqmf_id => measure_ids.sample(50))
     end
   end
 

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -86,12 +86,12 @@ module Cypress
       @patient_links_task_hash.each do |patient_links|
         calcuate_cat_3(patient_links[0].split('/')[2], bundle_id)
         upload_test_execution(extract_test_execution_link(patient_links[1], 'C1'), patient_links[0].split('/')[2], true) unless skip_c1_test
-        upload_test_execution(extract_test_execution_link(patient_links[1], 'C2'), patient_links[0].split('/')[2], false, skip_c1_test)
+        #upload_test_execution(extract_test_execution_link(patient_links[1], 'C2'), patient_links[0].split('/')[2], false, skip_c1_test)
       end
       # sleep(4)
-      download_filter_data
-      calculate_filtered_cat3(bundle_id)
-      upload_c4_test_executions
+      #download_filter_data
+      #calculate_filtered_cat3(bundle_id)
+      #upload_c4_test_executions
       cleanup_hashes
     end
 
@@ -344,7 +344,7 @@ module Cypress
                               :c1_test => c1_test,
                               :c2_test => '1',
                               :c3_test => '1',
-                              :c4_test => '1',
+                              :c4_test => '0',
                               :duplicate_patients => '0',
                               :randomize_patients => '0' } }
       RestClient::Request.execute(:method => :post,

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -73,13 +73,13 @@ module Validators
                                          'effective_date': Time.at(te.task.effective_date).in_time_zone.to_formatted_s(:number))
       calc_job.sync_job([record.id.to_s], @measures.map { |mes| mes._id.to_s })
       calc_job.stop
-      passed = determine_passed
+      passed = determine_passed(mrn, record, options)
 
       record.destroy
       passed
     end
 
-    def determine_passed
+    def determine_passed(mrn, record, options)
       passed = true
       @measures.each do |measure|
         original_results = QDM::IndividualResult.where('patient_id' => mrn, 'measure_id' => measure.id)


### PR DESCRIPTION
…oads

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code