### PR TITLE
Simplecov fixes

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,6 @@
+SimpleCov.start 'rails' do
+  merge_timeout 3600
+end
+
+require 'codecov'
+SimpleCov.formatter = SimpleCov::Formatter::Codecov

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,10 +5,6 @@
 # files.
 
 require 'simplecov'
-SimpleCov.start 'rails'
-
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 ENV['IGNORE_ROLES'] ||= 'false'
 

--- a/test/factories/bundles.rb
+++ b/test/factories/bundles.rb
@@ -7,14 +7,14 @@ FactoryBot.define do
     factory :static_bundle do
       entry = Rails.root.join('test', 'fixtures', 'artifacts', 'cms127v7.json')
       source_measure = JSON.parse(File.read(entry), max_nesting: 100)
-      active true
-      done_importing true
-      name 'Static Bundle'
-      title 'Static Bundle'
-      version '2018.0.0.2'
+      active { true }
+      done_importing { true }
+      name { 'Static Bundle' }
+      title { 'Static Bundle' }
+      version { '2018.0.0.2' }
       extensions { %w[map_reduce_utils hqmf_utils] }
-      measure_period_start 1_483_228_800 # Jan 1 2017
-      effective_date 1_514_764_799 # Dec 31 2017
+      measure_period_start { 1_483_228_800 } # Jan 1 2017
+      effective_date { 1_514_764_799 } # Dec 31 2017
 
       after(:create) do |bundle|
         # Load the extensions included in the bundle from the filesystem into mongo

--- a/test/factories/filter_tests.rb
+++ b/test/factories/filter_tests.rb
@@ -3,8 +3,8 @@ FactoryBot.define do
     sequence(:name) { |i| "Product Test Name #{i}" }
 
     factory :static_filter_test do
-      name 'Static Result'
-      _type 'FilteringTest'
+      name { 'Static Result' }
+      _type { 'FilteringTest' }
       options { { 'filters' => { 'genders' => ['F'] } } }
       expected_result = { 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE' =>
                           { 'measure_id' => 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE',
@@ -36,7 +36,7 @@ FactoryBot.define do
                                                      'DENEX' => {} } } }
       expected_results { expected_result }
 
