### PR TITLE
Fix support for older versions of VMWare on Cypress v4

### DIFF
--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -130,14 +130,17 @@
       "shutdown_command": "echo '{{user `default_pwd`}}' | sudo -S -E shutdown -P now",
       "vmdk_name": "disk",
       "disk_type_id": "0",
+      "memory": "8192",
+      "cpus": "4",
       "vmx_data": {
         "MemTrimRate": "0",
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "8192",
-        "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
+      },
+      "vmx_data_post": {
+        "bios.hddorder": ""
       },
       "disk_size": "100000"
     },
@@ -188,14 +191,17 @@
       "shutdown_command": "echo '{{user `default_pwd`}}' | sudo -S -E shutdown -P now",
       "vmdk_name": "disk",
       "disk_type_id": "0",
+      "memory": "8192",
+      "cpus": "4",
       "vmx_data": {
         "MemTrimRate": "0",
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "8192",
-        "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
+      },
+      "vmx_data_post": {
+        "bios.hddorder": ""
       },
       "disk_size": "100000"
     },
@@ -246,14 +252,17 @@
       "shutdown_command": "echo '{{user `default_pwd`}}' | sudo -S -E shutdown -P now",
       "vmdk_name": "disk",
       "disk_type_id": "0",
+      "memory": "8192",
+      "cpus": "4",
       "vmx_data": {
         "MemTrimRate": "0",
         "sched.mem.pshare.enable": "FALSE",
         "mainMem.useNamedFile": "FALSE",
         "prefvmx.minVmMemPct": "100",
-        "memsize": "8192",
-        "numvcpus": "4",
         "cpuid.coresPerSocket": "1"
+      },
+      "vmx_data_post": {
+        "bios.hddorder": ""
       },
       "disk_size": "100000"
     }


### PR DESCRIPTION
Our current releases fail to work on older versions of VMWare due to https://github.com/hashicorp/packer/issues/6742

This applies the fixes mentioned in the aforementioned thread.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-332
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code