### PR TITLE
expected_records need to be in IPP

### DIFF
--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -44,7 +44,7 @@ class ChecklistTest < ProductTest
       end
       Measure.where(:_id.in => m_ids)
     else
-      bundle.measures.in(:hqmf_id => measure_ids.sample(50))
+      bundle.measures.in(hqmf_id: measure_ids.sample(50))
     end
   end
 

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -86,12 +86,12 @@ module Cypress
       @patient_links_task_hash.each do |patient_links|
         calcuate_cat_3(patient_links[0].split('/')[2], bundle_id)
         upload_test_execution(extract_test_execution_link(patient_links[1], 'C1'), patient_links[0].split('/')[2], true) unless skip_c1_test
-        #upload_test_execution(extract_test_execution_link(patient_links[1], 'C2'), patient_links[0].split('/')[2], false, skip_c1_test)
+        # upload_test_execution(extract_test_execution_link(patient_links[1], 'C2'), patient_links[0].split('/')[2], false, skip_c1_test)
       end
       # sleep(4)
-      #download_filter_data
-      #calculate_filtered_cat3(bundle_id)
-      #upload_c4_test_executions
+      # download_filter_data
+      # calculate_filtered_cat3(bundle_id)
+      # upload_c4_test_executions
       cleanup_hashes
     end
 

--- a/lib/validators/smoking_gun_validator.rb
+++ b/lib/validators/smoking_gun_validator.rb
@@ -27,7 +27,8 @@ module Validators
       @sgd = {}
       @expected_records = []
       @measures.each do |mes|
-        @expected_records << QDM::IndividualResult.where('measure_id' => mes.id, 'extendedData.correlation_id' => @test_id.to_s).distinct(:patient)
+        @expected_records << QDM::IndividualResult.where('measure_id' => mes.id, 'IPP' => { '$gt' => 0 },
+                                                         'extendedData.correlation_id' => @test_id.to_s).distinct(:patient)
       end
       @expected_records = @expected_records.flatten.uniq
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code