### PR TITLE
Relative paths for c1 record sample tests are problematic when findin…

### DIFF
--- a/lib/validators/attribute_extractor.rb
+++ b/lib/validators/attribute_extractor.rb
@@ -1,11 +1,11 @@
 module Validators
   module AttributeExtractor
     XPATH_CONSTS = {
-      'relevantPeriod' => './cda:effectiveTime/cda:low',
-      'prevalencePeriod' => './cda:effectiveTime/cda:low',
-      'authorDatetime' => "../../..//cda:author[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.155']]/cda:time",
-      'relatedTo' => "./sdtc:inFulfillmentOf1/sdtc:templateId[@root='2.16.840.1.113883.10.20.24.3.126']",
-      'resultDatetime' => "./cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.2']]/cda:effectiveTime"
+      'relevantPeriod' => 'cda:effectiveTime/cda:low',
+      'prevalencePeriod' => 'cda:effectiveTime/cda:low',
+      'authorDatetime' => "/cda:author[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.155']]/cda:time",
+      'relatedTo' => "sdtc:inFulfillmentOf1/sdtc:templateId[@root='2.16.840.1.113883.10.20.24.3.126']",
+      'resultDatetime' => "cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.2']]/cda:effectiveTime"
     }.freeze
 
     # does a node need to be checked for an atttibute value
@@ -26,26 +26,46 @@ module Validators
     def find_attribute_values(node, code, source_criteria, index)
       # xpath expressions with codes
       xpath_map = {
-        'components' => "./cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.149]/cda:code[@code='#{code}']",
-        'diagnoses' => "./cda:entryRelationship/cda:act[./cda:code[@code='29308-4']]/cda:entryRelationship
+        'components' => "cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.149]/cda:code[@code='#{code}']",
+        'diagnoses' => "cda:entryRelationship/cda:act[./cda:code[@code='29308-4']]/cda:entryRelationship
                        /cda:observation/cda:value[@code='#{code}']",
-        'dischargeDisposition' => "./sdtc:dischargeDispositionCode[@code='#{code}']", # CMS31v5
-        'facilityLocations' => "./cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]
+        'dischargeDisposition' => "sdtc:dischargeDispositionCode[@code='#{code}']", # CMS31v5
+        'facilityLocations' => "cda:participant[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.100']]
                                /cda:participantRole/cda:code[@code='#{code}']",
-        'admissionSource' => "./cda:participant/cda:participantRole[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.151']]
-                             /cda:code[@code='#{code}']",
-        'route' => "../../../cda:routeCode[@code='#{code}']",
-        'ordinality' => "./cda:entryRelationship/cda:observation[./cda:code[@code='260870009']]/cda:value[@code='#{code}']
-                     or ./cda:priorityCode[@code='#{code}']", 'anatomicalLocationSite' => "./cda:targetSiteCode[@code='#{code}']",
-        'principalDiagnosis' => "./cda:entryRelationship/cda:observation[./cda:code[@code='8319008']]/cda:value[@code='#{code}']", # CMS188v6
-        'severity' => "./cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.8']]/cda:value[@code='#{code}']"
+        'admissionSource' => "cda:participant/cda:participantRole[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.151']]
+                             /cda:code[@code='#{code}']", 'route' => "cda:routeCode[@code='#{code}']",
+        'ordinality' => "cda:entryRelationship/cda:observation[./cda:code[@code='260870009']]/cda:value[@code='#{code}']
+                     or cda:priorityCode[@code='#{code}']", 'anatomicalLocationSite' => "cda:targetSiteCode[@code='#{code}']",
+        'principalDiagnosis' => "cda:entryRelationship/cda:observation[./cda:code[@code='8319008']]/cda:value[@code='#{code}']", # CMS188v6
+        'severity' => "cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.22.4.8']]/cda:value[@code='#{code}']"
       }
       # XPATH_CONSTS are the expressions without codes
       xpath_map.merge!(XPATH_CONSTS)
       if source_criteria['attributes']
-        return node.xpath(xpath_map[source_criteria.attributes[index].attribute_name]).blank? ? false : true
+        relative_path = relative_path_to_template_root(source_criteria['definition'])
+        return node.xpath(relative_path + xpath_map[source_criteria.attributes[index].attribute_name]).blank? ? false : true
       end
       false
