### PR TITLE
Use sync

### DIFF
--- a/app/jobs/measure_evaluation_job.rb
+++ b/app/jobs/measure_evaluation_job.rb
@@ -1,12 +1,19 @@
 class MeasureEvaluationJob < ApplicationJob
   queue_as :default
   include Job::Status
+
+  # The MeasureEvaluationJob aggregates Individual Results to calculated the expected results for a
+  # Measure Test or Task 
+  #
+  # @param [Object] test_or_task The ProductTest or Task being evalutated
+  # @param [Hash] options :individual_results are the raw results from JsEcqmCalc
+  # @return none
   def perform(test_or_task, options)
+    # Measure Evaluation Job can be run for a test (Measure Test), or a task (Filter Tasks)
     if test_or_task.is_a? ProductTest
       perform_for_product_test(test_or_task, options)
     elsif test_or_task.is_a? Task
       perform_for_task(test_or_task, options)
-
     end
   end
 
@@ -22,9 +29,11 @@ class MeasureEvaluationJob < ApplicationJob
     product_test.save
   end
 
-  def eval_measures(measures, product_test, _options, &_block)
+  def eval_measures(measures, product_test, options, &_block)
     erc = Cypress::ExpectedResultsCalculator.new(product_test.patients, product_test.id.to_s, product_test.effective_date)
-    results = erc.aggregate_results_for_measures(measures)
+    # if individual_results results are nested within 'Individual'.  If there are no individual results, set to nil
+    individual_results = options[:individual_results] ? options[:individual_results]['Individual'] : nil
+    results = erc.aggregate_results_for_measures(measures, individual_results)
     results
   end
 end

--- a/app/jobs/measure_evaluation_job.rb
+++ b/app/jobs/measure_evaluation_job.rb
@@ -3,7 +3,7 @@ class MeasureEvaluationJob < ApplicationJob
   include Job::Status
 
   # The MeasureEvaluationJob aggregates Individual Results to calculated the expected results for a
-  # Measure Test or Task 
+  # Measure Test or Task
   #
   # @param [Object] test_or_task The ProductTest or Task being evalutated
   # @param [Hash] options :individual_results are the raw results from JsEcqmCalc

--- a/lib/cypress/expected_results_calculator.rb
+++ b/lib/cypress/expected_results_calculator.rb
@@ -1,34 +1,47 @@
 module Cypress
   class ExpectedResultsCalculator
+
+    # The ExpectedResultsCalculator aggregates Individual Results to calculated the expected results for a
+    # Measure Test or Task 
+    #
+    # @param [Array] patients the list of patients that are included in the aggregate results
+    # @param [String] correlation_id the id used to associate a group of patients
+    # @param [String] effective_date used when generating the query_cache_object for HDS QRDA Cat III export
+    # @param [Hash] options :individual_results are the raw results from JsEcqmCalc
     def initialize(patients, correlation_id, effective_date)
       @correlation_id = correlation_id
+      # Hash of patient_id and their supplemental information
       @patient_sup_map = {}
       @measure_result_hash = {}
       @effective_date = effective_date
       patients.each do |patient|
+        # iterate through each patient and store their supplemental information
         add_patient_to_sup_map(@patient_sup_map, patient)
       end
     end
 
     def add_patient_to_sup_map(ps_map, patient)
