### PR TITLE
Byo patient view patients

### DIFF
--- a/app/views/application/_header_vendor.html.erb
+++ b/app/views/application/_header_vendor.html.erb
@@ -6,6 +6,9 @@
           <%= icon('fas fa-fw', 'plus', :"aria-hidden" => true) %> Add Product
         <% end %>
       <% end %>
+      <%= button_to records_path, params:{vendor_id: vendor.id} , :method => :get, :class => "btn btn-default" do %>
+        <%= icon('fas fa-fw', 'users', :"aria-hidden" => true) %> Vendor Patients
+      <% end %>
       <%= button_to edit_vendor_path(vendor), :method => :get, :class => "btn btn-default" do %>
         <%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %> Edit Vendor
       <% end %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -12,8 +12,8 @@
         <% if user_signed_in? %>
           <% curr_page = if current_page?(edit_user_registration_path)
                            :account
-                         elsif (controller.controller_name == 'records' && (params[:bundle_id] || params[:task_id].nil?)) ||
-                               (current_page?(:records) && params[:task_id].nil?)
+                         elsif (controller.controller_name == 'records' && (params[:bundle_id] || (params[:task_id].nil? &&
+                               params[:vendor_id].nil?)))  || (current_page?(:records) && params[:task_id].nil? && params[:vendor_id].nil?)
                            :master_patient_list
                          elsif current_page?(admin_path)
                            :admin

--- a/app/views/records/_calculation_results.html.erb
+++ b/app/views/records/_calculation_results.html.erb
@@ -2,6 +2,8 @@
   <tr>
     <% if product_test %>
       <td><%= link_to full_name(r), record_path(:id => r.id, :task_id => task.id) %></td>
+    <% elsif @vendor %>
+      <td><%= full_name(r) %></td>
     <% else %>
       <td><%= link_to full_name(r), bundle_record_path(bundle, r) %></td>
     <% end %>

--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -4,10 +4,6 @@
   <% result_values = get_result_values(patients, [measure], measure.population_ids.keys(), 'patient_id') %>
 <% end %>
 <h1><%= measure ? measure.display_name : 'All' %> Patients</h1>
-<% if @vendor %>
-  <% patients= Bundle.all.to_a.first.patients #temp for test%>
-  <% bundle= Bundle.all.to_a.first #temp for test%>
-<% end %>
 <% if (measure && measure_records.length.positive?) || (!measure  && patients.length.positive?) %>
 <table class="table table-condensed table-hover">
   <thead>

--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -4,6 +4,10 @@
   <% result_values = get_result_values(patients, [measure], measure.population_ids.keys(), 'patient_id') %>
 <% end %>
 <h1><%= measure ? measure.display_name : 'All' %> Patients</h1>
+<% if @vendor %>
+  <% patients= Bundle.all.to_a.first.patients #temp for test%>
+  <% bundle= Bundle.all.to_a.first #temp for test%>
+<% end %>
 <% if (measure && measure_records.length.positive?) || (!measure  && patients.length.positive?) %>
 <table class="table table-condensed table-hover">
   <thead>

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -16,17 +16,7 @@
     <% end %>
     <% # TODO: add button to download html patients for vendor?? %>
     <% if @vendor #add patients option%>
-      <% #TODO: change below admin_bundles_path to appropriate vendor patients path? %>
-      <%= bootstrap_form_tag url: admin_bundles_path, html: {id: "add_bundle_form"} do |f| %>
-        <div class="panel-body">
-          <%= f.file_field :file, label: 'Add Patients', accept: 'application/zip' %>
-        </div>
-
-        <div class="panel-footer">
-          <%= f.submit 'Import Patients', :class => "btn btn-success", :id => "submit_button", data: { disable_with: "Please wait..." } %>
-          <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>
-        </div>
-      <% end %>
+      <% #TODO: Add UI for patient upload %>
     <% else %>
       <%= button_to html_patients_product_test_path(@product_test), :method => :get, :class => "btn btn-default" do %>
         <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download HTML Patients

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -1,4 +1,4 @@
-<% if @task && @product_test %>
+<% if @vendor || (@task && @product_test) %>
 
   <h1>Patient List</h1>
   <div class="pull-right button-row">
@@ -14,8 +14,23 @@
         </ul>
       </div>
     <% end %>
-    <%= button_to html_patients_product_test_path(@product_test), :method => :get, :class => "btn btn-default" do %>
-      <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download HTML Patients
+    <% # TODO: add button to download html patients for vendor?? %>
+    <% if @vendor #add patients option%>
+      <% #TODO: change below admin_bundles_path to appropriate vendor patients path? %>
+      <%= bootstrap_form_tag url: admin_bundles_path, html: {id: "add_bundle_form"} do |f| %>
+        <div class="panel-body">
+          <%= f.file_field :file, label: 'Add Patients', accept: 'application/zip' %>
+        </div>
+
+        <div class="panel-footer">
+          <%= f.submit 'Import Patients', :class => "btn btn-success", :id => "submit_button", data: { disable_with: "Please wait..." } %>
+          <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>
+        </div>
+      <% end %>
+    <% else %>
+      <%= button_to html_patients_product_test_path(@product_test), :method => :get, :class => "btn btn-default" do %>
+        <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download HTML Patients
+      <% end %>
     <% end %>
   </div>
 

--- a/app/views/records/index.html.erb
+++ b/app/views/records/index.html.erb
@@ -83,7 +83,7 @@
 <% cache [@patients, @measure, hide_patient_calculation?] do %>
   <div class="row">
     <div id="records_list" class="col-sm-12">
-      <%= render 'records_list', :patients => @patients, :measure => @measure, :product_test => @product_test, :bundle => @bundle, :task => @task %>
+      <%= render 'records_list', :patients => @vendor ? @vendor.patients : @patients, :measure => @measure, :product_test => @product_test, :bundle => @bundle, :task => @task %>
     </div>
   </div>
 <% end #cache records %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
         get :supplemental_test_artifact
       end
     end
+    resources :records, only: %i[index show] do
+      collection do
+        get :by_measure
+      end
+    end
   end
 
   resources :products, only: %i[show edit update destroy favorite] do

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -58,3 +58,9 @@ Scenario: Successful filter records
   Then the user should see results for that measure
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
+
+Scenario: View Vendor Patient List Page
+  When the user visits the vendor records page
+  Then the user should see a list of vendor patients
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -125,3 +125,14 @@ end
 Then(/^the user should not see deprecated bundles$/) do
   page.assert_no_text '(Deprecated)'
 end
+
+When(/^the user visits the vendor records page$/) do
+  @bundle = Bundle.default
+  @vendor = Vendor.create!(name: 'test_vendor_name')
+  visit "/records?vendor_id=#{@vendor.id}"
+end
+
+Then(/^the user should see a list of vendor patients$/) do
+  page.assert_text 'All Patients'
+  assert page.has_selector?('table tbody tr', count: @vendor.patients.length), 'different count'
+end


### PR DESCRIPTION
BYO patient view patients allows a user to go to the Vendor view, then click on "Vendor Patients" to view (and eventually further manage) patients associated with this vendor. Currently, there is not a UI method for uploading patients for a vendor. As such, to see the table of patients, you may add patients directly to the database by copying bundle patients, altering their type to CQM::VendorPatient, and setting their correlation_id to be the vendor id.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:** Lauren DiCristofaro
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-407
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code