### PR TITLE
readd demographic information to original patient for duplication

### DIFF
--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -28,6 +28,7 @@ module Cypress
       end
       patient1.dataElements.concat patient_char_de
       patient2.dataElements.concat patient_char_de
+      patient.dataElements.concat patient_char_de
 
       [patient1, patient2]
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code