### PR TITLE
Fix eager loading in production

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -38,7 +38,7 @@ module Cypress
 
     # Do not swallow errors in after_commit/after_rollback callbacks.
     # config.active_record.raise_in_transactional_callbacks = true
-    config.autoload_paths += Dir["#{config.root}/lib/"]
+    config.eager_load_paths << Rails.root.join('lib')
     config.assets.paths << Rails.root.join('app', 'assets', 'fonts')
 
     # prevent rails from wrapping inputs with errors in a div of class "field_with_errors"


### PR DESCRIPTION
There is a change in Rails 5.x that disables autoloading after booting the app in production. This was breaking Cypress v5 during testing in production mode.

More information: https://blog.bigbinary.com/2016/08/29/rails-5-disables-autoloading-after-booting-the-app-in-production.html

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: This issue was detected while testing changes for https://jira.mitre.org/browse/CYPRESS-415
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code