### PR TITLE
Restructure Patient model for easier integration of Bring your own Patient

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,6 +35,7 @@ Metrics/BlockLength:
 Rails/InverseOf:
   Exclude:
     - 'app/models/product_test.rb'
+    - 'app/models/vendor.rb'
 
 # Offense count: 6
 # Configuration parameters: Include.

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -16,7 +16,7 @@ class ProductTest
   has_many :tasks, dependent: :destroy, inverse_of: :product_test
 
   # TODO: R2P: fix foreign key descriptor?
-  has_many :patients, dependent: :destroy, foreign_key: 'correlation_id', class_name: 'CQM::Patient'
+  has_many :patients, dependent: :destroy, foreign_key: 'correlation_id', class_name: 'CQM::ProductTestPatient'
 
   field :augmented_patients, type: Array, default: []
 
@@ -60,7 +60,7 @@ class ProductTest
   def self.destroy_by_ids(product_test_ids)
     tasks = Task.where(:product_test_id.in => product_test_ids)
     task_ids = tasks.pluck(:_id)
-    patients = CQM::Patient.where(:correlation_id.in => product_test_ids)
+    patients = ProductTestPatient.where(:correlation_id.in => product_test_ids)
     patient_ids = patients.pluck(:_id)
     test_executions = TestExecution.where(:task_id.in => task_ids)
     test_execution_ids = test_executions.pluck(:_id)

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -7,6 +7,7 @@ class Vendor
   scope :by_updated_at, -> { order(updated_at: :desc) }
 
   has_many :products, dependent: :destroy
+  has_many :patients, dependent: :destroy, foreign_key: 'correlation_id', class_name: 'CQM::VendorPatient'
   embeds_many :points_of_contact, class_name: 'PointOfContact', cascade_callbacks: true
 
   accepts_nested_attributes_for :points_of_contact, allow_destroy: true, reject_if: ->(poc) { poc[:name].blank? }

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -33,13 +33,12 @@ When(/^the user creates a product with tasks (.*)$/) do |tasks|
   measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
   bundle_id = Bundle.default._id
   tasks = tasks.split(', ')
-  @product = Product.new(vendor: @vendor, name: 'Product 1', measure_ids: measure_ids, c1_test: tasks.include?('c1'),
-                         c2_test: tasks.include?('c2'), c3_test: tasks.include?('c3'), c4_test: tasks.include?('c4'), bundle_id: bundle_id)
-  @product.save!
+  @product = Product.create(vendor: @vendor, name: 'Product 1', measure_ids: measure_ids, c1_test: tasks.include?('c1'),
+                            c2_test: tasks.include?('c2'), c3_test: tasks.include?('c3'), c4_test: tasks.include?('c4'), bundle_id: bundle_id)
   @product_test = @product.product_tests.create!({ name: @measure.name, measure_ids: measure_ids, cms_id: @measure.cms_id }, MeasureTest)
 
   provider = @product_test.provider
-  Patient.create!(provider_performances: [{ provider_id: provider.id }], correlation_id: @product_test.id.to_s)
+  ProductTestPatient.create!(provider_performances: [{ provider_id: provider.id }], correlation_id: @product_test.id.to_s)
 end
 
 # task_names should be either 'c1', 'c2', or both

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -17,11 +17,11 @@ module Cypress
       @options = options
     end
 
-    def execute
+    def execute(save = true)
       results = @measures.map do |measure|
         request_for(measure)
       end.flatten
-      CQM::IndividualResult.collection.insert_many(results)
+      CQM::IndividualResult.collection.insert_many(results) if save
       results
     end
 

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -81,7 +81,6 @@ module Cypress
         original_patient_id: patient.id,
         correlation_id: options['test_id']
       }
-      # TODO: R2P: use patient model
       unnumerify cloned_patient if patient.givenNames.map { |n| n =~ /\d/ }.any? || patient.familyName =~ /\d/
       cloned_patient.medical_record_number = next_medical_record_number unless options['disable_randomization']
       DemographicsRandomizer.randomize(cloned_patient, prng, allow_dups) if options['randomize_demographics']

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -76,12 +76,14 @@ module Cypress
       # If we need to clone a patient for any other reason then we will need to paramaterize
       # the type coming into this class.
       cloned_patient = ProductTestPatient.new(patient.attributes.except(:_id, :_type))
