### PR TITLE
Remove certification edition option

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -265,31 +265,12 @@ ready_run_once = function() {
     }
   });
 
-  // Changing the certification edition
-  $('.btn-checkbox input[name="product[cert_edition]"]').on('change', function() {
-    if ($(this).attr('disabled') != true) {
-      var edition = $(this).val();
-      if (edition == '2014') {
-        setCheckboxDisabled('#product_duplicate_patients', true);
-        setCheckboxDisabled('#product_c4_test', true);
-      }
-      else if (edition == '2015') {
-        setCheckboxDisabled('#product_duplicate_patients', false);
-        setCheckboxDisabled('#product_c4_test', false);
-        $('.btn-checkbox input[name="product[c2_test]"]').trigger('change');
-      }
-    }
-  });
-
   // Check Duplicate Records on C2 Test check
   $('.btn-checkbox input[name="product[c2_test]"]').on('change', function() {
     if ($(this).attr('disabled') != true) {
-      var edition = $('.btn-checkbox input[name="product[cert_edition]"]:checked').val();
       var c2_checked = $(this).prop('checked');
-      if (edition == '2015') {
-        setCheckboxDisabled('#product_duplicate_patients', !c2_checked);
-        $('.btn-checkbox input[name="product[duplicate_patients]"]').prop('checked', c2_checked);
-      }
+      setCheckboxDisabled('#product_duplicate_patients', !c2_checked);
+      $('.btn-checkbox input[name="product[duplicate_patients]"]').prop('checked', c2_checked);
     }
   });
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -129,7 +129,7 @@ class ProductsController < ApplicationController
   def product_params
     params[:product][:name]&.strip!
     params.require(:product).permit(:name, :version, :description, :randomize_patients, :duplicate_patients, :shift_patients,
-                                    :bundle_id, :measure_selection, :cert_edition, :c1_test, :c2_test, :c3_test, :c4_test,
+                                    :bundle_id, :measure_selection, :c1_test, :c2_test, :c3_test, :c4_test,
                                     :supplemental_test_artifact, :remove_supplemental_test_artifact, measure_ids: [])
   end
 

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -9,22 +9,6 @@
           <%= f.text_field :version %>
           <%= f.text_area :description %>
 
-          <legend class="control-label">Certification Edition</legend>
-          <div class="radio">
-            <%= f.form_group :cert_edition, help: "Select the certification edition." do %>
-              <%= f.radio_button :cert_edition, "2014",
-                                 label: "2014 Edition",
-                                 label_class: "btn btn-checkbox",
-                                 disabled: !product.new_record?,
-                                 checked: product.cert_edition == "2014" %>
-              <%= f.radio_button :cert_edition, "2015",
-                                 label: "2015 Edition",
-                                 label_class: "btn btn-checkbox",
-                                 disabled: !product.new_record?,
-                                 checked: product.cert_edition == "2015" %>
-            <% end # form_group %>
-          </div>
-
           <fieldset id="certification_options">
             <legend class="control-label">Certification Types</legend>
             <div id="certifications_errors_container"></div>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -13,8 +13,6 @@
     <dd><%= @product.name %></dd>
     <dt>Bundle</dt>
     <dd><%= "#{@bundle.title} v#{@bundle.version}" %></dd>
-    <dt>Certification Edition</dt>
-    <dd><%= @product.cert_edition %></dd>
     <dt>Cypress Version</dt>
     <dd><%= Cypress::Application::VERSION %></dd>
   </dl>

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -37,24 +37,15 @@ Scenario: Unsuccessful Create Product Because No Task Type Selected
 
 Scenario: Successful Create Product with debug mode off and C2 Type selected
   When debug mode is false
-  When a user creates a 2015 product with c1, c2 certifications and visits that product page
+  When a user creates a product with c1, c2 certifications and visits that product page
   Then the product value for randomize_patients should be true
   Then the product value for duplicate_patients should be true
