### PR TITLE
Add the file and line number that an error occured on to the status_message when product test building fails

### DIFF
--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -23,7 +23,7 @@ class ProductTestSetupJob < ApplicationJob
     product_test.ready
   rescue StandardError => e
     product_test.backtrace = e.backtrace.join("\n")
-    product_test.status_message = e.message + ' on ' + e.backtrace.first.remove(Rails.root.to_s)
+    product_test.status_message = error_message(e)
     product_test.errored
     product_test.save!
   end
@@ -33,5 +33,11 @@ class ProductTestSetupJob < ApplicationJob
                                        'effective_date': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number))
     calc_job.sync_job(patient_ids, product_test.measures.map { |mes| mes._id.to_s })
     calc_job.stop
+  end
+
+  private
+
+  def error_message(error)
+    error.message + ' on ' + error.backtrace.first.remove(Rails.root.to_s)
   end
 end

--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -23,7 +23,7 @@ class ProductTestSetupJob < ApplicationJob
     product_test.ready
   rescue StandardError => e
     product_test.backtrace = e.backtrace.join("\n")
-    product_test.status_message = e.message
+    product_test.status_message = e.message + ' on ' + e.backtrace.first.remove(Rails.root.to_s)
     product_test.errored
     product_test.save!
   end


### PR DESCRIPTION
This fixes an annoyance when trying to debug errors with product tests, and includes the first line of the backtrace for viewing in the app status message.

It may be worthwhile to consider providing only admins access to the full backtrace in the UI if we feel this is too much information. The problem is on the error message we say "please contact the cypress team with the following error message if the problem persists", and `undefined method [] for nil:NilClass` isn't a horribly helpful error for us to help debug.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-287
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed (N/A)
- [x] Tests are included and test edge cases (N/A)
- [x] Tests have been run locally and pass (N/A)

**Reviewer 1:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code