### PR TITLE
Reference 'cqm' libraries with remove HDS as a single commit on top o…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,12 +14,12 @@ gem 'bson_ext'
 gem 'mustache'
 gem 'os'
 
-gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'remove_hds'
+gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'remove_hds_v_1.0.2'
 # gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'master'
 gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators.git', branch: 'remove_hds'
 # gem 'cqm-converter', '~> 0.3.6'
 # gem 'cqm-models', '~> 0.8.4'
-gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'rails_upgrade'
+gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'rails_upgrade_v_0.2.1'
 # gem 'cqm-validators', '~> 0.1.0'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,17 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-models.git
-  revision: e2b2fac60183821df18e9dcd6bd14183f7d8ad1d
-  branch: remove_hds
+  revision: 7f37b3ccf7face5be824234adeb560df265c551a
+  branch: remove_hds_v_1.0.2
   specs:
-    cqm-models (1.0.1)
+    cqm-models (1.0.2)
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers.git
-  revision: 6b593f39c7b1783eecbb514fcba7632062771a83
-  branch: rails_upgrade
+  revision: e3e01970761befcd7bf88bcb51851e6c90df57f4
+  branch: rails_upgrade_v_0.2.1
   specs:
     cqm-parsers (1.0.0)
-      activesupport (~> 5.1.6)
+      activesupport (~> 5.0)
       builder (~> 3.1)
       erubis (~> 2.7.0)
       highline (~> 1.7.0)
@@ -27,10 +27,10 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-validators.git
-  revision: f18c64942affce7fbe4dcdfb3a56c277b44465a8
+  revision: 1841f19c75bcffade4ed0ff428eedc8607401e78
   branch: remove_hds
   specs:
-    cqm-validators (0.1.0)
+    cqm-validators (1.0.0)
       nokogiri (~> 1.8.2)
 
 GIT
@@ -568,4 +568,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.6
+   1.17.1


### PR DESCRIPTION
…f latest master

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code