+      cloned_patient.attributes = {
+        original_medical_record_number: patient.medical_record_number,
+        original_patient_id: patient.id,
+        correlation_id: options['test_id']
+      }
       # TODO: R2P: use patient model
       unnumerify cloned_patient if patient.givenNames.map { |n| n =~ /\d/ }.any? || patient.familyName =~ /\d/
-      cloned_patient.original_medical_record_number = cloned_patient.medical_record_number
-      cloned_patient.original_patient_id = patient.id
       cloned_patient.medical_record_number = next_medical_record_number unless options['disable_randomization']
-      cloned_patient.correlation_id = options['test_id']
       DemographicsRandomizer.randomize(cloned_patient, prng, allow_dups) if options['randomize_demographics']
       # work around to replace 'Other' race codes in Cypress bundle. Pass in static seed for consistent results.
       DemographicsRandomizer.randomize_race(cloned_patient, Random.new(0)) if cloned_patient.race == '2131-1'

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -72,7 +72,10 @@ module Cypress
 
     # if provider argument is nil, this function will assign a new provider based on the @option['providers'] and @option['generate_provider'] options
     def clone_and_save_patient(patient, prng, provider = nil, allow_dups = false)
-      cloned_patient = patient.clone
+      # This operates on the assumption that we are always cloning a patient for a product test.
+      # If we need to clone a patient for any other reason then we will need to paramaterize
+      # the type coming into this class.
+      cloned_patient = ProductTestPatient.new(patient.attributes.except(:_id, :_type))
       # TODO: R2P: use patient model
       unnumerify cloned_patient if patient.givenNames.map { |n| n =~ /\d/ }.any? || patient.familyName =~ /\d/
       cloned_patient.original_medical_record_number = cloned_patient.medical_record_number

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -21,20 +21,14 @@ class Bundle
 
   has_many :value_sets, class_name: 'ValueSet', inverse_of: :bundle
   has_many :products, dependent: :destroy
+  has_many :measures, foreign_key: :bundle_id, order: [:id.asc, :sub_id.asc]
+  has_many :patients, class_name: 'CQM::BundlePatient', foreign_key: :bundleId
 
   scope :active, -> { where(active: true) }
   scope :available, -> { where(:deprecated.ne => true) }
 
   def results
     CQM::IndividualResult.where('extendedData.correlation_id' => id.to_s)
-  end
-
-  def patients
-    Patient.where(bundleId: _id.to_s, correlation_id: nil).order_by([['last', :asc]])
-  end
-
-  def measures
-    Measure.where(bundle_id: id).order_by([['id', :asc], ['sub_id', :asc]])
   end
 
   def title

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -1,5 +1,4 @@
 # The Patient model is an extension of app/models/qdm/patient.rb as defined by CQM-Models.
-Patient = CQM::Patient
 
 module CQM
   class Patient
@@ -10,6 +9,12 @@ module CQM
     field :original_medical_record_number, type: String
     field :medical_record_number, type: String
     embeds_many :addresses
+    default_scope { order('last': :asc) }
+
+    # This allows us to instantiate Patients that do not belong to specific type of patient
+    # for the purposes of testing but blocks us from saving them to the database to ensure
+    # every patient actually in the database is of a valid type.
+    validates :_type, inclusion: %w[CQM::BundlePatient CQM::VendorPatient CQM::ProductTestPatient]
 
     def destroy
       calculation_results.destroy
@@ -135,4 +140,15 @@ module CQM
     # HDS helpers
     #
   end
+
+  class BundlePatient < Patient; end
+
+  class VendorPatient < Patient; end
+
+  class ProductTestPatient < Patient; end
 end
+
+Patient = CQM::Patient
+BundlePatient = CQM::BundlePatient
+VendorPatient = CQM::VendorPatient
+ProductTestPatient = CQM::ProductTestPatient

--- a/lib/validators/calculating_augmented_records.rb
+++ b/lib/validators/calculating_augmented_records.rb
@@ -16,7 +16,7 @@ module Validators
       nil
     end
 
-    # create a temporary saved record copy to do calculations on, then delete it
+    # create a temporary record copy to do calculations on
     def validate_calculated_results(rec, options)
       # return false unless mrn
       record = parse_record(rec.clone)
