### PR TITLE
Fix spinner on bundle import jobs

### DIFF
--- a/app/views/admin/_bundle_list.html.erb
+++ b/app/views/admin/_bundle_list.html.erb
@@ -68,7 +68,7 @@
         <td class="tracker-status">
           <%= tracker.status %>
           <% if tracker.status == :working %>
-            <%= icon('fas fa-fw', 'sync-alt', :"aria-hidden" => true) %>
+            <%= icon('fas fa-fw fa-spin', 'sync-alt', :"aria-hidden" => true) %>
           <% end %>
         </td>
         <td><%= tracker.log_message.last%></td>


### PR DESCRIPTION
Looks like the spinning import icon got messed up when I was messing with icons. This should fix that.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: (N/A)
- [x] Internal ticket links to this PR (N/A)
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases N/A, tested locally
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code