+    end
+
+    def relative_path_to_template_root(definition)
+      relative_path_map = { 'adverse_event' => '../../',
+                            'allergy_intolerance' => '../../../',
+                            'assessment' => './',
+                            'communication_from_patient_to_provider' => './',
+                            'communication_from_provider_to_patient' => './',
+                            'communication_from_provider_to_provider' => './',
+                            'device' => '../../../',
+                            'diagnosis' => './',
+                            'diagnostic_study' => './',
+                            'encounter' => './',
+                            'immunization' => '../../../',
+                            'intervention' => './',
+                            'laboratory_test' => './',
+                            'medication' => '../../../',
+                            'physical_exam' => './',
+                            'procedure' => './' }
+      relative_path_map[definition]
     end
   end
 end

--- a/test/fixtures/qrda/checklist/communication_fulfills.xml
+++ b/test/fixtures/qrda/checklist/communication_fulfills.xml
@@ -9,10 +9,13 @@
     <text>Communication From Provider to Provider: Consultant Report</text>
     <statusCode code="completed"/>
 
-    <effectiveTime>
-      <low value='20150402150000'/>
-      <high value='20150402150000'/>
-    </effectiveTime>
+    <author>
+      <templateId root="2.16.840.1.113883.10.20.24.3.155"/>
+      <time value='20150521161500'/>
+      <assignedAuthor>
+        <id root="403d1400-3565-0134-bb5b-20999b0ed66f"/>
+      </assignedAuthor>
+    </author>
 
     <participant typeCode="AUT">
       <participantRole classCode="ASSIGNED">

--- a/test/unit/lib/validators/attribute_extractor_test.rb
+++ b/test/unit/lib/validators/attribute_extractor_test.rb
@@ -5,12 +5,35 @@ class AttributeExtractorTest < ActiveSupport::TestCase
     @object.extend(Validators::AttributeExtractor)
   end
 
-  def test_start_datetime
+  def test_encounter_order_author_datetime
     source_criteria = {  'title' => 'Decision to Admit to Hospital Inpatient',
+                         'definition' => 'encounter',
                          'code_list_id' => '2.16.840.1.113883.3.117.1.7.1.295',
                          'attributes' => [{ 'attribute_name' => 'authorDatetime', 'attribute_valueset' => nil }] }
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'checklist', 'encounter_order_start_datetime.xml')).read
     code = '19951005'
+    doc = get_document(file)
+    assert @object.find_attribute_values(doc.xpath("//*[@code='#{code}']").first.parent, code, source_criteria, 0)
+  end
+
+  def test_communication_from_provider_to_provider
+    source_criteria = {  'title' => 'Consultant Report',
+                         'definition' => 'communication_from_provider_to_provider',
+                         'code_list_id' => '2.16.840.1.113883.3.464.1003.121.12.1006',
+                         'attributes' => [{ 'attribute_name' => 'authorDatetime', 'attribute_valueset' => nil }] }
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'checklist', 'communication_fulfills.xml')).read
+    code = '371530004'
+    doc = get_document(file)
+    assert @object.find_attribute_values(doc.xpath("//*[@code='#{code}']").first.parent, code, source_criteria, 0)
+  end
+
+  def test_diagnosis
+    source_criteria = {  'title' => 'Unilateral Amputation Below Or Above Knee, Unspecified Laterality',
+                         'definition' => 'diagnosis',
+                         'code_list_id' => '2.16.840.1.113883.3.464.1003.113.12.1059',
+                         'attributes' => [{ 'attribute_name' => 'prevalencePeriod', 'attribute_valueset' => nil }] }
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'checklist', 'diagnosis_anatomical_location.xml')).read
+    code = '298049006'
     doc = get_document(file)
     assert @object.find_attribute_values(doc.xpath("//*[@code='#{code}']").first.parent, code, source_criteria, 0)
   end


### PR DESCRIPTION
…g times
https://oncprojectracking.healthit.gov/support/browse/CYPRESS-1492

C1 Record Sample tests find the 'coded' value in a template and then find the 'attributes' using a relative path from the code.  This is problematic when the 'coded' values can be nested at different depths in a template.  For example, a Device code is nested like this  '/participant/participantRole/playingDevice/code' an adverse_event is nested like this '/entryRelationship/observation/value, a medication is nested like '/consumable/manufacturedProduct/manufacturedMaterial/code'.  

Instead of relying on a fix relative xpath statement from a code to the attributes, have the validator lookup the relative path from the code to the root of the template (i.e., the level where the templateId is) and the 'attribute_map' xpath will be relative path from the root to the attribute. 

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code