@@ -26,10 +26,8 @@ module Validators
       calc_job = Cypress::CqmExecutionCalc.new([record.qdmPatient], product_test.measures, product_test.value_sets_by_oid, nil,
                                                'effectiveDateEnd': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
-      results = calc_job.execute
-
+      results = calc_job.execute(false)
       passed = compare_results(results, record, options)
-      record.destroy
       passed
     end
 

--- a/lib/validators/calculating_augmented_records.rb
+++ b/lib/validators/calculating_augmented_records.rb
@@ -8,10 +8,9 @@ module Validators
     end
 
     # Functions related to individual record calculation results
-    def parse_and_save_record(record)
+    def parse_record(record)
       record.correlation_id = @test_id
       record.medical_record_number = rand(1_000_000_000_000_000)
-      record.save
       record
     rescue
       nil
@@ -20,7 +19,7 @@ module Validators
     # create a temporary saved record copy to do calculations on, then delete it
     def validate_calculated_results(rec, options)
       # return false unless mrn
-      record = parse_and_save_record(rec.clone)
+      record = parse_record(rec.clone)
       product_test = ProductTest.find(record.correlation_id)
       return false unless record
 

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -39,10 +39,9 @@ module Validators
       [original_value, calculated_value, pop]
     end
 
-    def parse_and_save_record(doc, options)
+    def parse_record(doc, options)
       patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
       Cypress::GoImport.replace_negated_codes(patient, @bundle)
-      patient.save
       patient
     rescue
       add_error('File failed import', file_name: options[:file_name])
@@ -53,7 +52,7 @@ module Validators
       mrn, = get_record_identifiers(doc, options)
       return false unless mrn
 
-      record = parse_and_save_record(doc, options)
+      record = parse_record(doc, options)
       return false unless record
 
       product_test = options['task'].product_test

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -65,9 +65,8 @@ module Validators
                                                options.test_execution.id.to_s,
                                                'effectiveDateEnd': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
-      results = calc_job.execute
+      results = calc_job.execute(false)
       passed = determine_passed(mrn, results, record, options)
-      record.destroy
       passed
     end
 

--- a/test/factories/patients.rb
+++ b/test/factories/patients.rb
@@ -1,7 +1,7 @@
 # Requires a bundleId to be passed in as a string, not a BSON Object
 
 FactoryBot.define do
-  factory :patient, class: Patient do
+  factory :patient, class: BundlePatient do
     transient do
       seq_id { 1 }
     end
@@ -26,7 +26,7 @@ FactoryBot.define do
       patient.save!
     end
 
-    factory :static_test_patient do
+    factory :static_test_patient, class: ProductTestPatient do
       familyName { 'A' }
       givenNames { ['Dental_Peds'] }
       qdmPatient { FactoryBot.build(:qdm_patient) }

--- a/test/jobs/measure_evaluation_job_test.rb
+++ b/test/jobs/measure_evaluation_job_test.rb
@@ -21,7 +21,7 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
       calc_job = Cypress::CqmExecutionCalc.new(pt.patients.map!(&:qdmPatient), pt.measures, pt.value_sets_by_oid, correlation_id,
                                                'effectiveDateEnd': Time.at(pt.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(pt.measure_period_start).in_time_zone.to_formatted_s(:number))
-      individual_results_from_sync_job = calc_job.execute
+      individual_results_from_sync_job = calc_job.execute(false)
 
       # calculate expected_results using individual results stored in database (don't pass in individual results)
       MeasureEvaluationJob.perform_now(pt, {})

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -6,15 +6,15 @@ class PatientTest < ActiveSupport::TestCase
   end
 
   def test_record_knows_bundle
-    patient = Patient.new(bundleId: @bundle.id)
+    patient = BundlePatient.new(bundleId: @bundle.id)
     patient.save
     assert_equal @bundle, patient.bundle, 'A record should know what bundle it is associated with if any'
   end
 
   def test_record_should_be_able_to_find_original
-    r1 = Patient.new(medical_record_number: '1a', bundleId: @bundle.id)
+    r1 = BundlePatient.new(medical_record_number: '1a', bundleId: @bundle.id)
     r1.save
-    r2 = Patient.new(medical_record_number: '1a', original_patient_id: r1.id, bundleId: @bundle.id)
+    r2 = ProductTestPatient.new(medical_record_number: '1a', original_patient_id: r1.id, bundleId: @bundle.id)
     r2.save
     assert_equal r1.id, r2.original_patient_id, 'Record should be able to find record it was cloned from'
   end

--- a/test/unit/lib/clinical_randomizer_test.rb
+++ b/test/unit/lib/clinical_randomizer_test.rb
@@ -2,20 +2,16 @@ require 'test_helper'
 
 class ClinicalRandomizerTest < ActiveSupport::TestCase
   setup do
-    @patient = Patient.new(givenNames: ['Foo'], familyName: 'Bar')
-    @bundle = FactoryBot.create(:static_bundle)
+    @bundle = FactoryBot.create(:static_bundle, measure_period_start: 1_293_840_000, effective_date: 1_325_375_999)
+    @patient = BundlePatient.new(givenNames: ['Foo'], familyName: 'Bar', bundleId: @bundle.id)
     @start = DateTime.new(2011, 1, 1, 0, 0, 0).utc
     @end = DateTime.new(2011, 12, 31, 23, 59, 59).utc
-    @bundle.measure_period_start = 1_293_840_000
-    @bundle.effective_date = 1_325_375_999
-    @patient.bundleId = @bundle.id
 
     @patient.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 10, 1, 23, 59, 59).utc, nil))
     @patient.save!
 
