### PR TITLE
Point cqm-models at master instead of a non-existent branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'os'
 
 gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patientapi', branch: 'better_codes_and_scalar_error'
 gem 'cqm-converter', git: 'https://github.com/projecttacoma/cqm-converter', branch: 'master'
-gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'results_object_mongoize'
+gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'qrda'
 gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'r5'
 # gem 'health-data-standards', '~> 3.7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,10 +68,10 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-models
-  revision: b85f92e339ce5adee20ff83a023911fe74455c5c
-  branch: results_object_mongoize
+  revision: 00d5c15613b0022b6fe9674577a8fb1b50a0f72b
+  branch: master
   specs:
-    cqm-models (0.7.6)
+    cqm-models (0.8.0)
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers


### PR DESCRIPTION
Builds are currently failing since the the `results_object_mongoize` no longer exists on cqm-models ever since the changes were merged in https://github.com/projecttacoma/cqm-models/pull/42

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: (N/A)
- [x] Internal ticket links to this PR (N/A)
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases (N/A)
- [x] Tests have been run locally and pass (N/A)

**Reviewer 1:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code