### PR TITLE
Fixing Font Awesome & Measure Selection Headings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'faker', '~> 1.5.0'
 gem 'sass-rails', '~> 5.0.4'
 # Dependencies for CMS Assets Framework
 gem 'bootstrap-sass', '~> 3.3.5'
-gem 'font-awesome-sass'
+gem 'font-awesome-sass', '~> 5.0.13'
 gem 'jquery-rails', '~> 4.0.4'
 gem 'jquery-ui-rails', '~> 5.0.5'
 gem 'modernizr-rails', '~> 2.7.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,7 +588,7 @@ DEPENDENCIES
   devise_invitable
   factory_bot_rails
   faker (~> 1.5.0)
-  font-awesome-sass
+  font-awesome-sass (~> 5.0.13)
   health-data-standards!
   jasny-bootstrap-rails
   jbuilder (~> 2.0)
@@ -638,4 +638,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -2,6 +2,11 @@
 // Helper functions //
 //////////////////////
 
+// The $.escapeSelector() can replace all instances of this function in jQuery 3
+function escapeCSS(str) {
+  return str.replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, "\\$&");
+}
+
 function CheckMany(group) {
   if (group == 'all') {
     $('.measure-group .measure-checkbox:not(:checked)').prop('checked', true).change();
@@ -27,7 +32,7 @@ function ToggleCustomSelection(task) {
 }
 
 function UpdateGroupSelections(event) {
-  var measure_category = $(event.currentTarget).attr('data-category');
+  var measure_category = escapeCSS($(event.currentTarget).attr('data-category'));
   var $groupChecks = $('.measure-group .measure-checkbox[data-category='+ measure_category +']');
 
   var groupIsSelected = !$groupChecks.filter(':not(:checked)').length; // true if none are unchecked
@@ -40,14 +45,14 @@ function UpdateGroupSelections(event) {
   $('#measure_tabs .ui-tabs-nav').find('[href*='+ measure_category +'] .selected-number')
     .html(function() {
       if (number_checked > 0) {
-        return number_checked + '<i aria-hidden="true" class="fa fa-fw fa-check"></i>'
+        return number_checked + '<i aria-hidden="true" class="fas fa-fw fa-check"></i>'
       } else { return '' }
     });
 
   $('.select-measures .panel-title .selected-number')
     .html(function() {
       if ($('.measure-group .measure-checkbox:checked').length > 0) {
-        return $('.measure-group .measure-checkbox:checked').length + '<i aria-hidden="true" class="fa fa-fw fa-check"></i>'
+        return $('.measure-group .measure-checkbox:checked').length + '<i aria-hidden="true" class="fas fa-fw fa-check"></i>'
       } else { return '(0)' }
     });
 
@@ -175,7 +180,7 @@ ready_run_on_refresh_bundle = function() {
 
   // Checking a group of measures
   $('.measure-group-all').on('change', function () {
-    $(this).closest('.measure-group').find('.measure-checkbox[data-category='+$(this).attr('id')+']')
+    $(this).closest('.measure-group').find('.measure-checkbox[data-category='+ escapeCSS($(this).attr('id')) +']')
       .prop('checked', this.checked).change().trigger('groupclick');
   });
 

--- a/app/assets/stylesheets/cypress/_alerts.scss
+++ b/app/assets/stylesheets/cypress/_alerts.scss
@@ -8,7 +8,7 @@
   &.alert-warning { @include alert-border($state-warning-text); }
   &.alert-danger { @include alert-border($state-danger-text); }
 
-  .fa-close { font-size: 1.4em; }
+  .fa-times { font-size: 1.4em; }
 
   .iconSpan {
     border-right: 0;

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -22,32 +22,16 @@ module VendorsHelper
   # status should be 'Passing', 'Failing', or 'Not Complete'
   # used for each certification status on vendor show page
   def status_to_css_classes(status)
-    classes = {}
-
     case status
     when 'passing'
-      classes['cell'] = 'status-passing'
-      classes['icon'] = 'check'
-      classes['type'] = 'fas'
-      classes['text'] = 'text-success'
+      { 'cell' => 'status-passing', 'icon' => 'check', 'type' => 'fas', 'text' => 'text-success' }
     when 'failing'
-      classes['cell'] = 'status-failing'
-      classes['icon'] = 'times'
-      classes['type'] = 'fas'
-      classes['text'] = 'text-danger'
+      { 'cell' => 'status-failing', 'icon' => 'times', 'type' => 'fas', 'text' => 'text-danger' }
     when 'errored'
-      classes['cell'] = 'status-errored'
-      classes['icon'] = 'exclamation'
-      classes['type'] = 'fas'
-      classes['text'] = 'text-warning'
+      { 'cell' => 'status-errored', 'icon' => 'exclamation', 'type' => 'fas', 'text' => 'text-warning' }
     else
-      classes['cell'] = 'status-not-started'
-      classes['icon'] = 'circle'
-      classes['type'] = 'far'
-      classes['text'] = 'text-info'
+      { 'cell' => 'status-not-started', 'icon' => 'circle', 'type' => 'far', 'text' => 'text-info' }
     end
-
-    classes
   end
 
   def vendor_statuses(vendor)

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -39,7 +39,7 @@ module VendorsHelper
       classes['text'] = 'text-warning'
     else
       classes['cell'] = 'status-not-started'
-      classes['icon'] = 'fa-circle-o'
+      classes['icon'] = 'fa-circle'
       classes['text'] = 'text-info'
     end
 

--- a/app/helpers/vendors_helper.rb
+++ b/app/helpers/vendors_helper.rb
@@ -27,19 +27,23 @@ module VendorsHelper
     case status
     when 'passing'
       classes['cell'] = 'status-passing'
-      classes['icon'] = 'fa-check'
+      classes['icon'] = 'check'
+      classes['type'] = 'fas'
       classes['text'] = 'text-success'
     when 'failing'
       classes['cell'] = 'status-failing'
-      classes['icon'] = 'fa-times'
+      classes['icon'] = 'times'
+      classes['type'] = 'fas'
       classes['text'] = 'text-danger'
     when 'errored'
       classes['cell'] = 'status-errored'
-      classes['icon'] = 'fa-exclamation'
+      classes['icon'] = 'exclamation'
+      classes['type'] = 'fas'
       classes['text'] = 'text-warning'
     else
       classes['cell'] = 'status-not-started'
-      classes['icon'] = 'fa-circle'
+      classes['icon'] = 'circle'
+      classes['type'] = 'far'
       classes['text'] = 'text-info'
     end
 

--- a/app/views/admin/_application_status.html.erb
+++ b/app/views/admin/_application_status.html.erb
@@ -1,6 +1,6 @@
 <div class="inline-block pull-right">
   <%= button_to admin_download_logs_path, :method => :get, :class => "btn btn-default" do %>
-    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Application Logs
+    <%= icon('fas', 'download', :"aria-hidden" => true) %> Download Application Logs
   <% end %>
 </div>
 

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -68,7 +68,7 @@
         <td class="tracker-status">
           <%= tracker.status %>
           <% if tracker.status == :working %>
-            <i class="fas fa-fw fa-spin fa-sync-alt"></i>
+            <%= icon('fas fa-fw', 'sync-alt', :"aria-hidden" => true) %>
           <% end %>
         </td>
         <td><%= tracker.log_message.last%></td>

--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -68,12 +68,12 @@
         <td class="tracker-status">
           <%= tracker.status %>
           <% if tracker.status == :working %>
-            <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i>
+            <i class="fas fa-fw fa-spin fa-sync-alt"></i>
           <% end %>
         </td>
         <td><%= tracker.log_message.last%></td>
         <td>
-          <%= link_to "", admin_tracker_path(tracker), :method => :delete, :class => "close fa fa-fw fa-close" if tracker.status == :failed %>
+          <%= link_to "", admin_tracker_path(tracker), :method => :delete, :class => "close fa fa-fw fa-times" if tracker.status == :failed %>
         </td>
       </tr>
       <% end %>

--- a/app/views/admin/_show_settings.html.erb
+++ b/app/views/admin/_show_settings.html.erb
@@ -5,7 +5,7 @@
 %>
 <div class="inline-block pull-right">
   <%= button_to edit_admin_settings_path, :method => :get, :class => "btn btn-default" do %>
-    <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Application Settings
+    <%= icon('fas', 'wrench', :"aria-hidden" => true) %> Edit Application Settings
   <% end %>
 </div>
 

--- a/app/views/admin/_user_list.html.erb
+++ b/app/views/admin/_user_list.html.erb
@@ -36,7 +36,7 @@
       </td>
       <td>
         <% unless user.id == current_user.id%>
-        <a class="btn btn-default" href="<%= edit_admin_user_path(user) %>"><i class="fa fa-fw fa-wrench" aria-hidden="true"></i>Edit User </a></td>
+        <a class="btn btn-default" href="<%= edit_admin_user_path(user) %>"><%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %></i>Edit User </a></td>
         <%end%>
     </tr>
     <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -29,7 +29,7 @@
        %>
         </table>
       </td>
-      <td><a class="btn btn-default" href="<%= edit_admin_user_path(user) %>"><i class="fa fa-fw fa-wrench" aria-hidden="true"></i>Edit User </a></td>
+      <td><a class="btn btn-default" href="<%= edit_admin_user_path(user) %>"><%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %>Edit User </a></td>
     </tr>
     <% end %>
   </tbody>

--- a/app/views/application/_alert.html.erb
+++ b/app/views/application/_alert.html.erb
@@ -32,7 +32,7 @@
 
 <% else %>
   <div class="clearfix alert alert-<%= alert_type %> alert-dismissible" role="alert" aria-live="polite">
-    <button type="button" class="close fa fa-fw fa-close" data-dismiss="alert" aria-label="Close"><span class="sr-only">Close alert</span></button>
+    <button type="button" class="close fa fa-fw fa-times" data-dismiss="alert" aria-label="Close"><span class="sr-only">Close alert</span></button>
 
     <div class="iconSpan pull-left">
       <i class="fa fa-fw fa-2x <%= alert_icon %>"></i>

--- a/app/views/application/_alert.html.erb
+++ b/app/views/application/_alert.html.erb
@@ -7,20 +7,21 @@
 
 <% alert_icon = case alert_type
                 when 'success'
-                  'fa-check-circle'
+                  'check-circle'
                 when 'warning'
-                  'fa-exclamation-triangle'
+                  'exclamation-triangle'
                 when 'danger'
-                  'fa-exclamation-circle'
+                  'exclamation-circle'
                 else
-                  'fa-info-circle'
+                  'info-circle'
                 end %>
 
 <!-- Alerts are either dismissable or confirmable. NOT BOTH -->
 <% if confirmation %>
   <div class="clearfix alert alert-<%= alert_type %>" role="alert" aria-live="polite">
     <div class="iconSpan pull-left">
-      <i class="fa fa-fw fa-2x <%= alert_icon %>"></i>
+      <%= icon('fas fa-fw fa-2x', alert_icon) %>
+
     </div>
     <div class="alertContent">
       <% [*messages].each do |msg| %>
@@ -32,10 +33,10 @@
 
 <% else %>
   <div class="clearfix alert alert-<%= alert_type %> alert-dismissible" role="alert" aria-live="polite">
-    <button type="button" class="close fa fa-fw fa-times" data-dismiss="alert" aria-label="Close"><span class="sr-only">Close alert</span></button>
+    <button type="button" class="close fas fa-fw fa-times" data-dismiss="alert" aria-label="Close"><span class="sr-only">Close alert</span></button>
 
     <div class="iconSpan pull-left">
-      <i class="fa fa-fw fa-2x <%= alert_icon %>"></i>
+      <%= icon('fas fa-fw fa-2x', alert_icon) %>
     </div>
     <div class="alertContent">
       <% [*messages].each do |msg| %>

--- a/app/views/application/_checklist_execution_results.html.erb
+++ b/app/views/application/_checklist_execution_results.html.erb
@@ -27,7 +27,7 @@
       <% unless execution.nil? %>
         <td><%= link_to 'View Results', new_task_test_execution_path(execution.task) %></td>
       <% else %>
-        <td>  <i aria-hidden = 'true' class = 'fa fa-fw fa-circle-o text-info'></i>
+        <td>  <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
           <span class = 'text-info'>Not Started</span>
         </td>
       <% end %>
@@ -49,11 +49,11 @@
             <i aria-hidden = 'true' class = 'fa fa-fw fa-exclamation text-warning'></i>
             <strong class = 'text-warning'>Errored</strong>
           <% else %>
-            <i aria-hidden = 'true' class = 'fa fa-fw fa-circle-o text-info'></i>
+            <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
             <strong class = 'text-info'>In Progress</strong>
           <% end %>
         <% else %>
-          <i aria-hidden = 'true' class = 'fa fa-fw fa-circle-o text-info'></i>
+          <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
           <span class = 'text-info'>Not Started</span>
         <% end %>
       </td>

--- a/app/views/application/_checklist_execution_results.html.erb
+++ b/app/views/application/_checklist_execution_results.html.erb
@@ -27,7 +27,7 @@
       <% unless execution.nil? %>
         <td><%= link_to 'View Results', new_task_test_execution_path(execution.task) %></td>
       <% else %>
-        <td>  <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
+        <td> <%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>
           <span class = 'text-info'>Not Started</span>
         </td>
       <% end %>
@@ -40,20 +40,20 @@
         <% unless execution.nil? %>
           <% case status_with_sibling %>
           <% when 'passing' %>
-            <i aria-hidden = 'true' class = 'fa fa-fw fa-check text-success'></i>
+            <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
             <strong class = 'text-success'>Passing</strong>
           <% when 'failing' %>
-            <i aria-hidden = 'true' class = 'fa fa-fw fa-times text-danger'></i>
+            <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
             <strong class = 'text-danger'>Failing</strong>
           <% when 'errored' %>
-            <i aria-hidden = 'true' class = 'fa fa-fw fa-exclamation text-warning'></i>
+            <%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>
             <strong class = 'text-warning'>Errored</strong>
           <% else %>
-            <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
+            <%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>
             <strong class = 'text-info'>In Progress</strong>
           <% end %>
         <% else %>
-          <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
+          <%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>
           <span class = 'text-info'>Not Started</span>
         <% end %>
       </td>

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -17,7 +17,7 @@
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_status_display' }});
   </script>
-  <p class="lead row bg-info execution-status"><i class="fa fa-fw fa-refresh fa-spin text-info"></i> In Progress</p>
+  <p class="lead row bg-info execution-status"><i class="fas fa-fw fa-spin fa-sync-alt text-info"></i> In Progress</p>
 <% end %>
 
 <table class = 'table table-hover table-condensed'>

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -17,7 +17,7 @@
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'checklist_status_display' }});
   </script>
-  <p class="lead row bg-info execution-status"><i class="fas fa-fw fa-spin fa-sync-alt text-info"></i> In Progress</p>
+  <p class="lead row bg-info execution-status"><%= icon('fas fa-fw fa-spin text-info', 'sync-alt', :"aria-hidden" => true) %> In Progress</p>
 <% end %>
 
 <table class = 'table table-hover table-condensed'>

--- a/app/views/application/_execution_status_message.html.erb
+++ b/app/views/application/_execution_status_message.html.erb
@@ -10,7 +10,7 @@
   <i aria-hidden='true' class = 'fa fa-fw fa-exclamation text-warning'</i>
   <strong class="text-info">Internal Error</strong>
 <% elsif !execution %>
-  <i aria-hidden = 'true' class = 'fa fa-fw fa-circle-o text-info'></i>
+  <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
   <span class = 'text-info'>Not Started</span>
 <% else %>
   <% classes = status_to_css_classes(execution.status.capitalize) %>
@@ -25,7 +25,7 @@
     <i aria-hidden = 'true' class = 'fa fa-fw fa-exclamation text-warning'></i>
     <strong class = 'text-warning'>Errored</strong>
   <% else %>
-    <i aria-hidden = 'true' class = 'fa fa-fw fa-circle-o text-info'></i>
+    <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
     <strong class = 'text-info'>In Progress</strong>
   <% end %>
 <% end %>

--- a/app/views/application/_execution_status_message.html.erb
+++ b/app/views/application/_execution_status_message.html.erb
@@ -7,25 +7,27 @@
 %>
 
 <% if test_state == :errored %>
-  <i aria-hidden='true' class = 'fa fa-fw fa-exclamation text-warning'</i>
+  <%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>
+
   <strong class="text-info">Internal Error</strong>
 <% elsif !execution %>
-  <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
+  <%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>
+
   <span class = 'text-info'>Not Started</span>
 <% else %>
   <% classes = status_to_css_classes(execution.status.capitalize) %>
   <% case execution.status %>
   <% when 'passing' %>
-    <i aria-hidden = 'true' class = 'fa fa-fw fa-check text-success'></i>
+    <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
     <strong class = 'text-success'>Passed</strong>
   <% when 'failing' %>
-    <i aria-hidden = 'true' class = 'fa fa-fw fa-times text-danger'></i>
+    <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
     <strong class = 'text-danger'>Failed</strong>
   <% when 'errored' %>
-    <i aria-hidden = 'true' class = 'fa fa-fw fa-exclamation text-warning'></i>
+    <%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>
     <strong class = 'text-warning'>Errored</strong>
   <% else %>
-    <i aria-hidden = 'true' class = 'far fa-fw fa-circle text-info'></i>
+    <%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>
     <strong class = 'text-info'>In Progress</strong>
   <% end %>
 <% end %>

--- a/app/views/application/_header_product.html.erb
+++ b/app/views/application/_header_product.html.erb
@@ -11,16 +11,16 @@
   <div class="panel-body">
     <div class="panel-actions pull-right">
       <%= button_to edit_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
-        <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Product
+        <%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %> Edit Product
       <% end %>
       <% if current_user.user_role?(:atl) || current_user.user_role?(:admin) %>
         <% unless product.supplemental_test_artifact.file.nil? %>
           <%= button_to supplemental_test_artifact_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
-            <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Supplemental Test Artifact
+            <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download Supplemental Test Artifact
           <% end %>
         <% end %>
         <%= button_to report_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
-          <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Report
+         <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download Report
         <% end %>
       <% end %>
     </div>

--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -3,11 +3,11 @@
     <div class="panel-actions pull-right">
       <% unless vendor.products.empty? %>
         <%= button_to new_vendor_product_path(vendor), :method => :get, :class => "btn btn-primary" do %>
-          <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
+          <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Product
         <% end %>
       <% end %>
       <%= button_to edit_vendor_path(vendor), :method => :get, :class => "btn btn-default" do %>
-        <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Vendor
+        <%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %> Edit Vendor
       <% end %>
     </div>
 
@@ -17,7 +17,7 @@
       <ul class="fa-ul vendor-details">
         <% if vendor.url? %>
           <li>
-            <i class="fa-li fa fa-globe" aria-hidden="true"></i>
+            <%= icon('fa-li fas', 'globe', :"aria-hidden" => true) %>
             <a href="<%= website_link(vendor.url) %>">
               <span class="sr-only">Website for vendor <%= vendor.name %></span>
               <%= website_link(vendor.url) %>
@@ -26,7 +26,7 @@
         <% end %>
         <% if vendor.address? %>
           <li>
-            <i class="fa-li fa fa-home" aria-hidden="true"></i>
+            <%= icon('fa-li fas', 'home', :"aria-hidden" => true) %>
             <span class="sr-only">Address for vendor <%= vendor.name %></span>
             <%= formatted_vendor_address(vendor) %>
           </li>
@@ -34,14 +34,14 @@
         <% if !vendor.points_of_contact.empty? %>
           <% vendor.points_of_contact.each do |poc| %>
             <li class="point-of-contact">
-              <i class="fa-li fa fa-user" aria-hidden="true"></i>
+              <%= icon('fa-li fas', 'user', :"aria-hidden" => true) %>
               <span class="sr-only">Point of contact for vendor <%= vendor.name %></span>
               <%= poc.name %> <%= "(#{poc.contact_type})" if poc.contact_type? %>
               <% if poc.email? || poc.phone? %>
                 <ul class="fa-ul">
                   <% if poc.email? %>
                     <li>
-                      <i class="fa-li fa fa-envelope" aria-hidden="true"></i>
+                      <%= icon('fa-li fas', 'envelope', :"aria-hidden" => true) %>
                       <a href="mailto:<%= poc.email %>?subject=Cypress%20testing%20for%20<%= vendor.name %>">
                         <span class="sr-only">Email for <%= poc.name %></span>
                         <%= poc.email %>
@@ -50,7 +50,7 @@
                   <% end %>
                   <% if poc.phone? %>
                     <li>
-                      <i class="fa-li fa fa-phone" aria-hidden="true"></i>
+                      <%= icon('fa-li fas', 'phone', :"aria-hidden" => true) %>
                       <% if poc.phone.gsub(/[^0-9]/, '').length == 10 %>
                         <a href="tel:<%= number_to_phone(poc.phone.gsub(/[^0-9]/, ''), country_code: 1) %>">
                           <span class="sr-only">Phone number for <%= poc.name %></span>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -51,14 +51,14 @@
           <% if current_user.user_role? :admin%>
             <li <% if curr_page == :admin %>class="active"<% end %>>
               <%= link_to admin_path, class: 'navbar-item'   do %>
-              <i class="fa fa-fw fa-gears" aria-hidden="true"></i>
+              <i class="fa fa-fw fa-cog" aria-hidden="true"></i>
               Admin
               <% end %>
             </li>
           <% end %>
           <li>
             <%= link_to destroy_user_session_path, class: 'navbar-item'  do %>
-                <i class="fa fa-fw fa-sign-out" aria-hidden="true"></i>
+                <i class="fa fa-fw fa-sign-out-alt" aria-hidden="true"></i>
                  Log Out
             <% end %>
           </li>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -3,7 +3,7 @@
     <div class="navbar-header">
       <%= link_to root_path do %>cypress <small><%= Cypress::Application::VERSION %></small><% end %>
       <button type="button" class="navbar-toggle navbar-right" data-toggle="collapse" data-target="#cypressNavbar" aria-label="navigation menu" role="button" aria-controls="cypressNavbar" aria-expanded="false">
-        <i class="fa fa-bars fa-2x" aria-hidden="true"></i>
+        <%= icon('fas fa-2x', 'bars', :"aria-hidden" => true) %>
         <span class="sr-only">Expand navigation menu</span>
       </button>
     </div>
@@ -24,41 +24,41 @@
 
           <li <% if curr_page == :dashboard %>class="active"<% end %>>
             <%= link_to root_path, class: 'navbar-item'   do %>
-            <i class="fa fa-fw fa-th-list" aria-hidden="true"></i>
+            <%= icon('fas fa-fw', 'th-list', :"aria-hidden" => true) %>
             Dashboard
             <% end %>
           </li>
           <li <% if curr_page == :master_patient_list %>class="active"<% end %>>
             <%= link_to records_path, class: 'navbar-item'   do %>
-            <i class="fa fa-fw fa-users" aria-hidden="true"></i>
+            <%= icon('fas fa-fw', 'users', :"aria-hidden" => true) %>
             Master Patient List
             <% end %>
           </li>
           <% if Settings.current.mode_internal? || Settings.current.mode_demo? %>
           <li>
           <%= link_to '/cvu', class: 'navbar-item', target: '_blank'   do %>
-              <i class="fa fa-fw fa-check-square-o" aria-hidden="true"></i>
+              <%= icon('fas', 'check-square', :"aria-hidden" => true) %>
               Validation Utility
               <% end %>
           </li>
           <% end %>
           <li <% if curr_page == :account %>class="active"<% end %>>
             <%= link_to edit_user_registration_path, class: 'navbar-item'   do %>
-            <i class="fa fa-fw fa-user" aria-hidden="true"></i>
+            <%= icon('fas fa-fw', 'user', :"aria-hidden" => true) %>
             <%= current_user.email.truncate(20) %>
             <% end %>
           </li>
           <% if current_user.user_role? :admin%>
             <li <% if curr_page == :admin %>class="active"<% end %>>
               <%= link_to admin_path, class: 'navbar-item'   do %>
-              <i class="fa fa-fw fa-cog" aria-hidden="true"></i>
+              <%= icon('fas fa-fw', 'cog', :"aria-hidden" => true) %>
               Admin
               <% end %>
             </li>
           <% end %>
           <li>
             <%= link_to destroy_user_session_path, class: 'navbar-item'  do %>
-                <i class="fa fa-fw fa-sign-out-alt" aria-hidden="true"></i>
+                <%= icon('fas fa-fw', 'sign-out-alt', :"aria-hidden" => true) %>
                  Log Out
             <% end %>
           </li>

--- a/app/views/application/_product_status_table.html.erb
+++ b/app/views/application/_product_status_table.html.erb
@@ -19,10 +19,10 @@
           <span>
             <%= button_to vendor_product_favorite_path(product.vendor_id, product), remote: true, :class => "btn btn-link btn-pop" do %>
               <% if (product.favorite_user_ids.include? current_user.id) %>
-                <i class="fas fa-fw fa-star" aria-hidden="true"></i>
+                <%= icon('fas fa-fw', 'star', :"aria-hidden" => true) %>
                 <span class="sr-only">product favorited</span>
               <% else %>
-                <i class="far fa-fw fa-star" aria-hidden="true"></i>
+                <%= icon('far fa-fw', 'star', :"aria-hidden" => true) %>
                 <span class="sr-only">product not favorited</span>
               <% end %>
             <% end %>
@@ -56,7 +56,7 @@
 
       <tr <%= 'hidden' if (status == 'errored' && total.zero?) %>>
         <th scope="row" class="test-status <%= classes['text'] %>">
-          <i aria-hidden="true" class="fa fa-fw <%= classes['icon'] %>"></i>
+          <%= icon("#{classes['type']} fa-fw", classes['icon'], :"aria-hidden" => true) %>
           <span class="total_status_count"><%= total %></span>
           <%= status.humanize %> Tests
         </th>

--- a/app/views/application/_product_status_table.html.erb
+++ b/app/views/application/_product_status_table.html.erb
@@ -19,10 +19,10 @@
           <span>
             <%= button_to vendor_product_favorite_path(product.vendor_id, product), remote: true, :class => "btn btn-link btn-pop" do %>
               <% if (product.favorite_user_ids.include? current_user.id) %>
-                <i class="fa fa-fw fa-star" aria-hidden="true"></i>
+                <i class="fas fa-fw fa-star" aria-hidden="true"></i>
                 <span class="sr-only">product favorited</span>
               <% else %>
-                <i class="fa fa-fw fa-star-o" aria-hidden="true"></i>
+                <i class="far fa-fw fa-star" aria-hidden="true"></i>
                 <span class="sr-only">product not favorited</span>
               <% end %>
             <% end %>

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -43,9 +43,9 @@
                       <td rowspan="3" class='data-criteria hide-me'>
                         <% if criteria_field.object.passed_qrda %>
                           <span class="sr-only">Passes QRDA</span>
-                          <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                          <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                         <% else %>
-                          <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                          <%= icon('fas fa-fw text-info invisible', 'play-circle', :"aria-hidden" => true) %>
                         <% end %>
                       </td>
                       <% valuessets = criteria_field.object.get_all_valuesets_for_dc(measure) %>
@@ -84,13 +84,13 @@
                           </td>
                           <td class='hide-me'>
                             <% if criteria_field.object.complete?.nil? %>
-                            <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                            <%= icon('fas fa-fw text-info invisible', 'play-circle', :"aria-hidden" => true) %>
                             <% elsif criteria_field.object.negated_valueset %>
-                            <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                            <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                             <% elsif criteria_field.object.code_complete %>
-                            <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                            <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                             <% else %>
-                            <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                            <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                             <% end %>
                             <% if criteria_field.object.negated_valueset %>
                            <%= criteria_field.select :selected_negated_valueset, valuessets.collect{ |vs| ["#{lookup_valueset_name(vs)} - #{vs}", vs] }, class: 'hide-me' %>
@@ -127,22 +127,22 @@
                         <% if coded_attribute?(criteria, checked_criteria.attribute_index) %>
                           <td class='hide-me'>
                             <% if criteria_field.object.complete?.nil? %>
-                              <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-info invisible', 'play-circle', :"aria-hidden" => true) %>
                             <% elsif criteria_field.object.attribute_complete %>
-                              <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                             <% else %>
-                              <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                             <% end %>
                             <%= criteria_field.text_field :attribute_code, hide_label: false, class: 'hide-me' %>
                           </td>
                         <% elsif criteria['value'] && criteria['value'].type != 'CD' || criteria['attributes'] %>
                           <td class='hide-me'>
                             <% if criteria_field.object.complete?.nil? %>
-                              <i class = 'fa fa-fw fa-play-circle text-info invisible' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-info invisible', 'play-circle', :"aria-hidden" => true) %>
                             <% elsif criteria_field.object.result_complete %>
-                              <i class = 'fa fa-fw fa-check text-success' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                             <% else %>
-                              <i class = 'fa fa-fw fa-times text-danger' aria-hidden="true"></i>
+                              <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                             <% end %>
                             <%= criteria_field.text_field :recorded_result, hide_label: false, class: 'hide-me' %>
                           </td>

--- a/app/views/checklist_tests/measure.html.erb
+++ b/app/views/checklist_tests/measure.html.erb
@@ -4,13 +4,13 @@
 
 <br/>
 <%= link_to(product_checklist_test_path(@product, @product_test), class: 'btn btn-primary') do %>
-  <i class = 'fa fa-fw fa-angle-left' aria-hidden = 'true'></i>Return to Record Sample
+  <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %>Return to Record Sample
 <% end %>
 
 <div class = 'test-steps'>
   <div class="panel panel-info">
     <div class="panel-heading">
-      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Checklist Instructions</h1>
+      <h1 class="panel-title test-step">1<%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %>Checklist Instructions</h1>
     </div>
     <%= render 'checklist_instructions', :instructions => APP_CONSTANTS['tests']['ChecklistTest']['instructions'] %>
   </div>

--- a/app/views/checklist_tests/show.html.erb
+++ b/app/views/checklist_tests/show.html.erb
@@ -5,14 +5,14 @@
 
 <div class="panel-actions pull-right">
   <%= button_to print_criteria_product_checklist_test_path(@product, @product_test), :method => :get, :class => "btn btn-default" do %>
-    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download Criteria List
+    <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download Criteria List
   <% end %>
 </div>
 <h1>Record Sample</h1>
 <div class = 'test-steps'>
   <div class="panel panel-info">
     <div class="panel-heading">
-      <h1 class="panel-title test-step">1<i class="fa fa-fw fa-bolt" aria-hidden="true"></i>Record Sample Instructions</h1>
+      <h1 class="panel-title test-step"> 1 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> Record Sample Instructions</h1>
     </div>
     <%= render 'checklist_instructions', :instructions => APP_CONSTANTS['tests']['ChecklistTest']['instructions'] %>
   </div>
@@ -21,7 +21,7 @@
   <div class="panel panel-info">
     <div class="panel-heading disable">
       <h1 class="panel-title test-step disable">
-        <%= 2 %> <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= 'Upload Files' %>
+        2 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> <%= 'Upload Files' %>
       </h1>
     </div>
     <div class="panel-body">
@@ -33,7 +33,7 @@
   <div class = 'panel panel-info'>
     <div class = 'panel-heading'>
       <h1 class = 'panel-title test-step'>
-        3 <i class = 'fa fa-fw fa-bolt' aria-hidden = 'true'></i> View Results
+        3 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> View Results
       </h1>
     </div>
     <div class = 'panel-body'>

--- a/app/views/devise/registrations/_recent_activity.html.erb
+++ b/app/views/devise/registrations/_recent_activity.html.erb
@@ -52,7 +52,7 @@
           <%= render 'execution_status_message', :execution => test_execution, :test_state => test.state %>
         </td>
         <td class="no-wrap" data-order="<%= test_execution.updated_at %>">
-          <i class="fa fa-fw fa-clock-o" aria-hidden="true"></i><%= local_time_ago(test_execution.updated_at) %>
+          <%= icon('far fa-fw', 'clock', :"aria-hidden" => true) %><%= local_time_ago(test_execution.updated_at) %>
         </td>
       </tr>
     <% end %>

--- a/app/views/errors/404.html.erb
+++ b/app/views/errors/404.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-primary">Page Not Found</h1>
 <p class="text-center text-info">
   <strong>
-    <i class="fa fa-fw fa-3x fa-question-circle" aria-hidden="true"></i>
+    <%= icon('fas fa-3x', 'question-circle', :"aria-hidden" => true) %>
   </strong>
 </p>
 <p class="lead">We're sorry but Cypress can't find this page. You might have followed a bad link or mis-typed a URL.</p>

--- a/app/views/errors/500.html.erb
+++ b/app/views/errors/500.html.erb
@@ -1,7 +1,7 @@
 <h1 class="text-danger">Server Error</h1>
 <p class="text-center text-danger">
   <strong>
-    <i class="fa fa-fw fa-3x fa-exclamation-triangle" aria-hidden="true"></i>
+    <%= icon('fas fa-3x', 'exclamation-circle', :"aria-hidden" => true) %>
   </strong>
 </p>
 <p class="lead">Something went wrong with this request. This is likely a problem with Cypress rather than a mistake on your part.</p>

--- a/app/views/product_tests/show.html.erb
+++ b/app/views/product_tests/show.html.erb
@@ -27,13 +27,13 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         <h1 class="panel-title test-step">
-          1 <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> Download Test Deck
+          1 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> Download Test Deck
         </h1>
       </div>
       <div class="panel-body">
         <%= form_for @product_test, url: { action: 'patients' }, :html => { :method => 'GET' } do |f| %>
           <%= button_tag(type: 'submit', class: 'btn btn-info btn-block') do %>
-            <i class = 'fa fa-fw fa-download'></i> Download CAT 1 (.zip)
+            <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download CAT 1 (.zip)
           <% end %>
         <% end %>
       </div>
@@ -43,7 +43,7 @@
   <div class = 'col-sm-6'>
     <h1 class = 'pull-left'>Current Test Status</h1>
     <button class = 'btn btn-primary pull-right'>
-      <i class = 'fa fa-fw fa-download'></i> Download Full Report
+      <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download Full Report
     </button>
     <table class = 'table table-condensed'>
       <thead>
@@ -94,7 +94,7 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <h1 class="panel-title">
-            2 <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= "Upload for #{tab_label_1}" %>
+            2 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> <%= "Upload for #{tab_label_1}" %>
           </h1>
         </div>
         <div class="panel-body">
@@ -117,7 +117,7 @@
       <div class="panel panel-info">
         <div class="panel-heading">
           <h1 class="panel-title">
-            2 <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= "Upload for #{tab_label_2}" %>
+            2 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> <%= "Upload for #{tab_label_2}" %>
           </h1>
         </div>
         <div class="panel-body">

--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -12,14 +12,14 @@
   <p>This download contains a folder for each measure selected for this product. Inside these folders are XML documents for each patient associated with that measure.</p>
   <%= form_for product, url: patients_vendor_product_path(product.vendor_id, product), :html => { :method => 'GET' } do |f| %>
     <%= button_tag(type: 'submit', class: 'btn btn-primary') do %>
-      <i class = 'fa fa-fw fa-download'></i> Download All Patients (.zip)
+      <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download All Patients (.zip)
     <% end %>
   <% end %>
 <% elsif product.product_tests.measure_tests.where(state: :errored).count.positive? %>
   One or more of the product tests did not build correctly.
 <% else %>
   <p>Patient records are being built for each measure.</p>
-  <p><i class="fas fa-fw fa-spin fa-sync-alt"></i><%= " #{num_measure_tests_ready} of #{num_measure_tests} measures ready" %></p>
+  <p><%= icon('fas fa-fw fa-spin', 'sync-alt', :"aria-hidden" => true) %><%= " #{num_measure_tests_ready} of #{num_measure_tests} measures ready" %></p>
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'bulk_download' }});
   </script>

