### PR TITLE
Mpl download zip fix

### DIFF
--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -3,7 +3,7 @@ module Cypress
     include ChecklistTestsHelper
     def self.create_test_zip(test_id, format = 'html')
       pt = ProductTest.find(test_id)
-      create_zip(pt.records.to_a, format)
+      create_zip(pt.patients.to_a, format)
     end
 
     def self.create_zip(patients, format)
@@ -13,13 +13,13 @@ module Cypress
     end
 
     def self.bundle_directory(bundle, path)
-      records = bundle.records
+      patients = bundle.patients
       %w[html qrda].each do |format|
         extensions = { html: 'html', qrda: 'xml' }
-        formatter = formatter_for_patients(records, format)
+        formatter = formatter_for_patients(patients, format)
         FileUtils.mkdir_p(File.join(path, "#{format}_records/"))
-        records.each do |r|
-          filename = "#{format}_records/#{r.first}_#{r.last}.#{extensions[format.to_sym]}".delete("'").tr(' ', '_')
+        patients.each do |r|
+          filename = "#{format}_records/#{r.givenNames.join('_')}_#{r.familyName}.#{extensions[format.to_sym]}".delete("'").tr(' ', '_')
           File.open(File.join(path, filename), 'w') do |f|
             f.write(formatter.export(r))
           end
@@ -106,8 +106,8 @@ module Cypress
       z << file_content
     end
 
-    def self.formatter_for_patients(records, format)
-      mes, sd, ed = Cypress::PatientZipper.measure_start_end(records)
+    def self.formatter_for_patients(patients, format)
+      mes, sd, ed = Cypress::PatientZipper.measure_start_end(patients)
       if format == 'html'
         formatter = Cypress::HTMLExporter.new(mes, sd, ed)
       elsif format == 'qrda'

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -54,8 +54,8 @@ module QDM
     end
 
     def provider
-      return nil unless extendedData.provider_performances
-      Provider.find(JSON.parse(extendedData.provider_performances).first['provider_id'])
+      return nil unless extendedData['provider_performances']
+      Provider.find(JSON.parse(extendedData['provider_performances']).first['provider_id'])
     end
 
     #

--- a/test/jobs/mpl_download_create_job_test.rb
+++ b/test/jobs/mpl_download_create_job_test.rb
@@ -25,6 +25,15 @@ class MplDownloadCreateJobTest < ActiveJob::TestCase
       assert_performed_jobs 1
       assert :ready, @bundle.mpl_status
       assert File.exist?(@bundle.mpl_path)
+      Zip::ZipFile.open(@bundle.mpl_path) do |zip_file|
+        assert_operator zip_file.entries.count, :>, 2
+        entry_names = zip_file.entries.collect(&:name)
+        @bundle.patients.each do |patient|
+          patient_file_name = "#{patient.givenNames.join('_')}_#{patient.familyName}".delete("'").tr(' ', '_')
+          assert_includes entry_names, "html_records/#{patient_file_name}.html"
+          assert_includes entry_names, "qrda_records/#{patient_file_name}.xml"
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This Pull Request fixes the fact that MPL Download `.zip` files did not have any patient files, either QRDA or HTML. This occurred as a result of the HDS `Record` to QDM `Patient` switchover.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-322
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code