### PR TITLE
Update Gemfile to use new ref in cqm-cqm-parsers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,10 +23,10 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers.git
-  revision: 73b7760d731d6d08e958a25d735377e6c4fc8549
+  revision: e5858b4b20e9caa2d4a0ddd8c669f229c49648ae
   branch: cat_1_patch
   specs:
-    cqm-parsers (0.1.1)
+    cqm-parsers (0.2.0)
       activesupport (~> 4.2.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
@@ -38,7 +38,7 @@ GIT
       nokogiri (~> 1.8.3)
       protected_attributes (~> 1.0.5)
       rest-client (~> 1.8.0)
-      rubyzip (~> 1.2.1)
+      rubyzip (~> 1.2.2)
       uuid (~> 2.3.7)
       zip-zip (~> 0.3)
 
@@ -606,4 +606,4 @@ RUBY VERSION
    ruby 2.3.7p456
 
 BUNDLED WITH
-   1.16.3
+   1.16.4


### PR DESCRIPTION
It seems that the Gemfile in cqm-parsers got update which broke the ability to install from the existing ref in the Gemfile.lock. Ran a `bundle update cqm-parsers` to fix the issue

**Submitter:**
- [x] This pull request describes why these changes were made.

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code