--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -19,7 +19,7 @@
   One or more of the product tests did not build correctly.
 <% else %>
   <p>Patient records are being built for each measure.</p>
-  <p><i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i><%= " #{num_measure_tests_ready} of #{num_measure_tests} measures ready" %></p>
+  <p><i class="fas fa-fw fa-spin fa-sync-alt"></i><%= " #{num_measure_tests_ready} of #{num_measure_tests} measures ready" %></p>
   <script>
     $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'bulk_download' }});
   </script>

--- a/app/views/products/_filtering_test_link.html.erb
+++ b/app/views/products/_filtering_test_link.html.erb
@@ -16,34 +16,34 @@
 
 <% if test.state != :ready %>
   <% if test.state == :queued %>
-    <i class="far fa-fw fa-circle text-muted" aria-hidden="true"></i>
+    <%= icon('far fa-fw text-muted', 'circle', :"aria-hidden" => true) %>
     <span class="label label-default">queued</span>
   <% elsif test.state == :building %>
-    <i class="fa fa-fw fa-cog fa-spin" aria-hidden="true"></i>
+    <%= icon('fas fa-fw fa-spin', 'cog', :"aria-hidden" => true) %>
     <span class="label label-default">building</span>
   <% elsif test.state == :errored %>
-  <i aria-hidden='true' class = 'fa fa-fw fa-exclamation text-warning'</i>
+  <%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>
   <strong class="text-info">Internal Error</strong>
   <% end %>
 <% else %>
   <% case status %>
   <% when 'passing' %>
