### PR TITLE
Randomize patient characteristic birthdate along with birthdate on pa…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,7 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
     - 'lib/cypress/api_measure_evaluator.rb'
+    - 'lib/cypress/demographics_randomizer.rb'
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -126,5 +126,21 @@ module Cypress
         patient.birthDatetime
       end
     end
+
+    def self.randomize_birthdate(patient, random: Random.new)
+      birth_datetime = patient.birthDatetime
+      while birth_datetime == patient.birthDatetime
+        patient.birthDatetime = patient.birthDatetime.change(
+          case random.rand(3)
+          when 0 then { day: 1, month: 1 }
+          when 1 then { day: random.rand(28) + 1 }
+          when 2 then { month: random.rand(12) + 1 }
+          end
+        )
+      end
+      if patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first
+        patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first.birthDatetime = patient.birthDatetime
+      end
+    end
   end
 end

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -73,15 +73,7 @@ module QDM
         patient = Cypress::NameRandomizer.randomize_patient_name_last(patient, :random => random)
         changed[:last] = [familyName, patient.familyName]
       when 2 # birthdate
-        while birthDatetime == patient.birthDatetime
-          patient.birthDatetime = patient.birthDatetime.change(
-            case random.rand(3)
-            when 0 then { :day => 1, :month => 1 }
-            when 1 then { :day => random.rand(28) + 1 }
-            when 2 then { :month => random.rand(12) + 1 }
-            end
-          )
-        end
+        Cypress::DemographicsRandomizer.randomize_birthdate(patient, :random => random)
         changed[:birthdate] = [birthDatetime, patient.birthDatetime]
       end
       [patient, changed]

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -91,6 +91,15 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     assert_equal @insurance_provider, @record['extendedData']['insurance_providers']
   end
 
+  def test_randomize_birthdate
+    bd = DateTime.new(1981, 6, 8, 4, 0, 0).utc
+    patient = Patient.new(bundleId: @bundle.id, birthDatetime: bd)
+    patient.dataElements << QDM::PatientCharacteristicBirthdate.new(birthDatetime: bd)
+    Cypress::DemographicsRandomizer.randomize_birthdate(patient)
+    assert_not_equal patient.birthDatetime, bd
+    assert_equal patient.birthDatetime, patient.dataElements[0].birthDatetime
+  end
+
   def test_randomize_insurance_provider
     Cypress::DemographicsRandomizer.randomize_insurance_provider(@record)
     ip = JSON.parse(@record['extendedData']['insurance_providers'])[0]


### PR DESCRIPTION
When randomizing birthDatetime, change on patient and patient characteristic birthdate element

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-357
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: Dave Czulada
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code