### PR TITLE
Use master branches of cqm-report and cqm-validators

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,8 +15,8 @@ gem 'mustache'
 gem 'os'
 
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'remove_hds_rebase_3_4'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports.git', branch: 'update_cqm_measure_model'
-gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators.git', branch: 'update_measure_model'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports.git', branch: 'master'
+gem 'cqm-validators', git: 'https://github.com/projecttacoma/cqm-validators.git', branch: 'master'
 
 # Use faker to generate addresses
 gem 'faker', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,8 +7,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-reports.git
-  revision: 8b5d6225be70e2e9e9e6d848391f491bf9e6633a
-  branch: update_cqm_measure_model
+  revision: be18834747dcdb63e17ed6fcc71226a7198ba773
+  branch: master
   specs:
     cqm-reports (1.0.0.0)
       erubis (~> 2.7.0)
@@ -22,8 +22,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-validators.git
-  revision: 3cca0cc486421be23b85d61b561f6025528eeb29
-  branch: update_measure_model
+  revision: 7d465773c0f001ee19ab7ef4ae300b8f08403b4c
+  branch: master
   specs:
     cqm-validators (0.1.0)
       nokogiri (~> 1.8.2)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code