-    <i class = 'fa fa-fw fa-check-circle text-success' aria-hidden="true"></i>
+    <%= icon('fas fa-fw text-success', 'check-circle', :"aria-hidden" => true) %>
     <%= link_to 'view', new_task_test_execution_path(task), :class => "label label-success" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'failing'%>
-    <i class = 'fa fa-fw fa-play-circle text-danger' aria-hidden="true"></i>
+    <%= icon('fas fa-fw text-danger', 'play-circle', :"aria-hidden" => true) %>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-danger" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'errored'%>
-    <i class = 'fa fa-fw fa-exclamation-circle text-warning' aria-hidden="true"></i>
+    <%= icon('fas fa-fw text-warning', 'exclamation-circle', :"aria-hidden" => true) %>
     <%= link_to 'retry', new_task_test_execution_path(task), :class => "label label-warning" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% when 'pending'%>
-    <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
+    <%= icon('fas fa-fw fa-spin text-testing', 'gavel', :"aria-hidden" => true) %>
     <%= link_to 'testing...', new_task_test_execution_path(task), :class => 'label label-default' %>
   <% else %>
-    <i class = 'fa fa-fw fa-play-circle text-info' aria-hidden="true"></i>
+    <%= icon('fas fa-fw text-info', 'play-circle', :"aria-hidden" => true) %>
     <%= link_to 'start', new_task_test_execution_path(task), :class => "label label-info" %>
     <%= render partial: '/products/product_test_upload', locals: { task: task } %>
   <% end %>