-  Then the product value for cert_edition should be 2015
 
 Scenario: Successful Create Product with debug mode off and C1 Type selected
   When debug mode is false
-  When a user creates a 2015 product with c1 certifications and visits that product page
+  When a user creates a product with c1 certifications and visits that product page
   Then the product value for randomize_patients should be true
   Then the product value for duplicate_patients should be false
-  Then the product value for cert_edition should be 2015
-
-Scenario: Successful Create Product with debug mode off in 2014 cert mode and C2 Type selected
-  When debug mode is false
-  When a user creates a 2014 product with c1, c2 certifications and visits that product page
-  Then the product value for randomize_patients should be true
-  Then the product value for duplicate_patients should be false
-  Then the product value for cert_edition should be 2014
 
 Scenario: Successful Create Product with Multiple Measures From Different Groups
   When the user creates a product with multiple measures from different groups
@@ -104,35 +95,18 @@ Scenario: Filtering properly hides irrelevant measures and tabs
   And the user types "CMS127v7" into the measure filter box
   Then "CMS127v7" is active on the screen
 
-Scenario: Changing certification type updates options appropriately
+Scenario: Options are appropriately enabled
   When the user navigates to the create product page
-  And the user chooses the "2014" Certification Edition
-  Then "C4 Test" checkbox should be disabled
-  Then "Duplicate Records" checkbox should be disabled
-
-Scenario: Changing certification type back and forth updates options appropriately
-  When the user navigates to the create product page
-  And the user chooses the "2014" Certification Edition
-  And the user chooses the "2015" Certification Edition
   Then "C4 Test" checkbox should be enabled
   Then "C4 Test" checkbox should be unchecked
 
-Scenario: Checking C2 Test updates Duplidate Records appropriately on 2015 cert edition
+Scenario: Checking C2 Test updates Duplicate Records
   When the user navigates to the create product page
-  And the user chooses the "2015" Certification Edition
   And the user chooses the "c2" Certification Type
   Then "Duplicate Records" checkbox should be enabled
   Then "Duplicate Records" checkbox should be checked
   Then "C4 Test" checkbox should be enabled
   Then "C4 Test" checkbox should be unchecked
-
-Scenario: Checking C2 Test updates Duplidate Records appropriately on 2015 cert edition
-  When the user navigates to the create product page
-  And the user chooses the "2014" Certification Edition
-  And the user chooses the "c2" Certification Type
-  Then "Duplicate Records" checkbox should be disabled
-  Then "Duplicate Records" checkbox should be unchecked
-  Then "C4 Test" checkbox should be disabled
 
 Scenario: Successful Cancel Create Product
   When the user cancels creating a product

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -5,43 +5,43 @@ Background:
   And the user has created a vendor with a product
 
 Scenario: Successful Select C1 and View Tabs
-  When a user creates a 2015 product with c1 certifications and visits that product page
+  When a user creates a product with c1 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and View Tabs
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C3 and View Tabs
-  When a user creates a 2015 product with c1, c3 certifications and visits that product page
+  When a user creates a product with c1, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C4 and View Tabs
-  When a user creates a 2015 product with c1, c4 certifications and visits that product page
+  When a user creates a product with c1, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and C3 and View Tabs
-  When a user creates a 2015 product with c2, c3 certifications and visits that product page
+  When a user creates a product with c2, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C2 and C4 and View Tabs
-  When a user creates a 2015 product with c2, c4 certifications and visits that product page
+  When a user creates a product with c2, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C3 and View Tabs
-  When a user creates a 2015 product with c1, c2, c3 certifications and visits that product page
+  When a user creates a product with c1, c2, c3 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C4 and View Tabs
-  When a user creates a 2015 product with c1, c2, c4 certifications and visits that product page
+  When a user creates a product with c1, c2, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Select C1 and C2 and C3 and C4 and View Tabs
-  When a user creates a 2015 product with c1, c2, c3, c4 certifications and visits that product page
+  When a user creates a product with c1, c2, c3, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
 
 Scenario: Successful Download All Patients
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should be able to download all patients
@@ -49,7 +49,7 @@ Scenario: Successful Download All Patients
   Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot View Download All Patients
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests do not have a state of ready
   And the user visits the product page
   Then the user should not be able to download all patients