-    @patient2 = Patient.new(givenNames: ['Bar'], familyName: 'Foo')
-    @patient2.bundleId = @bundle.id
+    @patient2 = BundlePatient.new(givenNames: ['Bar'], familyName: 'Foo', bundleId: @bundle.id)
     @patient2.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient2.qdmPatient.dataElements.push QDM::ProcedurePerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 10, 1, 23, 59, 59).utc, nil))
     @patient2.qdmPatient.dataElements.push QDM::Diagnosis.new(prevalencePeriod: QDM::Interval.new(DateTime.new(2011, 10, 2, 0, 0, 0).utc, nil))
@@ -25,21 +21,18 @@ class ClinicalRandomizerTest < ActiveSupport::TestCase
   end
 
   def setup_secondary_instances
-    @patient3 = Patient.new(givenNames: ['Insurance'], familyName: 'Test')
-    @patient3.bundleId = @bundle.id
+    @patient3 = BundlePatient.new(givenNames: ['Insurance'], familyName: 'Test', bundleId: @bundle.id)
     @patient3.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient3.insurance_providers = [{ start_time: @start }]
     @patient3.save!
 
-    @patient4 = Patient.new(givenNames: ['SplitDate'], familyName: 'Same')
-    @patient4.bundleId = @bundle.id
+    @patient4 = BundlePatient.new(givenNames: ['SplitDate'], familyName: 'Same', bundleId: @bundle.id)
     @patient4.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient4.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient4.insurance_providers = [{ start_time: @start }]
     @patient4.save!
 
-    @patient5 = Patient.new(givenNames: ['SplitDate'], familyName: 'Same_plus')
-    @patient5.bundleId = @bundle.id
+    @patient5 = BundlePatient.new(givenNames: ['SplitDate'], familyName: 'Same_plus', bundleId: @bundle.id)
     @patient5.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 24, 20, 53, 20).utc, nil))
     @patient5.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
     @patient5.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))

--- a/test/unit/lib/validators/expected_results_validator_test.rb
+++ b/test/unit/lib/validators/expected_results_validator_test.rb
@@ -14,24 +14,18 @@ class ExpectedResultsValidatorTest < ActiveSupport::TestCase
   end
 
   def setup_augmented_patients