--- a/app/views/products/_filtering_test_link.html.erb
+++ b/app/views/products/_filtering_test_link.html.erb
@@ -16,7 +16,7 @@
 
 <% if test.state != :ready %>
   <% if test.state == :queued %>
-    <i class="fa fa-fw fa-circle text-muted" aria-hidden="true"></i>
+    <i class="far fa-fw fa-circle text-muted" aria-hidden="true"></i>
     <span class="label label-default">queued</span>
   <% elsif test.state == :building %>
     <i class="fa fa-fw fa-cog fa-spin" aria-hidden="true"></i>

--- a/app/views/products/_filtering_test_status_display.html.erb
+++ b/app/views/products/_filtering_test_status_display.html.erb
@@ -28,7 +28,7 @@
         <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(test.cat3_task) %>">
           <%= render 'filtering_test_link', :test => test, :task => test.cat3_task, :parent_reloading => true %>
         </td>
-        <td class="no-wrap"><i class="fa fa-fw fa-clock-o" aria-hidden="true"></i>
+        <td class="no-wrap"><%= icon('far fa-fw', 'clock', :"aria-hidden" => true) %>
           <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>

--- a/app/views/products/_measure_test_link.html.erb
+++ b/app/views/products/_measure_test_link.html.erb
@@ -11,7 +11,7 @@
 
 <% if test.state != :ready %>
   <% if test.state == :queued %>
