### PR TITLE
Do not assign 'Other' race to patients generated for product tests

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -57,10 +57,6 @@ randomization:
       name           : Native Hawaiian or Other Pacific Islander
       codeSystem     : 2.16.840.1.113883.6.238
       codeSystemName : CDC Race
-    - code           : 2131-1
-      name           : Other Race
-      codeSystem     : 2.16.840.1.113883.6.238
-      codeSystemName : CDC Race
     - code           : 2106-3
       name           : White
       codeSystem     : 2.16.840.1.113883.6.238

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -181,7 +181,7 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
   end
 
   def test_perform_replace_other_race
-    # Clone and ensure they have random races
+    # Clone and ensure that "Other" is always replaced with the same code '2106-3'
     pcj = Cypress::PopulationCloneJob.new('randomize_demographics' => false)
     prng = Random.new(@pt.rand_seed.to_i)
     patient = Patient.first

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -180,6 +180,19 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
     assert_races_are_random
   end
 
+  def test_perform_replace_other_race
+    # Clone and ensure they have random races
+    pcj = Cypress::PopulationCloneJob.new('randomize_demographics' => false)
+    prng = Random.new(@pt.rand_seed.to_i)
+    patient = Patient.first
+    # Replace original race code with the code for 'Other'
+    patient.get_data_elements('patient_characteristic', 'race').first.dataElementCodes.first['code'] = '2131-1'
+    pcj.clone_and_save_patient(patient, prng, Provider.first)
+    cloned_patient = Patient.where('extendedData.original_patient' => patient.id).first
+    # Assert that the new race is consistent '2106-3'
+    assert_equal '2106-3', cloned_patient.race
+  end
+
   def assert_races_are_random
     found_random = false
     old_record_races = {}


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-365
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name: @rbclark 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code