### PR TITLE
Bump sprockets version to fix CVE-2018-3760

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,10 +50,10 @@ script:
   - 'if [ ${TEST_SUITE} = "cucumber" ]; then
       bundle exec cucumber;
     elif [ ${TEST_SUITE} = "audit" ]; then
-      bundle exec brakeman -qAzw1;
-      bundle exec bundle-audit check --update;
-      bundle exec overcommit --sign;
-      bundle exec overcommit --run;
+      bundle exec brakeman -qAzw1 &&
+      bundle exec bundle-audit check --update &&
+      bundle exec overcommit --sign &&
+      bundle exec overcommit --run
     else
       RUBYOPT="-W0" bundle exec rake test:$TEST_SUITE;
     fi'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -496,7 +496,7 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
     slop (3.6.0)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (2.3.3)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
There is a vulnerability in the version of Sprockets we have. Bumping the version to resolve.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-272
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases (N/A)
- [ ] Tests have been run locally and pass (N/A)

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code