-    <i class="fa fa-fw fa-circle text-muted" aria-hidden="true"></i>
+    <i class="far fa-fw fa-circle text-muted" aria-hidden="true"></i>
     <span class="label label-default">queued</span>
   <% elsif test.state == :building %>
     <i class="fa fa-fw fa-cog fa-spin" aria-hidden="true"></i>

--- a/app/views/products/_measure_test_link.html.erb
+++ b/app/views/products/_measure_test_link.html.erb
@@ -11,21 +11,21 @@
 
 <% if test.state != :ready %>
   <% if test.state == :queued %>
-    <i class="far fa-fw fa-circle text-muted" aria-hidden="true"></i>
+    <%= icon('far fa-fw text-muted', 'circle', :"aria-hidden" => true) %>
     <span class="label label-default">queued</span>
   <% elsif test.state == :building %>
-    <i class="fa fa-fw fa-cog fa-spin" aria-hidden="true"></i>
+    <%= icon('fas fa-fw fa-spin', 'cog', :"aria-hidden" => true) %>
     <span class="label label-default">building</span>
   <% elsif test.state == :errored %>
-    <i class= 'fa fa-exclamation-triangle' aria-hidden="true"></i>
+    <%= icon('fas', 'exclamation-triangle', :"aria-hidden" => true) %>
   <% end %>
 <% else %>
   <% case tasks_status(tasks) %>
   <% when 'pending' %>
-    <i class = 'fa fa-fw fa-gavel fa-spin text-testing' aria-hidden = 'true'></i>
+    <%= icon('fas fa-fw fa-spin text-testing', 'gavel', :"aria-hidden" => true) %>
     <span class = 'label label-default'>testing...</span>
   <% else %>
-    <i class = 'fa fa-fw fa-gavel invisible' aria-hidden = 'true'></i>
+    <%= icon('fas fa-fw invisible', 'gavel', :"aria-hidden" => true) %>
     <%= render partial: '/products/product_test_upload', locals: { task: task, label_class: 'label-info' } %>
   <% end %>
 <% end %>

--- a/app/views/products/_measure_tests_table_row.html.erb
+++ b/app/views/products/_measure_tests_table_row.html.erb
@@ -29,7 +29,7 @@
   <%= render partial: '/products/measure_test_link', locals: { test: test, task: task } %>
 </td>
 <td class="no-wrap" data-order="<%= task.updated_at %>">
-  <i class="fa fa-fw fa-clock-o" aria-hidden="true"></i><%= local_time_ago(task.updated_at) %>
+  <%= icon('far fa-fw', 'clock', :"aria-hidden" => true) %><%= local_time_ago(task.updated_at) %>
 </td>
 
 <% # Only reload if the measure_tests_table isn't reloading for us. (This currently only happens in create.js.erb) %>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -54,12 +54,12 @@
               <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product. Allowed filetypes are #{product.supplemental_test_artifact.extension_white_list.join(', ')}." do %>
                 <div class="fileinput fileinput-new input-group" data-provides="fileinput">
                   <div class="form-control" data-trigger="fileinput">
-                    <i class="fa fa-fw fa-file fileinput-exists"></i>
+                    <%= icon('fas fileinput-exists', 'file', :"aria-hidden" => true) %>
                     <span class="fileinput-filename"></span>
                   </div>
                     <span class="input-group-addon btn btn-info btn-file active">
-                    <span class="fileinput-new" data-trigger="fileinput"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</span>
-                    <span class="fileinput-exists" data-trigger="fileinput"><i class="fa fa-fw fa-refresh"></i> Change</span>
+                    <span class="fileinput-new" data-trigger="fileinput"><%= icon('fas', 'mouse-pointer', :"aria-hidden" => true) %> Select file</span>
+                    <span class="fileinput-exists" data-trigger="fileinput"><%= icon('fas', 'sync-alt', :"aria-hidden" => true) %> Change</span>
                     <span style="display:none;">
                       <%= f.file_field :supplemental_test_artifact, class: 'upload-results hidden', :aria => { label: 'supplemental_test_artifact_label' } %>
                     </span>

--- a/app/views/products/favorite.js.erb
+++ b/app/views/products/favorite.js.erb
@@ -1,7 +1,7 @@
 <% if (@product.favorite_user_ids.include? current_user.id) %>
-    $('#product-status-<%=@product.id%> th .button_to button i.fa-star-o').removeClass('fa-star-o').addClass('fa-star');
-    $('#product-status-<%@product.id%> th .button_to button span').text("product favorited");
+    $('#product-status-<%=@product.id%> th .button_to button i.fa-star').removeClass('far').addClass('fas');
+    $('#product-status-<%=@product.id%> th .button_to button span').text("product favorited");
 <% else %>
-    $('#product-status-<%=@product.id%> th .button_to button i.fa-star').removeClass('fa-star').addClass('fa-star-o');
+    $('#product-status-<%=@product.id%> th .button_to button i.fa-star').removeClass('fas').addClass('far');
     $('#product-status-<%=@product.id%> th .button_to button span').text("product not favorited");
 <% end %>

--- a/app/views/records/_calculation_result_icon.html.erb
+++ b/app/views/records/_calculation_result_icon.html.erb
@@ -1,13 +1,12 @@
 <% if result && result.positive? %>
   <span class="sr-only">Pass</span>
   <span class="fa-stack result-marker">
-    <i class="fa fa-circle fa-stack-2x" aria-hidden="true"></i>
-    <i class="fa fa-circle-thin fa-stack-2x" aria-hidden="true"></i>
+    <%= icon('fas fa-stack-2x', 'circle', :"aria-hidden" => true) %>
     <% unless result == 1 && !episode_of_care %>
       <strong class="fa-stack-1x result-text"><span class="sr-only">value of </span><%= result %></strong>
     <% end %>
   </span>
 <% else %>
   <span class="sr-only">Fail</span>
-  <i class="fa fa-circle-thin fa-2x empty-marker" aria-hidden="true"></i>
+  <%= icon('far fa-2x empty-marker', 'circle', :"aria-hidden" => true) %>
 <% end %>

--- a/app/views/records/_calculation_results.html.erb
+++ b/app/views/records/_calculation_results.html.erb
@@ -19,15 +19,14 @@
           <% if value && value.positive? %>
             <span class="sr-only">Pass</span>
             <span class="fa-stack result-marker">
-              <i class="fa fa-circle fa-stack-2x" aria-hidden="true"></i>
-              <i class="fa fa-circle-thin fa-stack-2x" aria-hidden="true"></i>
+              <%= icon('fas fa-stack-2x', 'circle', :"aria-hidden" => true) %>
               <% unless value == 1 && !measure.episode_of_care %>
                 <strong class="fa-stack-1x result-text"><span class="sr-only">value of </span><%= value %></strong>
               <% end %>
             </span>
           <% else %>
             <span class="sr-only">Fail</span>
-            <i class="fa fa-circle-thin fa-2x empty-marker" aria-hidden="true"></i>
+            <%= icon('far fa-2x empty-marker', 'circle', :"aria-hidden" => true) %>
           <% end %>
         </td>
       <% end %>

--- a/app/views/records/_mpl_download.html.erb
+++ b/app/views/records/_mpl_download.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% else %>
   <span class="sr-only">Preparing download for <%= bundle.title %></span>
-  <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i> Preparing Download
+  <i class="fas fa-fw fa-spin fa-sync-alt"></i> Preparing Download
 <% end %>
 <% unless current_mpl_status == :ready %>
   <script>

