### PR TITLE
Docker for Cypress v5

### DIFF
--- a/.pkgr.yml
+++ b/.pkgr.yml
@@ -5,6 +5,5 @@ dependencies:
 before:
   - mkdir -p /tmp/db
   - /usr/bin/mongod --dbpath /tmp/db --fork --syslog
-after_install: "contrib/scripts/after_install.sh"
 targets:
   ubuntu-16.04:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Pinned to the latest ruby 2.3.7 version of the Passenger base ocker image
-FROM phusion/passenger-ruby23:0.9.35
+# Pinned to the latest ruby 2.6.0 version of the Passenger base Docker image
+FROM phusion/passenger-ruby26:1.0.1
 
 RUN apt-get update \
     && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,29 +26,30 @@ ADD . /home/app/cypress
 # By creating it here it will get chowned correctly by the next declaration.
 RUN mkdir -p tmp public/data
 
+# DISABLE_DB disables an initializer that requires the DB to run, so we can precompile in the Docker build phase
+# SECRET_KEY_BASE sets a dummy secret key, so that the precompiler (which doesn't need the secret key for anything) can run
+RUN RAILS_ENV=production DISABLE_DB=true SECRET_KEY_BASE=precompile_only bundle exec rake assets:precompile
+
 # This line is a duplicate however it is done to significantly speed up testing. With this line twice
 # we are able to do the bundle install earlier on which means it is cached more often.
 RUN chown -R app:app .
+RUN chmod -R 0755 .
 
 RUN mkdir /etc/service/unicorn
 ADD docker_unicorn_start.sh /etc/service/unicorn/run
 RUN chmod 755 /etc/service/unicorn/run
 
-# RUN mkdir /etc/service/cypress_delayed_job_1
-# ADD docker_delayed_job.sh /etc/service/cypress_delayed_job_1/run
-# RUN chmod 755 /etc/service/cypress_delayed_job_1/run
-
-# DISABLE_SMTP_SETTINGS disables an initializer that requires the DB to run, so we can precompile in the Docker build phase
-# SECRET_KEY_BASE sets a dummy secret key, so that the precompiler (which doesn't need the secret key for anything) can run
-RUN RAILS_ENV=production DISABLE_SMTP_SETTINGS=true SECRET_KEY_BASE=precompile_only bundle exec rake assets:precompile
+RUN mkdir /etc/service/cypress_delayed_job_1
+ADD docker_delayed_job.sh /etc/service/cypress_delayed_job_1/run
+RUN chmod 755 /etc/service/cypress_delayed_job_1/run
 
 # Setup other workers based on first worker. This makes it where tweaking the number of workers
 # just requires changing this WORKER_COUNT. Unfortunately does not allow tweaking after build is completed.
-# ARG WORKER_COUNT=4
-# RUN if [ $WORKER_COUNT -gt 1 ]; then \
-#       for i in $(seq 2 1 $WORKER_COUNT); do \
-#         cp -R /etc/service/cypress_delayed_job_1 /etc/service/cypress_delayed_job_$i; \
-#       done; \
-#     fi
+ARG WORKER_COUNT=4
+RUN if [ $WORKER_COUNT -gt 1 ]; then \
+      for i in $(seq 2 1 $WORKER_COUNT); do \
+        cp -R /etc/service/cypress_delayed_job_1 /etc/service/cypress_delayed_job_$i; \
+      done; \
+    fi
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/passenger-ruby23:latest
+# Pinned to the latest ruby 2.3.7 version of the Passenger base ocker image
+FROM phusion/passenger-ruby23:0.9.35
 
 RUN apt-get update \
     && apt-get upgrade -y -o Dpkg::Options::="--force-confold" \

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -52,8 +52,6 @@ class Settings
 
   # This model should only be called using this method
   def self.current
-    return first if ENV['SKIP_SETTINGS_CREATE']&.to_boolean.eql?(true)
-
     Rails.cache.fetch('settings') do
       first_or_create
     end

--- a/app/views/layouts/report.html.erb
+++ b/app/views/layouts/report.html.erb
@@ -11,7 +11,7 @@
   <meta name="keywords" content="" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <style type="text/css">
-    <%= Rails.application.assets.find_asset('application.css').to_s.html_safe %>
+    <%= Rails.application.assets_manifest.find_sources('application.css').first.to_s.html_safe %>
   </style>
 </head>
 <body>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -2,7 +2,7 @@
 # upgrades failing to complete successfully.
 
 # These settings are kept in the constants file with the assumption that the end user should not be overriding them.
-bundle_file_path: 'temp/bundles'
+bundle_file_path: 'tmp/bundles'
 file_upload_root: 'data/upload/'
 
 # These were initially in I18n however for some reason I18n is not loaded when rake tasks are run, which means we often