@@ -57,7 +57,7 @@ Scenario: Cannot View Download All Patients
   Then the page should be accessible according to: wcag2aa
 
 Scenario: Can Download Report
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should be able to download the report
@@ -66,18 +66,18 @@ Scenario: Cannot Download Report when not an ATL
   Given the user is signed in as a non admin
   Given the user has created a vendor
   Given the user is owner of the vendor
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should not be able to download the report
 
 Scenario: Cannot Download a Supplemental Test Artifact when not uploaded
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests have a state of ready
   Then the user should not be able to download the supplemental test artifact
 
 Scenario: Can Multi Upload Cat I
-  When a user creates a 2015 product with c1, c2 certifications and visits that product page
+  When a user creates a product with c1, c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
   And the user visits the product page
@@ -86,14 +86,14 @@ Scenario: Can Multi Upload Cat I
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload Cat III
-  When a user creates a 2015 product with c2 certifications and visits that product page
+  When a user creates a product with c2 certifications and visits that product page
   And all product tests have a state of ready
   And the user visits the product page
   And the user uploads a cat III document to product test 1
   Then the user should see a cat III test testing for product test 1
 
 Scenario: Can Multi Upload To Filtering Test
-  When a user creates a 2015 product with c1, c4 certifications and visits that product page
+  When a user creates a product with c1, c4 certifications and visits that product page
   And the user adds a product test
   And filtering tests are added to product
   And all product tests have a state of ready
@@ -105,7 +105,7 @@ Scenario: Can Multi Upload To Filtering Test
   And the user should see a cat III test testing for filtering test 1
 
 Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times
-  When a user creates a 2015 product with c1 certifications and visits that product page
+  When a user creates a product with c1 certifications and visits that product page
   And the user adds a product test
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
@@ -119,7 +119,7 @@ Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times with page reload before test completion
-  When a user creates a 2015 product with c1 certifications and visits that product page
+  When a user creates a product with c1 certifications and visits that product page
   And the user adds a product test
   And all product tests have a state of ready
   And the user adds cat I tasks to all product tests
@@ -136,7 +136,7 @@ Scenario: Can Multi Upload to the Same Task on a Measure Test Multiple Times wit
   Then the user should see a cat I test testing for product test 1
 
 Scenario: Can Multi Upload to the Same Task on a Filtering Test Multiple Times
-  When a user creates a 2015 product with c1, c4 certifications and visits that product page
+  When a user creates a product with c1, c4 certifications and visits that product page
   And the user adds a product test
   And filtering tests are added to product
   And all product tests have a state of ready

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -19,7 +19,6 @@ And(/^the user has created a vendor with a product selecting C4 testing$/) do
                      'shift_patients' => '0',
                      'bundle_id' => bundle_id,
                      'measure_selection' => 'custom',
-                     'cert_edition' => '2015',
                      'c1_test' => '1',
                      'c2_test' => '0',
                      'c3_test' => '0',

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -43,13 +43,11 @@ When(/^debug mode is (.*)$/) do |debug_mode_value|
 end
 
 # certs argument stands for certifications and should be a comma separated list of some of these values: c1, c2, c3, c4