--- a/app/views/records/_mpl_download.html.erb
+++ b/app/views/records/_mpl_download.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 <% else %>
   <span class="sr-only">Preparing download for <%= bundle.title %></span>
-  <i class="fas fa-fw fa-spin fa-sync-alt"></i> Preparing Download
+  <%= icon('fas fa-fw fa-spin', 'sync-alt', :"aria-hidden" => true) %> Preparing Download
 <% end %>
 <% unless current_mpl_status == :ready %>
   <script>

--- a/app/views/records/by_filter_task.html.erb
+++ b/app/views/records/by_filter_task.html.erb
@@ -13,7 +13,7 @@
     </div>
   <% end %>
   <%= button_to good_results_task_path(@task), :method => :get, :class => "btn btn-default" do %>
-    <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download HTML Patients
+    <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download HTML Patients
   <% end %>
 </div>
 

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -15,7 +15,7 @@
       </div>
     <% end %>
     <%= button_to html_patients_product_test_path(@product_test), :method => :get, :class => "btn btn-default" do %>
-      <i class="fa fa-fw fa-download" aria-hidden="true"></i> Download HTML Patients
+      <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download HTML Patients
     <% end %>
   </div>
 

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -32,17 +32,15 @@
                     <% if value && value.positive? %>
                       <span class="sr-only">Pass</span>
                       <span class="fa-stack result-marker">
-                        <i class="fa fa-circle fa-stack-2x" aria-hidden="true"></i>
-                        <i class="fa fa-circle-thin fa-stack-2x" aria-hidden="true"></i>
+                        <%= icon('fas fa-stack-2x', 'circle', :"aria-hidden" => true) %>
                         <% unless value == 1 && !m.episode_of_care %>
                           <strong class="fa-stack-1x result-text"><span class="sr-only">value of </span><%= value %></strong>
                         <% end %>
                       </span>
                     <% else %>
                       <span class="sr-only">Fail</span>
-                      <i class="fa fa-circle-thin fa-2x empty-marker" aria-hidden="true"></i>
+                      <%= icon('far fa-2x empty-marker', 'circle', :"aria-hidden" => true) %>
                     <% end %>
-                    </span>
                   </td>
                 <% end %>
               </tr>

--- a/app/views/test_executions/_execution_download.html.erb
+++ b/app/views/test_executions/_execution_download.html.erb
@@ -12,16 +12,16 @@
     <%= form_tag(patients_product_test_path(product_test), method: 'get') do |f| %>
       <%= hidden_field_tag :id, :value => product_test.id %>
       <%= button_tag(type: 'submit', class: 'btn btn-info') do %>
-        <i class = 'fa fa-fw fa-download'></i> Download QRDA Category I (.zip)
+        <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download QRDA Category I (.zip)
       <% end %>
     <% end %>
   <% elsif product_test.state == :errored %>
-    <p><i class="fa fa-exlamation-triangle" aria-hidden="true"></i>Cypress encountered an internal error while building this measure. Please contact the Cypress team at https://github.com/projectcypress/cypress/issues, and include the text below:</p>
+    <p><%= icon('fas', 'exlamation-triangle', :"aria-hidden" => true) %>Cypress encountered an internal error while building this measure. Please contact the Cypress team at https://github.com/projectcypress/cypress/issues, and include the text below:</p>
     <code>
       <%= product_test.status_message %>
     </code>
   <% else %>
-    <p><i class="fas fa-fw fa-spin fa-sync-alt"></i> Cypress is building test patients for this measure. You will be able to download a zip file of QRDA Category I documents. </p>
+    <p><%= icon('fas fa-fw fa-spin', 'sync-alt', :"aria-hidden" => true) %> Cypress is building test patients for this measure. You will be able to download a zip file of QRDA Category I documents. </p>
     <script>
       $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_download' }});
     </script>

--- a/app/views/test_executions/_execution_download.html.erb
+++ b/app/views/test_executions/_execution_download.html.erb
@@ -21,7 +21,7 @@
       <%= product_test.status_message %>
     </code>
   <% else %>
-    <p><i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i> Cypress is building test patients for this measure. You will be able to download a zip file of QRDA Category I documents. </p>
+    <p><i class="fas fa-fw fa-spin fa-sync-alt"></i> Cypress is building test patients for this measure. You will be able to download a zip file of QRDA Category I documents. </p>
     <script>
       $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'execution_download' }});
     </script>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -7,7 +7,7 @@
 %>
 
 <% if execution.status_with_sibling == 'incomplete' %>
-  <p class="lead row bg-info execution-status"><i class="fas fa-fw fa-spin fa-sync-alt text-info"></i> In Progress</p>
+  <p class="lead row bg-info execution-status"><%= icon('fas fa-fw fa-spin text-info', 'sync-alt', :"aria-hidden" => true) %> In Progress</p>
   <p>You do not need to reload your browser. Results will automatically display when the tests are done running.</p>
   <% # ajax contacts test_execution's show controller action with format: 'js'. controller then directs to show.js.erb which will wait, then re-render %>
   <script>
@@ -21,19 +21,19 @@
     <% [execution, execution.sibling_execution].compact.each do |ex| %>
       <% ex_type = ex.task._type[0, 2] # get first two letters e.g. C1 or C3 %>
       <% if ex.errored? %>
-        <p class="lead row bg-warning execution-status"><i class="fa fa-fw fa-exclamation-circle text-warning" aria-hidden="true"></i> <%= ex_type %> Execution: An internal error occurred</p>
+        <p class="lead row bg-warning execution-status"><%= icon('fas fa-fw text-warning', 'exclamation-circle', :"aria-hidden" => true) %> <%= ex_type %> Execution: An internal error occurred</p>
       <% elsif ex.passing? %>
         <%= render partial: 'test_executions/results/passing_result', locals: { execution: ex, execution_type: ex_type } %>
       <% elsif ex.failing? %>
         <p class="lead row bg-danger execution-status">
-          <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i> <%= ex_type %> Execution:
+          <%= icon('fas fa-fw text-danger', 'times-circle', :"aria-hidden" => true) %> <%= ex_type %> Execution:
           <%= execution_failure_message(ex) %>
         </p>
       <% end %>
     <% end %>
   <% else %>
     <p class="lead row bg-danger execution-status">
-      <i class="fa fa-fw fa-times-circle text-danger" aria-hidden="true"></i>
+      <%= icon('fas fa-fw text-danger', 'times-circle', :"aria-hidden" => true) %>
       <%= execution_failure_message(execution) %>
     </p>
   <% end %>
@@ -50,7 +50,7 @@
     <h2>Missing or Duplicate Files</h2>
     <ul class="fa-ul">
       <% collected_errors.nonfile.each do |error_message| %>
-        <li><i class="fa-li fa fa-times" aria-hidden="true"></i> <%= error_message %></li>
+        <li><%= icon('fas fa-li', 'times', :"aria-hidden" => true) %> <%= error_message %></li>
       <% end %>
     </ul>
   <% end %>
@@ -66,9 +66,9 @@
               <% if total_errors.positive? %>
                 <div class="file-name">
                   <% if error_result.keys.any? { |s| s != 'Other Warnings' && s != 'CMS Warnings' && error_result[s].execution_errors.count.positive?} %>
-                    <i aria-hidden='true' class='fa fa-fw fa-times text-danger'></i>
+                    <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                   <% else %>
-                    <i aria-hidden='true' class='fa fa-fw fa-exclamation-triangle text-warning'></i>
+                    <%= icon('fas fa-fw text-warning', 'exclamation-triangle', :"aria-hidden" => true) %>
                   <% end %>
                   <%= file_name %>
                 </div>
@@ -80,7 +80,7 @@
                 </div>
               <% else %>
                 <div class="file-name">
-                  <i aria-hidden='true' class='fa fa-fw fa-check text-success'></i>
+                  <%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>
                   <%= file_name %>
                   <span class="sr-only">no errors</span>
                 </div>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -7,7 +7,7 @@
 %>
 
 <% if execution.status_with_sibling == 'incomplete' %>
-  <p class="lead row bg-info execution-status"><i class="fa fa-fw fa-refresh fa-spin text-info"></i> In Progress</p>
+  <p class="lead row bg-info execution-status"><i class="fas fa-fw fa-spin fa-sync-alt text-info"></i> In Progress</p>
   <p>You do not need to reload your browser. Results will automatically display when the tests are done running.</p>
   <% # ajax contacts test_execution's show controller action with format: 'js'. controller then directs to show.js.erb which will wait, then re-render %>
   <script>

--- a/app/views/test_executions/_execution_upload.html.erb
+++ b/app/views/test_executions/_execution_upload.html.erb
@@ -28,7 +28,7 @@
 <%= form_for(TestExecution.new, :html => { method: :post, :multipart => true }, url: task_test_executions_path(task)) do |f| %>
   <div class="fileinput fileinput-new input-group" data-provides="fileinput">
     <div class="form-control" data-trigger="fileinput">
-      <i class="fa fa-fw fa-file fileinput-exists"></i>
+      <%= icon('fas fa-fw fileinput-exists', 'file', :"aria-hidden" => true) %>
       <span class="fileinput-filename"></span>
     </div>
     <% if disable %>
@@ -36,10 +36,10 @@
     <% else %>
       <span class="input-group-addon btn btn-info btn-file active">
     <% end %>
