### PR TITLE
Cqm validators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,6 @@ gem 'os'
 gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patientapi', branch: 'better_codes_and_scalar_error'
 gem 'cqm-converter', git: 'https://github.com/projecttacoma/cqm-converter', branch: 'master'
 
-gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators', branch: 'master'
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'qrda'
 gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators', branch: 'master'

--- a/Gemfile
+++ b/Gemfile
@@ -16,10 +16,10 @@ gem 'os'
 gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patientapi', branch: 'better_codes_and_scalar_error'
 gem 'cqm-converter', git: 'https://github.com/projecttacoma/cqm-converter', branch: 'master'
 
-# gem 'cqm-validators' , git: 'https://github.com/projecttacoma/cqm-validators', branch: 'cqm_validator_library'
-gem 'cqm-validators', path: 'https://github.com/projecttacoma/cqm-validators', branch: 'cqm_validator_library'
+gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators', branch: 'master'
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'qrda'
+gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators', branch: 'master'
 gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'r5'
 # gem 'health-data-standards', '~> 3.7.0'
 

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'os'
 
 gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patientapi', branch: 'better_codes_and_scalar_error'
 gem 'cqm-converter', git: 'https://github.com/projecttacoma/cqm-converter', branch: 'master'
+
+# gem 'cqm-validators' , git: 'https://github.com/projecttacoma/cqm-validators', branch: 'cqm_validator_library'
+gem 'cqm-validators', path: '../cqm-validators'
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'qrda'
 gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'r5'

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'cql_qdm_patientapi', git: 'https://github.com/projecttacoma/cql_qdm_patient
 gem 'cqm-converter', git: 'https://github.com/projecttacoma/cqm-converter', branch: 'master'
 
 # gem 'cqm-validators' , git: 'https://github.com/projecttacoma/cqm-validators', branch: 'cqm_validator_library'
-gem 'cqm-validators', path: '../cqm-validators'
+gem 'cqm-validators', path: 'https://github.com/projecttacoma/cqm-validators', branch: 'cqm_validator_library'
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', branch: 'master'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'qrda'
 gem 'health-data-standards', git: 'https://github.com/projectcypress/health-data-standards.git', branch: 'r5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,20 +95,10 @@ GIT
       zip-zip (~> 0.3)
 
 GIT
-  remote: https://github.com/projecttacoma/cqm-validators
-  revision: 0a88dda78deb27105f1dbfe316a648207a02509a
-  branch: master
+PATH
+  remote: ../cqm-validators
   specs:
     cqm-validators (0.1.0)
-      nokogiri (~> 1.8.2)
-
-GIT
-  remote: https://github.com/turbolinks/turbolinks-classic
-  revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
-  branch: master
-  specs:
-    turbolinks (3.0.0)
-      coffee-rails
 
 GEM
   remote: https://rubygems.org/
@@ -580,11 +570,6 @@ DEPENDENCIES
   cqm-converter!
   cqm-models!
   cqm-parsers!