-      ps_map[patient.id] = {}
-      ps_map[patient.id]['SEX'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.55')[0].dataElementCodes[0].code
-      ps_map[patient.id]['RACE'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.59')[0].dataElementCodes[0].code
-      ps_map[patient.id]['ETHNICITY'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.56')[0].dataElementCodes[0].code
-      ps_map[patient.id]['PAYER'] = JSON.parse(patient.extendedData.insurance_providers).first['codes']['SOP'].first
+      patient_id = patient.id.to_s
+      ps_map[patient_id] = {}
+      ps_map[patient_id]['SEX'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.55')[0].dataElementCodes[0].code
+      ps_map[patient_id]['RACE'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.59')[0].dataElementCodes[0].code
+      ps_map[patient_id]['ETHNICITY'] = patient.get_by_hqmf_oid('2.16.840.1.113883.10.20.28.3.56')[0].dataElementCodes[0].code
+      ps_map[patient_id]['PAYER'] = JSON.parse(patient.extendedData.insurance_providers).first['codes']['SOP'].first
     end
 
-    def aggregate_results_for_measures(measures)
+    def aggregate_results_for_measures(measures, individual_results = nil)
       measures.each do |measure|
         @measure_result_hash[measure.key] = {}
-        aggregate_results_for_measure(measure)
+        measure_individual_results = nil
+        measure_individual_results = individual_results[measure.id.to_s].values if individual_results
+        aggregate_results_for_measure(measure, measure_individual_results)
       end
       @measure_result_hash
     end
 
     # rubocop:disable Metrics/AbcSize
-    def aggregate_results_for_measure(measure)
-      individual_results = QDM::IndividualResult.where('measure_id' => measure._id, 'extendedData.correlation_id' => @correlation_id)
+    def aggregate_results_for_measure(measure, individual_results = nil)
+      individual_results ||= QDM::IndividualResult.where('measure_id' => measure._id, 'extendedData.correlation_id' => @correlation_id)
       measure_populations = %w[DENOM NUMER DENEX DENEXCEP IPP MSRPOPL MSRPOPLEX]
       @measure_result_hash[measure.key]['supplemental_data'] = {}
       measure_populations.each do |pop|
@@ -39,10 +52,9 @@ module Cypress
         measure_populations.each do |pop|
           next if ir[pop].nil? || ir[pop].zero?
           @measure_result_hash[measure.key][pop] += ir[pop]
-          increment_sup_info(@patient_sup_map[ir.patient_id], pop, @measure_result_hash[measure.key])
+          increment_sup_info(@patient_sup_map[ir.patient_id.to_s], pop, @measure_result_hash[measure.key])
         end
-
-        observ_values.concat get_observ_values(ir.episode_results) if ir.episode_results
+        observ_values.concat get_observ_values(ir['episode_results']) if ir['episode_results']
       end
       @measure_result_hash[measure.key]['OBSERV'] = median(observ_values.reject(&:nil?))
       @measure_result_hash[measure.key]['measure_id'] = measure.hqmf_id

--- a/test/jobs/measure_evaluation_job_test.rb
+++ b/test/jobs/measure_evaluation_job_test.rb
@@ -5,8 +5,38 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
     vendor = FactoryBot.create(:vendor)
     @bundle = FactoryBot.create(:static_bundle)
     @result = QME::QualityReportResult.new(DENOM: 48, NUMER: 44, antinumerator: 4, DENEX: 0)
-    @product = vendor.products.create(name: 'test_product', c2_test: true, randomize_patients: true, bundle_id: @bundle.id,
+    @product = vendor.products.create(name: 'test_product', c2_test: true, randomize_patients: false, bundle_id: @bundle.id,
                                       measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+  end
+
+  def test_can_use_sync_and_async_results
+    pt = @product.product_tests.build({ name: 'test_for_measure_1a', bundle_id: @bundle.id,
+                                        measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
+    perform_enqueued_jobs do
+      pt.save
+      pt.reload
+      # clear out expected_results created with product test
+      pt.expected_results = nil
+
+      patient_ids = pt.patients.map { |rec| rec._id.to_s }
+      correlation_id = BSON::ObjectId.new.to_s
+      calc_job = Cypress::JsEcqmCalc.new('correlation_id': correlation_id,
+                                         'effective_date': Time.at(pt.effective_date).in_time_zone.to_formatted_s(:number))
+      individual_results_from_sync_job = calc_job.sync_job(patient_ids, pt.measures.map { |mes| mes._id.to_s })
+      calc_job.stop
+
+      # calculate expected_results using individual results stored in database (don't pass in individual results)
+      MeasureEvaluationJob.perform_now(pt, {})
+      db_expected_results = pt.expected_results
+
+      pt.expected_results = nil
+
+      # calculate expected_results using individual results returned from sync_job (pass in individual results)
+      MeasureEvaluationJob.perform_now(pt, individual_results: individual_results_from_sync_job)
+      sync_job_expected_results = pt.expected_results
+
+      assert_equal db_expected_results, sync_job_expected_results
+    end
   end
 
   def test_can_queue_product_test_job


### PR DESCRIPTION
https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1488

A race condition can happen with the expected_results_calculator if it runs before the js-ecqm-engine is finished writing the results to the database.  This can be fixed by using the results returned from the sync job, instead of using a database query.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code