-      <span class="fileinput-new" data-trigger="fileinput"><i class="fa fa-fw fa-mouse-pointer"></i> Select file</span>
-      <span class="fileinput-exists" data-trigger="fileinput"><i class="fa fa-fw fa-refresh"></i> Change</span>
+      <span class="fileinput-new" data-trigger="fileinput"><%= icon('fas', 'mouse-pointer', :"aria-hidden" => true) %> Select file</span>
+      <span class="fileinput-exists" data-trigger="fileinput"><%= icon('fas', 'sync-alt', :"aria-hidden" => true) %> Change</span>
       <%= file_field_tag :results, class: 'upload-results hidden', :disabled => disable, accept: accept_type, :aria => { label: 'execution_upload_label', hidden: true } %>
     </span>
-    <a id = 'submit-upload' class="input-group-addon fileinput-exists btn btn-success"><i class="fa fa-fw fa-upload"></i> Upload</a>
+    <a id = 'submit-upload' class="input-group-addon fileinput-exists btn btn-success"><%= icon('fas', 'upload', :"aria-hidden" => true) %> Upload</a>
   </div>
 <% end %>

--- a/app/views/test_executions/_expected_result_icon.html.erb
+++ b/app/views/test_executions/_expected_result_icon.html.erb
@@ -5,5 +5,5 @@
   </span>
 <% else %>
   <span class="sr-only">Fail</span>
-  <i class="fa fa-circle-thin fa-2x empty-marker" aria-hidden="true"></i>
+  <%= icon('far fa-2x empty-marker', 'circle', :"aria-hidden" => true) %>
 <% end %>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -36,11 +36,12 @@
         </div>
         <div class = 'col-sm-6 text-left margin-top-1'>
           <% if task_status == 'passing' %>
-            <i class = 'fa fa-check text-success'></i><strong class = 'text-success'> Passing</strong>
+
+            <%= icon('fas text-success', 'check', :"aria-hidden" => true) %><strong class = 'text-success'> Passing</strong>
           <% elsif task_status == 'failing' %>
-            <i class = 'fa fa-times text-danger'></i><strong class = 'text-danger'> Failing</strong>
+            <%= icon('fas text-danger', 'times', :"aria-hidden" => true) %><strong class = 'text-danger'> Failing</strong>
           <% elsif task_status == 'errored' %>
-            <i class = 'fa fa-exclamation text-warning'></i><strong class = 'text-warning'> Internal Error</strong>
+            <%= icon('fas text-warning', 'exclamation', :"aria-hidden" => true) %><strong class = 'text-warning'> Internal Error</strong>
           <% else # incomplete (in progress b/c execution exists) %>
             <strong class = 'text-info'>In Progress...</strong>
           <% end %>

--- a/app/views/test_executions/file_result.html.erb
+++ b/app/views/test_executions/file_result.html.erb
@@ -4,7 +4,7 @@
 
 <br/>
 <%= link_to(task_test_execution_path(@task, @test_execution), class: 'btn btn-primary') do %>
-  <i class = 'fa fa-fw fa-angle-left' aria-hidden = 'true'></i>Return to Testing
+  <%= icon('fas fa-fw', 'angle-left', :"aria-hidden" => true) %>Return to Testing
 <% end %>
 <br/>
 <br/>

--- a/app/views/test_executions/results/_node.html.erb
+++ b/app/views/test_executions/results/_node.html.erb
@@ -59,7 +59,7 @@
         <% btn_errors = '' %>
         <% errors.each { |error| btn_errors << " error_#{error.id}" } %>
         <button type = "button" class="btn btn-warning error-popup-btn pull-right <%= btn_errors %>" data-toggle="popover" data-placement = "bottom" title = '<%= popup_title %>' data-html = 'true' data-content = '<%= popup_content %>'>
-          <i class="fa fa-fw fa-comment" data-error="<%= %{error_#{error_id}} %>" aria-hidden="true"></i> <span><%= popup_button_text %></span>
+          <%= icon('fas fa-fw', 'comment', {:"aria-hidden" => true, :"data-error" => "error_#{error_id}"}) %> <span><%= popup_button_text %></span>
         </button>
       <% end %>
     <% end %>

--- a/app/views/test_executions/results/_passing_result.html.erb
+++ b/app/views/test_executions/results/_passing_result.html.erb
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-sm-7">
-    <p class="lead bg-success execution-status"><i class="fa fa-fw fa-check-circle text-success"></i> <%= execution_type + " Execution: " unless execution_type.nil? %>Passed</p>
+    <p class="lead bg-success execution-status"><%= icon('fas fa-fw text-success', 'check-circle', :"aria-hidden" => true) %> <%= execution_type + " Execution: " unless execution_type.nil? %>Passed</p>
     <div class="row">
       <div class="col-sm-6">
         <% if execution.task.product_test.is_a? MeasureTest %>
@@ -15,14 +15,14 @@
           <% if displaying_cat1?(execution.task) %>
             <% if cat3_task && cat3_task.status != "passing" %>
               <li>
-                <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                <%= icon('fas fa-li', 'list', :"aria-hidden" => true) %>
                 <%= link_to "Try the associated QRDA Category III Measure Test", new_task_test_execution_path(cat3_task) %>
               </li>
             <% end %>
           <% else %>
             <% if cat1_task && cat1_task.status != "passing" %>
               <li>
-                <i class="fa-li fa fa-list" aria-hidden="true"></i>
+                <%= icon('fas fa-li', 'list', :"aria-hidden" => true) %>
                 <%= link_to "Try the associated QRDA Category I Measure Test", new_task_test_execution_path(cat1_task) %>
               </li>
             <% end %>
@@ -33,18 +33,18 @@
         <ul class="fa-ul">
           <% if execution.task.product_test.product.c1_test %>
             <li>
-              <i class="fa-li fa fa-list" aria-hidden="true"></i>
+              <%= icon('fas fa-li', 'list', :"aria-hidden" => true) %>
               <%= link_to 'Try a different Measure Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#MeasureTest" %>
             </li>
             <li>
-              <i class="fa-li fa fa-eye" aria-hidden="true"></i>
+              <%= icon('fas fa-li', 'eye', :"aria-hidden" => true) %>
               <%= link_to 'Try a Record Sample', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#ChecklistTest" %>
             </li>
           <% end %>
 
           <% if execution.task.product_test.product.c4_test %>
             <li>
-              <i class="fa-li fa fa-filter" aria-hidden="true"></i>
+              <%= icon('fas fa-li', 'filter', :"aria-hidden" => true) %>
               <%= link_to 'Try a Filtering Test', vendor_product_path(execution.task.product_test.product.vendor.id, execution.task.product_test.product.id) + "#FilteringTest" %>
             </li>
           <% end %>

--- a/app/views/test_executions/results/_xmlnav.html.erb
+++ b/app/views/test_executions/results/_xmlnav.html.erb
@@ -2,24 +2,24 @@
   <div class="btn-group" role="toolbar" aria-label="File error navigation">
     <div class="btn-group" role="group">
       <button type="button" class="btn btn-link nav-link nav-first">
-        <i class = "fa fa-fw fa-fast-backward" aria-hidden="true"></i> First
+        <%= icon('fas fa-fw', 'fast-backward', :"aria-hidden" => true) %> First
       </button>
 
       <button type="button" class="btn btn-link nav-link nav-prev">
-        <i class = "fa fa-fw fa-step-backward" aria-hidden="true"></i> Prev
+        <%= icon('fas fa-fw', 'step-backward', :"aria-hidden" => true) %> Prev
       </button>
 
       <button type="button" class="btn btn-link nav-link nav-next">
-        Next <i class = "fa fa-fw fa-step-forward" aria-hidden="true"></i>
+        Next <%= icon('fas fa-fw', 'step-forward', :"aria-hidden" => true) %>
       </button>
 
       <button type="button" class="btn btn-link nav-link nav-last">
-        Last <i class = "fa fa-fw fa-fast-forward" aria-hidden="true"></i>
+        Last <%= icon('fas fa-fw', 'fast-forward', :"aria-hidden" => true) %>
       </button>
     </div>
     <div class="btn-group" role="group">
       <a href="#results_panel" class="btn btn-link">
-        <i class = "fa fa-arrow-up"></i> Back to top
+        <%= icon('fas', 'arrow-up', :"aria-hidden" => true) %> Back to top
       </a>
     </div>
   </div>

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -13,10 +13,10 @@
 <% unless @task.is_a?(C1ChecklistTask) || @task.is_a?(C3ChecklistTask) %>
   <div class="panel clearfix">
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'prev').id), :method => :get, :class => "btn btn-default pull-left" do %>
-      <i class="fa fa-fw fa-step-backward" aria-hidden="true"></i> Previous Test: <%= iterate_task(@task, 'prev').product_test.cms_id %>
+      <%= icon('fas fa-fw', 'step-backward', :"aria-hidden" => true) %> Previous Test: <%= iterate_task(@task, 'prev').product_test.cms_id %>
     <% end %>
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'next').id), :method => :get, :class => "btn btn-default pull-right" do %>
-      Next Test: <%= iterate_task(@task, 'next').product_test.cms_id %> <i class="fa fa-fw fa-step-forward" aria-hidden="true"></i>
+      Next Test: <%= iterate_task(@task, 'next').product_test.cms_id %> <%= icon('fas fa-fw', 'step-forward', :"aria-hidden" => true) %>
     <% end %>
   </div>
 <% end %>
@@ -48,7 +48,7 @@
     <div class="panel panel-info">
       <div class="panel-heading">
         <h1 class="panel-title test-step">
-          <%= index + 1 %> <i class="fa fa-fw fa-bolt" aria-hidden="true"></i> <%= step.title %>
+          <%= index + 1 %> <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> <%= step.title %>
         </h1>
       </div>
       <div class="panel-body">

--- a/app/views/vendors/_vendor.html.erb
+++ b/app/views/vendors/_vendor.html.erb
@@ -3,10 +3,10 @@
   <td>
     <%= button_to vendor_favorite_path(vendor), remote: true, :class => "btn btn-link btn-pop" do %>
       <% if (vendor.favorite_user_ids.include? current_user.id)  %>
