### PR TITLE
Really actually fix the field_values display issue

### DIFF
--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -122,7 +122,7 @@
                         <td> <strong> Attributes </strong> </td>
                         <td><%= checklist_test_criteria_attribute(criteria, checked_criteria.attribute_index) %></td>
                         <td>
-                          <%= render partial: 'checklist_tests/field_values', locals: { attribute: criteria['attributes'][checked_criteria.attribute_index], result: criteria['value'], product_test: product_test, index: criteria_field.index, disable_modal: false } if criteria['attributes'] || criteria['value'] %>
+                          <%= render partial: 'checklist_tests/field_values', locals: { attribute: criteria['attributes'][checked_criteria.attribute_index], result: criteria['value'], product_test: product_test, index: criteria_field.index, disable_modal: false } if criteria['attributes'] %>
                         </td>
                         <% if coded_attribute?(criteria, checked_criteria.attribute_index) %>
                           <td class='hide-me'>

--- a/features/checklist_tests/edit.feature
+++ b/features/checklist_tests/edit.feature
@@ -1,0 +1,14 @@
+Feature: C1 Visual Checklist Test
+
+Background:
+  Given the user is signed in
+  And the user has created a vendor with a product selecting C1 testing with one measure
+
+Scenario: Edit Record Sample Test
+  When the user creates a product that certifies c1, c3 and visits the record sample page
+  Then the user should see a button to edit the checklist test
+  And the user clicks the Edit Test button
+  And the user picks Patient Characteristic Sex: ONCAdministrativeSex as a replacement for the first data criteria
+  And the user saves the record sample test
+  Then the Patient Characteristic Sex data criteria should exist
+

--- a/features/step_definitions/checklist_test.rb
+++ b/features/step_definitions/checklist_test.rb
@@ -26,6 +26,14 @@ And(/^the user views the record sample tab$/) do
   page.find("[href='##{html_id}']").click
 end
 
+And(/^the user picks (.*) as a replacement for the first data criteria$/) do |criteria_text|
+  page.select(criteria_text, from: 'product_test_checked_criteria_attributes_0_replacement_data_criteria')
+end
+
+And(/^the user saves the record sample test$/) do
+  page.find("input[value='Save']").click
+end
+
 # # # # # # # #
 #   W H E N   #
 # # # # # # # #
@@ -47,8 +55,8 @@ end
 
 #   A N D   #
 
-When(/^the user views that checklist test$/) do
-  page.find("input[type = submit][value = 'View Test']").click
+When(/^the user views that record sample test$/) do
+  page.find("input[type = submit][value = 'View Record Sample']").click
 end
 
 And(/^the user deletes the checklist test$/) do
@@ -133,6 +141,16 @@ Then(/^the user should see a button to revisit the checklist test$/) do
   # assert page.has_selector?("input[type = submit][value = 'View Test']")
 end
 
+Then(/^the user should (not )?see a button to edit the checklist test$/) do |not_present|
+  selector_presence = page.has_selector?('#modifyrecord')
+  puts not_present
+  if not_present
+    assert !selector_presence
+  else
+    assert selector_presence
+  end
+end
+
 Then(/^the user should be able to generate another checklist test$/) do
   steps %( And the user views the record sample tab )
   assert_equal false, page.has_selector?("input[type = submit][value = 'View Test']")
@@ -194,4 +212,8 @@ Then(/^the user should see the individual measure checklist page for measure (.*
   page.assert_text(measure.cms_id)
   page.assert_text(measure.name)
   page.assert_text 'Return to Record Sample'
+end
+
+Then(/^the (.*) data criteria should exist$/) do |criteria_text|
+  page.has_text?(criteria_text)
 end


### PR DESCRIPTION
#1060 "fixed" the issue it was meant to fix, but along the way it also disappeared some page elements that we didn't want to disappear. This fix brings them back, while still avoiding that 500 error.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-363
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name: Lauren DiCristofaro
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code