### PR TITLE
parse_and_save_record needs options to be passed in to construct the …

### DIFF
--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -45,7 +45,7 @@ module Validators
       "#{hqmf_qrda_tuple['hqmf_name']}:"
     end
 
-    def parse_and_save_record(doc)
+    def parse_and_save_record(doc, options)
       patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
       Cypress::GoImport.replace_negated_codes(patient, @bundle)
       patient.save
@@ -61,7 +61,7 @@ module Validators
       mrn, = get_record_identifiers(doc, options)
       return false unless mrn
 
-      record = parse_and_save_record(doc)
+      record = parse_and_save_record(doc, options)
       return false unless record
 
       # This Logic will need to be updated with CQL calculations


### PR DESCRIPTION
…error message

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code