-        <i class="fa fa-fw fa-star" aria-hidden="true"></i>
+        <i class="fas fa-fw fa-star" aria-hidden="true"></i>
         <span class="sr-only">vendor favorited</span>
       <% else %>
-        <i class="fa fa-fw fa-star-o" aria-hidden="true"></i>
+        <i class="far fa-fw fa-star" aria-hidden="true"></i>
         <span class="sr-only">vendor not favorited</span>
       <% end %>
     <% end %>

--- a/app/views/vendors/_vendor.html.erb
+++ b/app/views/vendors/_vendor.html.erb
@@ -3,10 +3,10 @@
   <td>
     <%= button_to vendor_favorite_path(vendor), remote: true, :class => "btn btn-link btn-pop" do %>
       <% if (vendor.favorite_user_ids.include? current_user.id)  %>
-        <i class="fas fa-fw fa-star" aria-hidden="true"></i>
+        <%= icon('fas fa-fw', 'star', :"aria-hidden" => true) %>
         <span class="sr-only">vendor favorited</span>
       <% else %>
-        <i class="far fa-fw fa-star" aria-hidden="true"></i>
+        <%= icon('far fa-fw', 'star', :"aria-hidden" => true) %>
         <span class="sr-only">vendor not favorited</span>
       <% end %>
     <% end %>
@@ -15,7 +15,7 @@
   <td>
     <% if vendor_statuses['total'].zero? %>
       <%= button_to new_vendor_product_path(vendor), :method => :get, :class => "btn btn-primary btn-sm" do %>
-        <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
+        <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Product
       <% end %>
     <% else %>
       <%= vendor_statuses['total'] %>
@@ -34,7 +34,7 @@
   <% end %>
   <td class="text-right">
     <%= button_to edit_vendor_path(vendor), :method => :get, :class => "btn btn-sm btn-default" do %>
-      <i class="fa fa-fw fa-wrench" aria-hidden="true"></i> Edit Vendor
+      <%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %> Edit Vendor
     <% end %>
   </td>
 </tr>

--- a/app/views/vendors/favorite.js.erb
+++ b/app/views/vendors/favorite.js.erb
@@ -1,7 +1,7 @@
 <% if (@vendor.favorite_user_ids.include? current_user.id) %>
-    $('#vendor-status-<%=@vendor.id%> td .button_to button i.fa-star-o').removeClass('fa-star-o').addClass('fa-star');
+    $('#vendor-status-<%=@vendor.id%> td .button_to button i.fa-star').removeClass('far').addClass('fas');
     $('#vendor-status-<%=@vendor.id%> td .button_to button span').text("vendor favorited");
 <% else %>
-    $('#vendor-status-<%=@vendor.id%> td .button_to button i.fa-star').removeClass('fa-star').addClass('fa-star-o');
+    $('#vendor-status-<%=@vendor.id%> td .button_to button i.fa-star').removeClass('fas').addClass('far');
     $('#vendor-status-<%=@vendor.id%> td .button_to button span').text("vendor not favorited");
 <% end %>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -2,12 +2,12 @@
   <p class="lead">
     Start EHR Certification with
     <%= button_to new_vendor_path, :method => :get, :class => "btn btn-primary btn-lg" do %>
-      <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Vendor
+      <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Vendor
     <% end %>
   </p>
 <% else %>
   <%= button_to new_vendor_path, :method => :get, :class => "btn btn-primary pull-right" do %>
-    <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Vendor
+    <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Vendor
   <% end %>
 
   <% @favorites = @vendors.select{ |v| v.favorite_user_ids.include? current_user.id} %>
@@ -19,10 +19,10 @@
           <th scope="col"><span class="sr-only">Actions</span></th>
           <th scope="col">Vendor</th>
           <th scope="col">Products</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-check text-success"></i> Passing</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-times text-danger"></i> Failing</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-exclamation text-warning"></i> Errored</th>
-          <th scope="col"><i aria-hidden="true" class="far fa-fw fa-circle text-info"></i> Incomplete</th>
+          <th scope="col"><%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>Passing</th>
+          <th scope="col"><%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>Failing</th>
+          <th scope="col"><%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>Errored</th>
+          <th scope="col"><%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>Incomplete</th>
           <th scope="col"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
@@ -41,10 +41,10 @@
           <th scope="col"><span class="sr-only">Actions</span></th>
           <th scope="col">Vendor</th>
           <th scope="col">Products</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-check text-success"></i> Passing</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-times text-danger"></i> Failing</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-exclamation text-warning"></i> Errored</th>
-          <th scope="col"><i aria-hidden="true" class="far fa-fw fa-circle text-info"></i> Incomplete</th>
+          <th scope="col"><%= icon('fas fa-fw text-success', 'check', :"aria-hidden" => true) %>Passing</th>
+          <th scope="col"><%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>Failing</th>
+          <th scope="col"><%= icon('fas fa-fw text-warning', 'exclamation', :"aria-hidden" => true) %>Errored</th>
+          <th scope="col"><%= icon('far fa-fw text-info', 'circle', :"aria-hidden" => true) %>Incomplete</th>
           <th scope="col"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>

--- a/app/views/vendors/index.html.erb
+++ b/app/views/vendors/index.html.erb
@@ -22,7 +22,7 @@
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-check text-success"></i> Passing</th>
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-times text-danger"></i> Failing</th>
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-exclamation text-warning"></i> Errored</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-circle-o text-info"></i> Incomplete</th>
+          <th scope="col"><i aria-hidden="true" class="far fa-fw fa-circle text-info"></i> Incomplete</th>
           <th scope="col"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>
@@ -44,7 +44,7 @@
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-check text-success"></i> Passing</th>
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-times text-danger"></i> Failing</th>
           <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-exclamation text-warning"></i> Errored</th>
-          <th scope="col"><i aria-hidden="true" class="fa fa-fw fa-circle-o text-info"></i> Incomplete</th>
+          <th scope="col"><i aria-hidden="true" class="far fa-fw fa-circle text-info"></i> Incomplete</th>
           <th scope="col"><span class="sr-only">Actions</span></th>
         </tr>
       </thead>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -4,7 +4,7 @@
   <p class="lead">
     Start EHR Certification with
     <%= button_to new_vendor_product_path(@vendor), :method => :get, :class => "btn btn-primary btn-lg" do %>
-      <i class="fa fa-fw fa-plus" aria-hidden="true"></i> Add Product
+      <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Product
     <% end %>
   </p>
 <% else %>
@@ -26,7 +26,7 @@
           <%= link_to('Loading Error - Try Again?', url_for(page: @products_nonfav.current_page + 1)) %>
         </p>
         <p id="loading-more" class="default-hidden">
-          <i class="fas fa-fw fa-spin fa-sync-alt"></i>
+          <%= icon('fas fa-fw fa-spin', 'sync-alt', :"aria-hidden" => true) %>
           Loading More Products
         </p>
       </div>

--- a/app/views/vendors/show.html.erb
+++ b/app/views/vendors/show.html.erb
@@ -26,7 +26,7 @@
           <%= link_to('Loading Error - Try Again?', url_for(page: @products_nonfav.current_page + 1)) %>
         </p>
         <p id="loading-more" class="default-hidden">
-          <i class="fa fa-fw fa-refresh fa-spin inline-icon info-icon"></i>
+          <i class="fas fa-fw fa-spin fa-sync-alt"></i>
           Loading More Products
         </p>
       </div>

--- a/test/helpers/vendors_helper_test.rb
+++ b/test/helpers/vendors_helper_test.rb
@@ -150,15 +150,19 @@ class VendorsHelperTest < ActiveJob::TestCase
 
   def test_status_to_css_classes
     assert_equal 'status-passing', status_to_css_classes('passing')['cell']
-    assert_equal 'fa-check', status_to_css_classes('passing')['icon']
+    assert_equal 'check', status_to_css_classes('passing')['icon']
+    assert_equal 'fas', status_to_css_classes('passing')['type']
     assert_equal 'text-success', status_to_css_classes('passing')['text']
     assert_equal 'status-failing', status_to_css_classes('failing')['cell']
-    assert_equal 'fa-times', status_to_css_classes('failing')['icon']
+    assert_equal 'times', status_to_css_classes('failing')['icon']
+    assert_equal 'fas', status_to_css_classes('failing')['type']
     assert_equal 'text-danger', status_to_css_classes('failing')['text']
     assert_equal 'status-not-started', status_to_css_classes('not_started')['cell']
-    assert_equal 'fa-circle-o', status_to_css_classes('not_started')['icon']
+    assert_equal 'circle', status_to_css_classes('not_started')['icon']
+    assert_equal 'far', status_to_css_classes('not_started')['type']
     assert_equal 'text-info', status_to_css_classes('not_started')['text']
-    assert_equal 'fa-exclamation', status_to_css_classes('errored')['icon']
+    assert_equal 'exclamation', status_to_css_classes('errored')['icon']
+    assert_equal 'fas', status_to_css_classes('errored')['type']
     assert_equal 'status-errored', status_to_css_classes('errored')['cell']
     assert_equal 'text-warning', status_to_css_classes('errored')['text']
   end


### PR DESCRIPTION
This fixes a bug with the measure selection options on the product page. Previously the heading `Community/Population Health` was breaking the `Eligible Hospital eCQMs` and `Eligible Professional eCQMs` headings since as soon as the filter tried to search for something with a `/` in it, a syntax error would be raised.

This also renames all the font awesome icons from the version 4 names to the version 5 names.

I think I got all the icons but if anyone spots any I missed please let me know.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-269
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code