-      measure_ids ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+      measure_ids { ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }
       association :product, :factory => :product_static_bundle
       after(:create) do |pt|
         extended_data = { 'correlation_id' => pt.id,

--- a/test/factories/individual_results.rb
+++ b/test/factories/individual_results.rb
@@ -1,10 +1,10 @@
 FactoryBot.define do
   factory :individual_result, class: QDM::IndividualResult do
-    IPP 1
-    DENOM 1
-    NUMER 0
-    DENEXCEP 0
-    DENEX 0
+    IPP { 1 }
+    DENOM { 1 }
+    NUMER { 0 }
+    DENEXCEP { 0 }
+    DENEX { 0 }
     factory :individual_bundle_result do
       transient do
         bundleId { Bundle.find_by(name: 'Static Bundle')._id }

--- a/test/factories/measures.rb
+++ b/test/factories/measures.rb
@@ -2,16 +2,16 @@ FactoryBot.define do
   factory :measure, class: Measure do
     entry = Rails.root.join('test', 'fixtures', 'artifacts', 'cms127v7.json')
     transient do
-      seq_id 1
+      seq_id { 1 }
     end
     source_measure = JSON.parse(File.read(entry), max_nesting: 100)
     name { "Measure Name #{seq_id}" }
     hqmf_id { "53e3f13d-e5cf-445f-8dda-3720aff8401#{seq_id}" }
     hqmf_set_id { "7c00e09b-02dc-458b-8587-7f0347a443f#{seq_id}" }
-    continuous_variable false
-    category 'none'
-    type 'ep'
-    episode_of_care true
+    continuous_variable { false }
+    category { 'none' }
+    type { 'ep' }
+    episode_of_care { true }
     trait :diagnosis do
       hqmf_doc = { 'source_data_criteria' => { 'DiagnosisActivePregnancy' =>
                                                { 'title'  => 'Pregnancy',
@@ -78,23 +78,23 @@ FactoryBot.define do
     factory  :measure_without_diagnosis, traits: [:no_diagnosis]
 
     factory  :static_measure do
-      name 'Static Measure'
-      cms_id source_measure['cms_id']
-      hqmf_id 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'
-      hqmf_set_id 'C621C7B6-EB1F-11E7-8C3F-9A214CF093AE'
+      name { 'Static Measure' }
+      cms_id { source_measure['cms_id'] }
+      hqmf_id { 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE' }
+      hqmf_set_id { 'C621C7B6-EB1F-11E7-8C3F-9A214CF093AE' }
 
-      continuous_variable source_measure['continuous_variable']
-      category 'static'
-      type 'ep'
-      sub_id 'a'
+      continuous_variable { source_measure['continuous_variable'] }
+      category { 'static' }
+      type { 'ep' }
+      sub_id { 'a' }
 
-      episode_of_care source_measure['episode_of_care']
+      episode_of_care { source_measure['episode_of_care'] }
       hqmf_document { source_measure['hqmf_document'] }
       source_data_criteria { source_measure['source_data_criteria'] }
       population_criteria { source_measure['population_criteria'] }
-      populations source_measure['populations']
+      populations { source_measure['populations'] }
       measure_period { source_measure['measure_period'] }
-      oids source_measure['oids']
+      oids { source_measure['oids'] }
       population_ids { source_measure['population_ids'] }
     end
   end

--- a/test/factories/patients.rb
+++ b/test/factories/patients.rb
@@ -3,13 +3,13 @@
 FactoryBot.define do
   factory :patient, class: Patient do
     transient do
-      seq_id 1
+      seq_id { 1 }
     end
 
-    familyName 'MPL record'
+    familyName { 'MPL record' }
     givenNames { [seq_id.to_s] }
-    qdmVersion '5.3'
-    birthDatetime DateTime.new(1940, 1, 1).utc
+    qdmVersion { '5.3' }
+    birthDatetime { DateTime.new(1940, 1, 1).utc }
     extended_data_value = {
       'medical_record_assigner' => 'Bonnie',
       'notes' => "70yo female; DExcl 56,90 Num 127,130 DExcep 139,149\n*17qdes\n*Pt w h/o advancing dementia and heart failure. Suffered multiple fractures requiring surgery and occ therapy.",
@@ -149,16 +149,16 @@ FactoryBot.define do
         'qdmVersion' => '5.3'
       }
     ]
-    dataElements data_elements_value
+    dataElements { data_elements_value }
 
     after(:create) do |patient|
       create(:individual_bundle_result, patient_id: patient._id, bundleId: patient.bundleId)
     end
 
     factory :static_test_patient do
-      familyName 'A'
-      givenNames ['Dental_Peds']
-      birthDatetime DateTime.new(1940, 1, 1).utc
+      familyName { 'A' }
+      givenNames { ['Dental_Peds'] }
+      birthDatetime { DateTime.new(1940, 1, 1).utc }
       extendedData do
         { 'medical_record_number' => '1234' }.merge(extended_data_value)
       end

--- a/test/factories/pocs.rb
+++ b/test/factories/pocs.rb
@@ -2,16 +2,16 @@ FactoryBot.define do
   factory :poc, class: PointOfContact do
     sequence(:name) { |i| "Contact #{i}" }
     sequence(:email) { |i| "contact#{i}@example.com" }
-    phone '1(222)333-4444'
-    contact_type 'Admin'
+    phone { '1(222)333-4444' }
+    contact_type { 'Admin' }
     sequence(:id) { |i| i }
 
     factory :poc1 do
-      name 'poc1'
+      name { 'poc1' }
     end
 
     factory :poc_no_name do
-      name nil
+      name { nil }
     end
   end
 end

--- a/test/factories/product_tests.rb
+++ b/test/factories/product_tests.rb
@@ -3,9 +3,9 @@ FactoryBot.define do
     sequence(:name) { |i| "Product Test Name #{i}" }
 
     factory :product_test_static_result do
-      name 'Static Result'
-      _type 'MeasureTest'
-      cms_id 'CMS1234'
+      name { 'Static Result' }
+      _type { 'MeasureTest' }
+      cms_id { 'CMS1234' }
       aug_record = [{ 'original_patient_id' => '',
                       'medical_record_number' =>  '1234',
                       'first' =>  %w[Dental_Peds Denial_Peds],
@@ -42,7 +42,7 @@ FactoryBot.define do
                                                      'NUMER' => {},
                                                      'DENEX' => {} } } }
       expected_results { expected_result }
-      measure_ids ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+      measure_ids { ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }
       association :product, :factory => :product_static_bundle
       after(:create) do |pt|
         extended_data = { 'correlation_id' => pt.id,

--- a/test/factories/products.rb
+++ b/test/factories/products.rb
@@ -3,27 +3,27 @@ FactoryBot.define do
     sequence(:name) { |i| "Product Name #{i}" }
 
     factory :product_no_name do
-      name ''
+      name { '' }
     end
 
     factory :product_static_name do
-      name 'Product Same Name'
+      name { 'Product Same Name' }
     end
 
     factory :static_product do
-      name 'Product Static Bundle'
-      description 'Product Static Bundle'
+      name { 'Product Static Bundle' }
+      description { 'Product Static Bundle' }
       trait :default do
-        c1_test true
-        c2_test true
+        c1_test { true }
+        c2_test { true }
         association :vendor, name: 'Static Bundle Vendor'
       end
       trait :no_c2 do
-        c1_test true
-        c2_test false
+        c1_test { true }
+        c2_test { false }
         association :vendor, name: '2015 Vendor No C2'
       end
-      measure_ids ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+      measure_ids { ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }
       association :bundle, :factory => :static_bundle
       after(:create) do |p|
         p.add_checklist_test

--- a/test/factories/providers.rb
+++ b/test/factories/providers.rb
@@ -1,31 +1,39 @@
 FactoryBot.define do
   factory :provider, class: Provider do
     sequence(:given_name) { |i| "Given_Name #{i}" }
-    specialty '200000000X'
+    specialty { '200000000X' }
     trait :default do
-      cda_identifiers [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '020700270' },
-                       { 'root' => '2.16.840.1.113883.4.2', 'extension' => '1520670765' },
-                       { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
-      addresses [{ 'street' => ['202 Burlington Rd'], 'city' => 'Bedford', 'state' => 'MA', 'zip' => '01730', 'country' => 'US' }]
+      cda_identifiers do
+        [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '020700270' },
+         { 'root' => '2.16.840.1.113883.4.2', 'extension' => '1520670765' },
+         { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      end
+      addresses { [{ 'street' => ['202 Burlington Rd'], 'city' => 'Bedford', 'state' => 'MA', 'zip' => '01730', 'country' => 'US' }] }
     end
 
     trait :tin do
-      cda_identifiers [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1520670765' },
-                       { 'root' => '2.16.840.1.113883.4.2', 'extension' => '897230473' },
-                       { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      cda_identifiers do
+        [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1520670765' },
+         { 'root' => '2.16.840.1.113883.4.2', 'extension' => '897230473' },
+         { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      end
     end
 
     trait :npi do
-      cda_identifiers [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1480614951' },
-                       { 'root' => '2.16.840.1.113883.4.2', 'extension' => '020700270' },
-                       { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      cda_identifiers do
+        [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1480614951' },
+         { 'root' => '2.16.840.1.113883.4.2', 'extension' => '020700270' },
+         { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      end
     end
 
     trait :combination do
-      cda_identifiers [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1520670765' },
-                       { 'root' => '2.16.840.1.113883.4.2', 'extension' => '020700270' },
-                       { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
-      addresses [{ 'street' => ['100 Bureau Drive'], 'city' => 'Gaithersburg', 'state' => 'MD', 'zip' => '20899', 'country' => 'US' }]
+      cda_identifiers do
+        [{ 'root' => '2.16.840.1.113883.4.6', 'extension' => '1520670765' },
+         { 'root' => '2.16.840.1.113883.4.2', 'extension' => '020700270' },
+         { 'root' => '2.16.840.1.113883.4.336', 'extension' => '563358' }]
+      end
+      addresses { [{ 'street' => ['100 Bureau Drive'], 'city' => 'Gaithersburg', 'state' => 'MD', 'zip' => '20899', 'country' => 'US' }] }
     end
 
     factory :default_provider, traits: [:default]

--- a/test/factories/query_cache.rb
+++ b/test/factories/query_cache.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :query_cache, class: HealthDataStandards::CQM::QueryCache do
-    calculation_date Time.now.in_time_zone
+    calculation_date { Time.now.in_time_zone }
 
     factory :static_query_cache do
       population_ids_hash = { 'IPP' => 'EA122D3D-5348-43DB-96A5-2D044ACAAA4D',
@@ -17,16 +17,16 @@ FactoryBot.define do
                                               'PAYER' => { '1' => 1 } },
                                  'NUMER' => {},
                                  'DENEX' => {} }
-      IPP 1
-      DENOM 1
-      NUMER 0
-      DENEX 0
-      DENEXCEP 0
-      MSRPOPL 0
-      measure_id 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'
-      population_ids population_ids_hash
-      supplemental_data supplemental_data_hash
-      effective_date 1_514_764_799
+      IPP { 1 }
+      DENOM { 1 }
+      NUMER { 0 }
+      DENEX { 0 }
+      DENEXCEP { 0 }
+      MSRPOPL { 0 }
+      measure_id { 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE' }
+      population_ids { population_ids_hash }
+      supplemental_data { supplemental_data_hash }
+      effective_date { 1_514_764_799 }
     end
   end
 end

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :role, class: Role do
-    name 'user'
+    name { 'user' }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,14 +1,14 @@
 FactoryBot.define do
   factory :user, class: User do
-    email 'test@test.com'
-    password 'Cypre$$v3'
-    terms_and_conditions '1'
+    email { 'test@test.com' }
+    password { 'Cypre$$v3' }
+    terms_and_conditions { '1' }
 
     factory :admin_user do
-      id '4def93dd4f85cf8968000010'
-      email 'admin@test.com'
-      password 'Cypre$$v3'
-      terms_and_conditions '1'
+      id { '4def93dd4f85cf8968000010' }
+      email { 'admin@test.com' }
+      password { 'Cypre$$v3' }
+      terms_and_conditions { '1' }
 
       after(:create) do |user|
         create(:role, user_ids: [user._id], name: 'admin')
@@ -16,10 +16,10 @@ FactoryBot.define do
     end
 
     factory :atl_user do
-      id '4def93dd4f85cf8968000001'
-      email 'atl@test.com'
-      password 'Cypre$$v3'
-      terms_and_conditions '1'
+      id { '4def93dd4f85cf8968000001' }
+      email { 'atl@test.com' }
+      password { 'Cypre$$v3' }
+      terms_and_conditions { '1' }
 
       after(:create) do |user|
         create(:role, user_ids: [user._id], name: 'atl')
@@ -27,20 +27,20 @@ FactoryBot.define do
     end
 
     factory :user_user do
-      id '4def93dd4f85cf8968000002'
-      email 'user@test.com'
-      password 'Cypre$$v3'
-      terms_and_conditions '1'
+      id { '4def93dd4f85cf8968000002' }
+      email { 'user@test.com' }
+      password { 'Cypre$$v3' }
+      terms_and_conditions { '1' }
       after(:create) do |user|
         create(:role, user_ids: [user._id], name: 'owner')
       end
     end
 
     factory :vendor_user do
-      id '4def93dd4f85cf8968000003'
-      email 'vendor@test.com'
-      password 'Cypre$$v3'
-      terms_and_conditions '1'
+      id { '4def93dd4f85cf8968000003' }
+      email { 'vendor@test.com' }
+      password { 'Cypre$$v3' }
+      terms_and_conditions { '1' }
 
       after(:create) do |user|
         user.role_ids = []
@@ -49,10 +49,10 @@ FactoryBot.define do
     end
 
     factory :other_user do
-      id '4def93dd4f85cf8968000004'
-      email 'other@test.com'
-      password 'Cypre$$v3'
-      terms_and_conditions '1'
+      id { '4def93dd4f85cf8968000004' }
+      email { 'other@test.com' }
+      password { 'Cypre$$v3' }
+      terms_and_conditions { '1' }
 
       after(:create) do |user|
         user.role_ids = []

--- a/test/factories/value_sets.rb
+++ b/test/factories/value_sets.rb
@@ -1,17 +1,17 @@
 FactoryBot.define do
   factory :value_set, class: HealthDataStandards::SVS::ValueSet do
     transient do
-      seq_id 1
+      seq_id { 1 }
     end
 
     display_name { "Value Set Name #{seq_id}" }
     oid { "1.#{seq_id}.#{seq_id + 1}.#{seq_id + 2}" }
-    version '123'
+    version { '123' }
     concepts { [{ 'code' => (seq_id * (seq_id + 1) * (seq_id + 2)).to_s, 'code_system' => '2.16.840.1.113883.6.96', 'code_system_name' => 'SNOMED-CT' }] }
 
     factory :value_set_payer do
-      display_name 'Payer'
-      oid '2.16.840.1.114222.4.11.3591'
+      display_name { 'Payer' }
+      oid { '2.16.840.1.114222.4.11.3591' }
       payer_codes = [{ 'code' => '1', 'code_system' => '2.16.840.1.113883.3.221.5' },
                      { 'code' => '2', 'code_system' => '2.16.840.1.113883.3.221.5' },
                      { 'code' => '349', 'code_system' => '2.16.840.1.113883.3.221.5' }]

--- a/test/factories/vendors.rb
+++ b/test/factories/vendors.rb
@@ -11,11 +11,11 @@ FactoryBot.define do
     end
 
     factory :vendor_no_name do
-      name ''
+      name { '' }
     end
 
     factory :vendor_static_name do
-      name 'Vendor Same Name'
+      name { 'Vendor Same Name' }
     end
 
     # with points_of_contact

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -125,9 +125,12 @@ class ProductTestTest < ActiveJob::TestCase
       de1 = patient1.dataElements.fetch(x)
       de2 = patient2.dataElements.fetch(x)
       de1.attributes.each do |k, v|
-        assert_nil de2.attributes[k], 'random repeatability error: dataElements different, non-nil match' if v.nil?
-        # the _id is the BSON::Id for the dataElement.  The id is the QDM::Id for the dataElement.  The QDM::Id will reference the BSON:Id
-        assert_equal v, de2.attributes[k], 'random repeatability error: dataElements different' unless %w[_id id].include?(k)
+        if v.nil?
+          assert_nil de2.attributes[k], 'random repeatability error: dataElements different, non-nil match'
+        else
+          # the _id is the BSON::Id for the dataElement.  The id is the QDM::Id for the dataElement.  The QDM::Id will reference the BSON:Id
+          assert_equal v, de2.attributes[k], 'random repeatability error: dataElements different' unless %w[_id id].include?(k)
+        end
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,4 @@
 require 'simplecov'
-SimpleCov.start 'rails'
-
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 # Mongo::Logger.logger.level = Logger::WARN
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
* Fix simplecov not merging Cucumber and Unit test coverage files in Codecov.io
* Fix a bunch of deprecation warnings from Minitest and FactoryBot, including

```
     DEPRECATION WARNING: Static attributes will be removed in FactoryBot 5.0. Please use dynamic attributes instead by wrapping the attribute value in a block:

     name { "Vendor Same Name" }
```

and

`DEPRECATED: Use assert_nil if expecting nil from test/models/product_test_test.rb:130. This will fail in Minitest 6.`

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code