--- a/config/initializers/cqm_execution_service.rb
+++ b/config/initializers/cqm_execution_service.rb
@@ -1,0 +1,2 @@
+Rails.application.config.ces_host = ENV['CQM_EXECUTION_SERVICE_HOST'] || 'localhost'
+Rails.application.config.ces_port = ENV['CQM_EXECUTION_SERVICE_PORT'] || '8081'

--- a/config/initializers/mongoid.rb
+++ b/config/initializers/mongoid.rb
@@ -10,4 +10,4 @@ module BSON
   end
 end
 
-Mongoid::Tasks::Database.create_indexes if Rails.env.production? && !ENV['DISABLE_DB']
+Mongoid::Tasks::Database.create_indexes if (Rails.env.production? || Rails.env.development?) && !ENV['DISABLE_DB']

--- a/config/initializers/mongoid.rb
+++ b/config/initializers/mongoid.rb
@@ -9,3 +9,5 @@ module BSON
     end
   end
 end
+
+Mongoid::Tasks::Database.create_indexes if Rails.env.production? && !ENV['DISABLE_DB']

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,2 +1,4 @@
 # This will apply the current mailer settings on app startup.
-Settings.current&.apply_mailer_settings
+unless ENV['DISABLE_SMTP_SETTINGS']
+  Settings.current&.apply_mailer_settings
+end

--- a/config/initializers/smtp.rb
+++ b/config/initializers/smtp.rb
@@ -1,4 +1,4 @@
 # This will apply the current mailer settings on app startup.
-unless ENV['DISABLE_SMTP_SETTINGS']
-  Settings.current&.apply_mailer_settings
-end
+
+Settings.current&.apply_mailer_settings unless ENV['DISABLE_DB']
+

--- a/contrib/scripts/after_install.sh
+++ b/contrib/scripts/after_install.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-SKIP_SETTINGS_CREATE=true cypress run rake db:mongoid:create_indexes

--- a/contrib/scripts/after_install.sh
+++ b/contrib/scripts/after_install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-SKIP_SETTINGS_CREATE=true cypress run rake db:migrate db:mongoid:create_indexes
+SKIP_SETTINGS_CREATE=true cypress run rake db:mongoid:create_indexes

--- a/contrib/scripts/create_env_prod.sh
+++ b/contrib/scripts/create_env_prod.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "SECRET_KEY_BASE=$(LC_CTYPE=C < /dev/urandom tr -dc A-Za-z0-9 | head -c${1:-128};echo;)" > .env-prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,3 @@
-# WARNING: This docker-compose.yml, and the associated Dockerfile,
-# are only functional for Cypress v3.x. Docker installation 
-# methods are not yet supported for Cypress v4, as of 2018-07-10
-
 version: "3"
 
 services:
@@ -9,20 +5,40 @@ services:
     build:
       context: .
     volumes:
-      - /home/app/cypress/public/data
-    tmpfs:
-      - /home/app/cypress/tmp:size=2g,uid=9999
+      - cypress-tmp:/home/app/cypress/public/data
     environment:
       - MONGO_PORT_27017_TCP_ADDR=mongodb
       - MONGO_PORT_27017_TCP_PORT=27017
+      - CQM_EXECUTION_HOST=cqm-execution-service
     ports:
       - "3000:3000"
-    links:
-      - mongodb:mongo
     env_file: .env-prod
     restart: unless-stopped
+    networks:
+      - cypress-net
   mongodb:
-    image: mongo:3.4.5
+    image: mongo:latest
     volumes:
       - /data/db
+      - ./mongo:/etc/mongo
+    command: --config=/etc/mongo/docker_mongod.conf
     restart: unless-stopped
+    networks:
+      - cypress-net
+    ports:
+      - "27017:27017"
+  cqm-execution-service:
+    image: docker/cqm-execution-service:latest
+    networks:
+      - cypress-net
+    ports:
+      - "8081:8081"
+
+networks:
+  cypress-net:
+
+volumes:
+  cypress-tmp:
+    driver_opts:
+      type: tmpfs
+      device: tmpfs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       - MONGO_PORT_27017_TCP_ADDR=mongodb
       - MONGO_PORT_27017_TCP_PORT=27017
-      - CQM_EXECUTION_HOST=cqm-execution-service
+      - CQM_EXECUTION_SERVICE_HOST=cqm-execution-service
     ports:
       - "3000:3000"
     env_file: .env-prod
@@ -17,7 +17,7 @@ services:
     networks:
       - cypress-net
   mongodb:
-    image: mongo:latest
+    image: mongo:3.4.5
     volumes:
       - /data/db
       - ./mongo:/etc/mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "27017:27017"
   cqm-execution-service:
-    image: tacoma/cqm-execution-service:latest
+    image: tacoma/cqm-execution-service:cypress_v5
     networks:
       - cypress-net
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     ports:
       - "27017:27017"
   cqm-execution-service:
-    image: docker/cqm-execution-service:latest
+    image: tacoma/cqm-execution-service:latest
     networks:
       - cypress-net
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
     volumes:
-      - cypress-tmp:/home/app/cypress/public/data
+      - cypress-vol:/home/app/cypress/public/data
     environment:
       - MONGO_PORT_27017_TCP_ADDR=mongodb
       - MONGO_PORT_27017_TCP_PORT=27017
@@ -38,7 +38,4 @@ networks:
   cypress-net:
 
 volumes:
-  cypress-tmp:
-    driver_opts:
-      type: tmpfs
-      device: tmpfs
+  cypress-vol:

--- a/lib/cypress.rb
+++ b/lib/cypress.rb
@@ -2,4 +2,5 @@ Dir[File.dirname(__FILE__) + '/cypress/*.rb'].each { |file| require file }.each 
 Dir[File.dirname(__FILE__) + '/cypress/patient_export/*.rb'].each { |file| require file }.each { |file| require file }
 Dir[File.dirname(__FILE__) + '/ext/*.rb'].each { |file| require file }.each { |file| require file }
 Dir[File.dirname(__FILE__) + '/validators/*.rb'].each { |file| require file }.each { |file| require file }
+require_relative 'bootstrap_breadcrumbs_builder.rb'
 require_relative 'job_status.rb'

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -29,7 +29,7 @@ module Cypress
       # oids field. There is a value_set_oids on the measure for this explicit purpose.
       post_data = post_data.to_json(methods: %i[_type value_set_oids])
       begin
-        response = RestClient::Request.execute(method: :post, url: self.class.create_connection_string, :timeout: 120,
+        response = RestClient::Request.execute(method: :post, url: self.class.create_connection_string, timeout: 120,
                                                payload: post_data, headers: { content_type: 'application/json' })
       rescue => e
         raise e.to_s || 'Calculation failed without an error message'

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -3,8 +3,6 @@ require 'securerandom'
 
 module Cypress
   class CqmExecutionCalc
-    CALCULATION_SERVICE_URL = 'http://localhost:8081/calculate'.freeze
-
     attr_accessor :patients, :measures, :value_set_oids, :options
 
     def initialize(patients, measures, value_set_oids, correlation_id, options)
@@ -31,7 +29,7 @@ module Cypress
       # oids field. There is a value_set_oids on the measure for this explicit purpose.
       post_data = post_data.to_json(methods: %i[_type value_set_oids])
       begin
-        response = RestClient::Request.execute(method: :post, url: CALCULATION_SERVICE_URL, timeout: 120,
+        response = RestClient::Request.execute(method: :post, url: create_connection_string, :timeout: 120,
                                                payload: post_data, headers: { content_type: 'application/json' })
       rescue => e
         raise e.to_s || 'Calculation failed without an error message'
@@ -51,6 +49,11 @@ module Cypress
           pop_criteria
         end
       end
+    end
+
+    def self.create_connection_string
+      config = Rails.application.config
+      "http://#{config.ces_host}:#{config.ces_port}"
     end
 
     private

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -29,7 +29,7 @@ module Cypress
       # oids field. There is a value_set_oids on the measure for this explicit purpose.
       post_data = post_data.to_json(methods: %i[_type value_set_oids])
       begin
-        response = RestClient::Request.execute(method: :post, url: create_connection_string, :timeout: 120,
+        response = RestClient::Request.execute(method: :post, url: self.class.create_connection_string, :timeout: 120,
                                                payload: post_data, headers: { content_type: 'application/json' })
       rescue => e
         raise e.to_s || 'Calculation failed without an error message'
@@ -53,7 +53,7 @@ module Cypress
 
     def self.create_connection_string
       config = Rails.application.config
-      "http://#{config.ces_host}:#{config.ces_port}"
+      "http://#{config.ces_host}:#{config.ces_port}/calculate"
     end
 
     private

--- a/mongo/docker_mongod.conf
+++ b/mongo/docker_mongod.conf
@@ -1,0 +1,2 @@
+setParameter:
+  maxBSONDepth: 500


### PR DESCRIPTION
This PR fixes the Cypress Docker and Docker Compose infrastructures to work with Cypress v5, as currently available in `master`. It updates:

* The Ruby base image used to build Cypress
* The measure calculation engine used by Cypress (to `cqm-execution-service`, as built on https://hub.docker.com/r/tacoma/cqm-execution-service
* The way the CQM Execution Service URL gets built, to allow for it to be on a host other than `localhost` (useful for more than Docker)
* A typo (I think?) that caused a separate temp folder (`temp/bundles`) to be built, rather than using the existing `tmp` folder
* An environment variable (`DISABLE_DB`) to be used to kill DB access during the precompile step, to allow for precompilation of assets in the Docker image
* One update to `require` the `BootstrapBreadcrumbsBuilder`, which wasn't previously included.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases N/A
- [x] Tests have been run locally and pass N/A

**Reviewer 1:**

Name: Robert Clark
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code