### PR TITLE
Add disclaimer to Docker-related files about how it won't work for v4 yet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# WARNING: This Dockerfile, and the associated docker-compose.yml,
+# are only functional for Cypress v3.x. Docker installation 
+# methods are not yet supported for Cypress v4, as of 2018-07-10
+
 FROM phusion/passenger-ruby23:latest
 
 RUN apt-get update \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,7 @@
+# WARNING: This docker-compose.yml, and the associated Dockerfile,
+# are only functional for Cypress v3.x. Docker installation 
+# methods are not yet supported for Cypress v4, as of 2018-07-10
+
 version: "3"
 
 services:


### PR DESCRIPTION
Docker isn't functional in Cypress yet, as an installation technique, but we don't want to remove the files as they'll be used in the future. For the time being, I've added a disclaimer to both the `Dockerfile` and `docker-compose.yml` files, stating that they don't work in Cypress v4. This will be removed once we have a chance to make Docker work as an installation method for Cypress v4.

Additionally, I will be adding notes to the Cypress wiki pages to the same effect.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-290
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code