-When(/^a user creates a (.*) product with (.*) certifications( and a supplemental artifact)? and visits that product page$/) do |cert_ed, certs, sta|
-  certs = certs.split(', ')
+When(/^a user creates a product with (.*) certifications( and a supplemental artifact)? and visits that product page$/) do |certs, sta|
   steps %( When the user navigates to the create product page for vendor #{@vendor.name} )
   product_name = "mp #{rand}"
   file_path = Rails.root.join('app', 'assets', 'images', 'cypress_bg_cropped.png')
   page.fill_in 'Name', :with => product_name
-  page.choose("#{cert_ed} Edition")
   page.find('#product_c1_test').click if certs.include? 'c1'
   page.find('#product_c2_test').click if certs.include? 'c2'
   page.find('#product_c3_test').click if certs.include? 'c3'
@@ -323,10 +321,6 @@ end
 And(/^the user uploads a cat III document to filtering test (.*)$/) do |filtering_test_number|
   html_id = td_div_id_for_cat3_task_for_filtering_test(filtering_test_number)
   attach_xml_to_multi_upload(html_id)
-end
-
-And(/^the user chooses the "(.*)" Certification Edition$/) do |certification_edition|
-  page.find("#product_cert_edition_#{certification_edition}").click
 end
 
 And(/^the user chooses the "(.*)" Certification Type$/) do |certification_type|

--- a/lib/cypress/create_total_test_zip.rb
+++ b/lib/cypress/create_total_test_zip.rb
@@ -6,7 +6,7 @@ module Cypress
         add_measure_zips(z, product.product_tests.measure_tests, format)
         add_checklist_zips(z, product.product_tests.checklist_tests, criteria_list)
         add_filtering_zips(z, product.product_tests.filtering_tests, format, filtering_list) unless product.product_tests.filtering_tests.empty?
-        add_html_files(z, product.product_tests) unless product.cert_edition == '2015' && product.c2_test
+        add_html_files(z, product.product_tests) unless product.c2_test
       end
       file
     end

--- a/test/factories/products.rb
+++ b/test/factories/products.rb
@@ -18,16 +18,9 @@ FactoryBot.define do
         c2_test true
         association :vendor, name: 'Static Bundle Vendor'
       end
-      trait :default_2014 do
-        c1_test true
-        c2_test true
-        cert_edition '2014'
-        association :vendor, name: '2014 Vendor'
-      end
       trait :no_c2 do
         c1_test true
         c2_test false
-        cert_edition '2015'
         association :vendor, name: '2015 Vendor No C2'
       end
       measure_ids ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
@@ -38,7 +31,6 @@ FactoryBot.define do
       end
 
       factory :product_static_bundle, :traits => [:default]
-      factory :product_2014, :traits => [:default_2014]
       factory :product_no_c2, :traits => [:no_c2]
     end
   end

--- a/test/models/checklist_test_test.rb
+++ b/test/models/checklist_test_test.rb
@@ -126,6 +126,7 @@ class ChecklistTestTest < ActiveJob::TestCase
 
   def test_inappropriate_code_for_attribute_vs
     @test.create_checked_criteria
+    simplify_criteria(@test)
     checked_criteria = @test.checked_criteria[0]
     checked_criteria.attribute_code = 'thisalsoisntacode'
     checked_criteria.validate_criteria

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -78,30 +78,6 @@ class MeasureTestTest < ActiveJob::TestCase
     end
   end
 
-  def test_create_task_2014_edition
-    product = @vendor.products.create(name: 'test_product', c1_test: true, randomize_patients: true, cert_edition: '2014',
-                                      bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
-    pt = product.product_tests.build({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
-                                       bundle_id: @bundle.id }, MeasureTest)
-    pt.create_tasks
-    assert pt.tasks.c1_task, 'product test should have a c1_task'
-    assert_equal false, pt.tasks.cat1_filter_task, 'product test for 2014 certification should not have a C4 task'
-    assert_equal false, pt.tasks.cat3_filter_task, 'product test for 2014 certification should not have a C4 task'
-
-    perform_enqueued_jobs do
-      assert pt.save, 'should be able to save valid product test'
-      assert_performed_jobs 1
-      assert pt.patients.count.positive?, 'product test creation should have created random number of test records'
-      assert pt.patients.count < 10, 'product tests for 2014 editions should have fewer than 10 records'
-      pt.reload
-      assert_not_nil pt.patient_archive, 'Product test should have archived patient records'
-      assert_not_nil pt.html_archive, 'Product test should have archived patient HTMLs'
-      assert_equal pt.patients.count, count_zip_entries(pt.patient_archive.file.path), 'Archive should contain more files than the test'
-      assert count_zip_entries(pt.html_archive.file.path) == count_zip_entries(pt.patient_archive.file.path), 'QRDA Archive and HTML archive should have same # files'
-      assert_not_nil pt.expected_results, 'Product test should have expected results'
-    end
-  end
-
   def test_create_task_c2
     @product.c2_test = true
     pt = @product.product_tests.build({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -25,7 +25,6 @@ class ProducTest < ActiveSupport::TestCase
                            bundle_id: @bundle.id).save!
     assert pt.valid?, 'record should be valid'
     assert pt.save, 'Should be able to create and save a Product'
-    assert_equal '2015', pt.cert_edition
     assert_equal true, pt.randomize_patients
     assert_equal false, pt.duplicate_patients
   end
@@ -37,33 +36,8 @@ class ProducTest < ActiveSupport::TestCase
                            bundle_id: @bundle.id).save!
     assert pt.valid?, 'record should be valid'
     assert pt.save, 'Should be able to create and save a Product'
-    assert_equal '2015', pt.cert_edition
     assert_equal true, pt.randomize_patients
     assert_equal true, pt.duplicate_patients
-  end
-
-  def test_create_2014_certification_no_c2
-    pt = Product.new(vendor: @vendor, name: 'test_product', c1_test: true, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'], bundle_id: @bundle.id, cert_edition: '2014')
-    pt.product_tests.build(name: 'test_product_test_name',
-                           measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
-                           bundle_id: @bundle.id).save!
-    assert pt.valid?, 'record should be valid'
-    assert pt.save, 'Should be able to create and save a 2014 cert edition Product'
-    assert_equal '2014', pt.cert_edition
-    assert_equal true, pt.randomize_patients
-    assert_equal false, pt.duplicate_patients
-  end
-
-  def test_create_2014_certification_with_c2
-    pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'], bundle_id: @bundle.id, cert_edition: '2014')
-    pt.product_tests.build(name: 'test_product_test_name',
-                           measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
-                           bundle_id: @bundle.id).save!
-    assert pt.valid?, 'record should be valid'
-    assert pt.save, 'Should be able to create and save a Product'
-    assert_equal '2014', pt.cert_edition
-    assert_equal true, pt.randomize_patients
-    assert_equal false, pt.duplicate_patients
   end
 
   def test_offset

--- a/test/unit/lib/create_download_zip_test.rb
+++ b/test/unit/lib/create_download_zip_test.rb
@@ -3,11 +3,10 @@ require 'fileutils'
 
 class CreateDownloadZipTest < ActiveSupport::TestCase
   test 'Should create appropriate html' do
-    product2014 = FactoryBot.create(:product_2014)
     product_2015_c1 = FactoryBot.create(:product_no_c2)
     product_2015_c2 = FactoryBot.create(:product_static_bundle)
 
-    [product2014, product_2015_c1, product_2015_c2].each do |product|
+    [product_2015_c1, product_2015_c2].each do |product|
       pt = product.product_tests.build({ name: 'mtest', measure_ids: product.measure_ids }, MeasureTest)
       pt.save
       pt.generate_patients
@@ -17,7 +16,7 @@ class CreateDownloadZipTest < ActiveSupport::TestCase
       file = Cypress::CreateTotalTestZip.create_total_test_zip(product, nil, nil, 'qrda')
 
       Zip::File.open(file) do |zip_file|
-        if product.cert_edition == '2015' && product.c2_test
+        if product.c2_test
           assert_empty zip_file.glob('*.html.zip')
         else
           assert_not_empty zip_file.glob('*.html.zip')


### PR DESCRIPTION
2015 is the only possible cert edition in 4.0.0, so we don't need the option in `Product`, or any of the related items.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-296
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code