-<<<<<<< HEAD
-  cucumber (~> 3.0.2)
-=======
-  cqm-validators!
->>>>>>> cqm-validator gem version of cypress
   cucumber-rails
   database_cleaner
   devise (= 4.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,10 +95,20 @@ GIT
       zip-zip (~> 0.3)
 
 GIT
-PATH
-  remote: ../cqm-validators
+  remote: https://github.com/projecttacoma/cqm-validators
+  revision: 0a88dda78deb27105f1dbfe316a648207a02509a
+  branch: master
   specs:
     cqm-validators (0.1.0)
+      nokogiri (~> 1.8.2)
+
+GIT
+  remote: https://github.com/turbolinks/turbolinks-classic
+  revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
+  branch: master
+  specs:
+    turbolinks (3.0.0)
+      coffee-rails
 
 GEM
   remote: https://rubygems.org/
@@ -570,6 +580,8 @@ DEPENDENCIES
   cqm-converter!
   cqm-models!
   cqm-parsers!
+  cqm-validators!
+  cucumber (~> 3.0.2)
   cucumber-rails
   database_cleaner
   devise (= 4.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,17 +95,20 @@ GIT
       zip-zip (~> 0.3)
 
 GIT
+  remote: https://github.com/projecttacoma/cqm-validators
+  revision: 0a88dda78deb27105f1dbfe316a648207a02509a
+  branch: master
+  specs:
+    cqm-validators (0.1.0)
+      nokogiri (~> 1.8.2)
+
+GIT
   remote: https://github.com/turbolinks/turbolinks-classic
   revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
   branch: master
   specs:
     turbolinks (3.0.0)
       coffee-rails
-
-PATH
-  remote: ../cqm-validators
-  specs:
-    cqm-validators (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,11 @@ GIT
     turbolinks (3.0.0)
       coffee-rails
 
+PATH
+  remote: ../cqm-validators
+  specs:
+    cqm-validators (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -572,7 +577,11 @@ DEPENDENCIES
   cqm-converter!
   cqm-models!
   cqm-parsers!
+<<<<<<< HEAD
   cucumber (~> 3.0.2)
+=======
+  cqm-validators!
+>>>>>>> cqm-validator gem version of cypress
   cucumber-rails
   database_cleaner
   devise (= 4.1.1)

--- a/config/initializers/cypress.rb
+++ b/config/initializers/cypress.rb
@@ -1,3 +1,4 @@
+require 'cqm_validators'
 require 'cypress'
 require 'health-data-standards'
 require 'hqmf-parser'

--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -4,7 +4,7 @@ module Validators
   class ChecklistCriteriaValidator < QrdaFileValidator
     include Validators::ChecklistResultExtractor
     include Validators::Validator
-    include HealthDataStandards::Validate
+    include ::CqmValidators
 
     self.validator = :checklist
 

--- a/lib/validators/cms_schematron_validator.rb
+++ b/lib/validators/cms_schematron_validator.rb
@@ -1,7 +1,7 @@
 module Validators
   class CMSSchematronValidator < QrdaFileValidator
     include Validators::Validator
-    include HealthDataStandards::Validate
+    include CqmValidators
 
     self.validator = :cms_schematron
     @bundle_version = Settings.current&.default_bundle

--- a/lib/validators/cms_schematron_validator.rb
+++ b/lib/validators/cms_schematron_validator.rb
@@ -1,11 +1,7 @@
 module Validators
   class CMSSchematronValidator < QrdaFileValidator
     include Validators::Validator
-    include CqmValidators
-
-    self.validator = :cms_schematron
-    @bundle_version = Settings.current&.default_bundle
-
+    include ::CqmValidators
     def initialize(schematron_file, name, bundle_version = Settings.current.default_bundle)
       @validator = Schematron::Validator.new(name, schematron_file) if File.exist?(schematron_file)
       @bundle_version = bundle_version

--- a/lib/validators/expected_results_validator.rb
+++ b/lib/validators/expected_results_validator.rb
@@ -1,6 +1,6 @@
 module Validators
   class ExpectedResultsValidator < QrdaFileValidator
-    include HealthDataStandards::Validate::ReportedResultExtractor
+    include ::CqmValidators::ReportedResultExtractor
     include Validators::Validator
     attr_accessor :reported_results
 

--- a/lib/validators/qrda_cat1_validator.rb
+++ b/lib/validators/qrda_cat1_validator.rb
@@ -3,7 +3,7 @@
 module Validators
   class QrdaCat1Validator < QrdaFileValidator
     include Validators::Validator
-    include HealthDataStandards::Validate
+    include ::CqmValidators
 
     self.validator = :qrda_cat1
 
@@ -20,12 +20,12 @@ module Validators
                             [CDA.instance, Cat1R5.instance]
                           end
       @validators = if is_c3_validation_task
-                      [HealthDataStandards::Validate::DataValidator.new(bundle, measures.collect(&:hqmf_id))]
+                      [CqmValidators::DataValidator.new(bundle, measures.collect(&:hqmf_id))]
                     else
                       format_validators
                     end
       @validators += format_validators if is_c3_validation_task && !test_has_c1
-      @validators << HealthDataStandards::Validate::QrdaQdmTemplateValidator.new(bundle.qrda_version)
+      @validators << CqmValidators::QrdaQdmTemplateValidator.new(bundle.qrda_version)
     end
 
     # Validates a QRDA Cat I file.  This routine will validate the file against the CDA schema as well as the

--- a/lib/validators/qrda_cat3_validator.rb
+++ b/lib/validators/qrda_cat3_validator.rb
@@ -1,8 +1,7 @@
 require 'validators/qrda_cat1_validator'
 module Validators
   class QrdaCat3Validator < QrdaFileValidator
-    include HealthDataStandards::Validate
-    include Validators::Validator
+    include ::CqmValidators
 
     self.validator = :qrda_cat3
 


### PR DESCRIPTION
Cypress now uses cqm-validators gem to validate QRDA cat 3 files. The best way to test this is to start on master create a product and get known good results edit the QRDA 3 file and remove some entry relationships and then upload the file. Note the errors that you see on master and then switch to this branch and upload the same file and make sure that the error are the same.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR https://jira.mitre.org/browse/CYPRESS-281
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code