### PR TITLE
bundle updates (versions, deleting cascade, active bundle management,…

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -61,7 +61,7 @@ class ProductTest
   def self.destroy_by_ids(product_test_ids)
     tasks = Task.where(:product_test_id.in => product_test_ids)
     task_ids = tasks.pluck(:_id)
-    patients = QDM::Patient.where(:test_id.in => product_test_ids)
+    patients = QDM::Patient.where(:'extendedData.correlation_id'.in => product_test_ids)
     patient_ids = patients.pluck(:_id)
     test_executions = TestExecution.where(:task_id.in => task_ids)
     test_execution_ids = test_executions.pluck(:_id)
@@ -75,7 +75,7 @@ class ProductTest
     # long after the parent data was destroyed.
     Artifact.where(:test_execution_id.in => test_execution_ids).destroy
     # TODO: CQL: use new results model?
-    HealthDataStandards::CQM::PatientCache.where(:'value.patient_id'.in => patient_ids).delete
+    QDM::IndividualResult.where(:patient_id.in => patient_ids).delete
     ProductTest.in(:id => product_test_ids).delete
   end
 

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -17,34 +17,31 @@
           <td class = "text-center"><%= bundle.version %></td>
           <td class="text-center">
 
-            <% if !bundle.active %>
-
-              <% unless bundle.deprecated? %>
-                <%= button_to "Set Default", set_default_admin_bundle_path(bundle), :method => :post, :class => "btn btn-xs btn-default" %>
-                <%= render 'action_button',
-                                :button_text => 'Deprecate',
-                                :button_classes => 'btn btn-xs btn-danger',
-                                :button_action => 'post',
-                                :object => bundle,
-                                :object_name => bundle.title,
-                                :object_action => 'deprecate',
-                                :action_path => deprecate_admin_bundle_path(bundle),
-                                :modal_title => 'Deprecate Bundle',
-                                :modal_message => 'Deprecating a bundle will leave all products and test results, however new tests will not be able to created with this bundle.'
-                           %>
-              <% end %>
+            <% unless bundle.deprecated? %>
+              <%= button_to "Set Default", set_default_admin_bundle_path(bundle), :method => :post, :class => "btn btn-xs btn-default" unless bundle.active %>
               <%= render 'action_button',
-                              :button_text => 'Remove',
+                              :button_text => 'Deprecate',
                               :button_classes => 'btn btn-xs btn-danger',
-                              :button_action => 'delete',
+                              :button_action => 'post',
                               :object => bundle,
                               :object_name => bundle.title,
-                              :action_path => admin_bundle_path(bundle),
-                              :object_action => 'delete',
-                              :modal_title => 'Remove Bundle',
-                              :modal_message => 'Removing a bundle will also delete all associated products and test results.'
+                              :object_action => 'deprecate',
+                              :action_path => deprecate_admin_bundle_path(bundle),
+                              :modal_title => 'Deprecate Bundle',
+                              :modal_message => 'Deprecating a bundle will leave all products and test results, however new tests will not be able to created with this bundle.'
                          %>
             <% end %>
+            <%= render 'action_button',
+                            :button_text => 'Remove',
+                            :button_classes => 'btn btn-xs btn-danger',
+                            :button_action => 'delete',
+                            :object => bundle,
+                            :object_name => bundle.title,
+                            :action_path => admin_bundle_path(bundle),
+                            :object_action => 'delete',
+                            :modal_title => 'Remove Bundle',
+                            :modal_message => 'Removing a bundle will also delete all associated products and test results.'
+                       %>
           </td>
         </tr>
       <% end %>

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -24,7 +24,7 @@ class Bundle
   def deprecate
     results.destroy
     FileUtils.rm(mpl_path) if File.exist?(mpl_path)
-    update(:deprecated => true)
+    update(:deprecated => true, :active => false)
   end
 
   def destroy


### PR DESCRIPTION
… and enable deletion/deprecation of last bundle)
To test... upload bundles, deprecate bundles, and delete bundles. Try same year bundles, years previous to 2018, deleting last bundle, deprecating last bundle, and potentially other combinations. Check database after deletion of bundle for full removal of IndividualResult and Patient files (also fixes product_test deletion issue).
Note: must have indexed database to delete bundles (as according to instructions for Fix MPL PR https://github.com/projectcypress/cypress/pull/1017
Run 'bundle exec rake db:mongoid:create_indexes' after db creation

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:** Lauren DiCristofaro
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-295 and https://jira.mitre.org/browse/CYPRESS-245 and https://jira.mitre.org/browse/CYPRESS-294
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Laura Clark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code