### PR TITLE
Fix lookup_codevalues when a bundle is passed in

### DIFF
--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -55,7 +55,7 @@ module ChecklistTestsHelper
 
   def lookup_codevalues(oid, bundle = nil)
     filter = { oid: oid }
-    params.store(:bundle_id, bundle) unless bundle.nil?
+    filter.store(:bundle_id, bundle) unless bundle.nil?
     vs = HealthDataStandards::SVS::ValueSet.where(filter)
 
     return [] unless vs&.first

--- a/test/helpers/checklist_tests_helper_test.rb
+++ b/test/helpers/checklist_tests_helper_test.rb
@@ -3,6 +3,15 @@ require 'test_helper'
 class ChecklistTestsHelperTest < ActiveSupport::TestCase
   include ChecklistTestsHelper
 
+  # This ensures that the filtering on lookup_codevalues properly limits results
+  # to a specific bundle when specified
+  def test_lookup_codevalues_multiple_bundles
+    @bundle1 = FactoryBot.create(:static_bundle)
+    @bundle2 = FactoryBot.create(:bundle)
+
+    assert_empty lookup_codevalues(@bundle1.value_sets.first.oid, @bundle2)
+  end
+
   def test_checklist_test_criteria_attribute
     c1 = {}
     c2 = {}


### PR DESCRIPTION
While cherry-picking the changes from Cypress v4 to v5 I noticed a variable naming mistake in the filtering logic. I have fixed the mistake and added a test for it.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: (N/A)
- [x] Internal ticket links to this PR (N/A)
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code