-    @patient1 = Patient.new(givenNames: ['Jill'], familyName: 'Mcguire', medical_record_number: '198718e0-4d42-0135-8680-12999b0ed66f')
-    ir1 = CQM::IndividualResult.new(IPP: 1.000000, patient_id: @patient1.id, patient: @patient1, measure: @measure)
-    ir1.save!
-    @patient1.save!
+    @patient1 = ProductTestPatient.create(givenNames: ['Jill'], familyName: 'Mcguire', medical_record_number: '198718e0-4d42-0135-8680-12999b0ed66f')
+    ir1 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient1.id, patient: @patient1, measure: @measure)
     @augmented_patient1 = { 'original_patient_id' => @patient1.id, 'medical_record_number' => '198718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Jill J], 'last' => %w[Mcguire Mcguirn], :gender => %w[F M] }
 
-    @patient2 = Patient.new(givenNames: ['Ivan'], familyName: 'Mcguire', medical_record_number: '098718e0-4d42-0135-8680-12999b0ed66f')
-    ir2 = CQM::IndividualResult.new(IPP: 1.000000, patient_id: @patient2.id, patient: @patient2, measure: @measure)
-    ir2.save!
-    @patient2.save!
+    @patient2 = ProductTestPatient.create(givenNames: ['Ivan'], familyName: 'Mcguire', medical_record_number: '098718e0-4d42-0135-8680-12999b0ed66f')
+    ir2 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient2.id, patient: @patient2, measure: @measure)
     @augmented_patient2 = { 'original_patient_id' => @patient2.id, 'medical_record_number' => '098718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Ivan Ivan], 'last' => %w[Mcguire Mcguirn], :gender => %w[M F] }
 
-    @patient3 = Patient.new(givenNames: ['Joe'], familyName: 'Mcguire', medical_record_number: '298718e0-4d42-0135-8680-12999b0ed66f')
-    ir3 = CQM::IndividualResult.new(IPP: 1.000000, patient_id: @patient3.id, patient: @patient3, measure: @measure)
-    ir3.save!
-    @patient3.save!
+    @patient3 = ProductTestPatient.create(givenNames: ['Joe'], familyName: 'Mcguire', medical_record_number: '298718e0-4d42-0135-8680-12999b0ed66f')
+    ir3 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient3.id, patient: @patient3, measure: @measure)
     @augmented_patient3 = { 'original_patient_id' => @patient3.id, 'medical_record_number' => '298718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Joe John], 'last' => %w[Mcguire Mcguirn], :gender => %w[M M] }
   end

--- a/test/unit/lib/validators/expected_results_validator_test.rb
+++ b/test/unit/lib/validators/expected_results_validator_test.rb
@@ -15,17 +15,17 @@ class ExpectedResultsValidatorTest < ActiveSupport::TestCase
 
   def setup_augmented_patients
     @patient1 = ProductTestPatient.create(givenNames: ['Jill'], familyName: 'Mcguire', medical_record_number: '198718e0-4d42-0135-8680-12999b0ed66f')
-    ir1 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient1.id, patient: @patient1, measure: @measure)
+    CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient1.id, patient: @patient1, measure: @measure)
     @augmented_patient1 = { 'original_patient_id' => @patient1.id, 'medical_record_number' => '198718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Jill J], 'last' => %w[Mcguire Mcguirn], :gender => %w[F M] }
 
     @patient2 = ProductTestPatient.create(givenNames: ['Ivan'], familyName: 'Mcguire', medical_record_number: '098718e0-4d42-0135-8680-12999b0ed66f')
-    ir2 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient2.id, patient: @patient2, measure: @measure)
+    CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient2.id, patient: @patient2, measure: @measure)
     @augmented_patient2 = { 'original_patient_id' => @patient2.id, 'medical_record_number' => '098718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Ivan Ivan], 'last' => %w[Mcguire Mcguirn], :gender => %w[M F] }
 
     @patient3 = ProductTestPatient.create(givenNames: ['Joe'], familyName: 'Mcguire', medical_record_number: '298718e0-4d42-0135-8680-12999b0ed66f')
-    ir3 = CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient3.id, patient: @patient3, measure: @measure)
+    CQM::IndividualResult.create(IPP: 1.000000, patient_id: @patient3.id, patient: @patient3, measure: @measure)
     @augmented_patient3 = { 'original_patient_id' => @patient3.id, 'medical_record_number' => '298718e0-4d42-0135-8680-12999b0ed66f',
                             'first' => %w[Joe John], 'last' => %w[Mcguire Mcguirn], :gender => %w[M M] }
   end


### PR DESCRIPTION
This adds 3 subclasses of Patient, BundlePatient, VendorPatient, and ProductTestPatient

These 3 subclasses allow us to take advantage of Rails Single Table Inheritance, providing us with a :_type field on the Patient model. This type field allows us to properly use has_many relations in the app again which was previously not possible on models such as the bundle model.

Additionally, this has restructured the bundle import to use insert_many instead of insert_one which provides a huge performance speedup during bundle import.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code