### PR TITLE
Remove Modernizr, as it doesn't seem to be used anymore

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,6 @@ gem 'bootstrap-sass', '~> 3.3.5'
 gem 'font-awesome-sass', '~> 5.0.13'
 gem 'jquery-rails', '~> 4.0.4'
 gem 'jquery-ui-rails', '~> 5.0.5'
-gem 'modernizr-rails', '~> 2.7.1'
 
 # Add pagination support
 gem 'kaminari-mongoid'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -317,7 +317,6 @@ GEM
       ruby-progressbar
     mocha (1.6.0)
       metaclass (~> 0.0.1)
-    modernizr-rails (2.7.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     mongo (2.6.1)
@@ -571,7 +570,6 @@ DEPENDENCIES
   minitest-rails
   minitest-reporters
   mocha
-  modernizr-rails (~> 2.7.1)
   mongoid (~> 5.0.0)
   mongoid_rails_migrations!
   mustache
@@ -607,4 +605,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.2
+   1.16.3

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,6 @@
   <meta name="keywords" content="" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag :modernizr %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -11,7 +11,6 @@
   <meta name="keywords" content="" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag :modernizr %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>


### PR DESCRIPTION
Doing some performance analysis of Cypress, and realized that this JS library gets included, despite the fact that Cypress doesn't use it anywhere. Removing it should speed the page load up.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code