### PR TITLE
(5.0.0) Negate ValueSets

### DIFF
--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -533,7 +533,7 @@ module Cypress
 
     def import_cat1_file(doc, patient_ids, bundle_id)
       patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-      Cypress::GoImport.replace_negated_codes(patient, Bundle.find(bundle_id))
+      Cypress::QRDAPostProcessor.replace_negated_codes(patient, Bundle.find(bundle_id))
       patient.save
       patient_ids << patient.id
     end

--- a/lib/cypress/go_import.rb
+++ b/lib/cypress/go_import.rb
@@ -10,13 +10,13 @@ module Cypress
       negated_element = data_element.dataElementCodes.map { |dec| dec if dec.codeSystem == 'NA_VALUESET' }.first
       negated_vs = negated_element.code
       # If Cypress has a default code selected, use it.  Otherwise, use the first in the valueset.
-      negated_code = if bundle.default_negation_codes && bundle.default_negation_codes[negated_vs]
-                       QDM::Code.new(bundle.default_negation_codes[negated_vs]['code'], bundle.default_negation_codes[negated_vs]['codeSystem'])
-                     else
-                       valueset = ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
-                       QDM::Code.new(valueset.first.concepts.first['code'], valueset.first.concepts.first['code_system_name'])
-                     end
-      data_element.dataElementCodes << negated_code
+      code = if bundle.default_negation_codes && bundle.default_negation_codes[negated_vs]
+               { code: bundle.default_negation_codes[negated_vs]['code'], codeSystem: bundle.default_negation_codes[negated_vs]['codeSystem'] }
+             else
+               valueset = ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
+               { code: valueset.first.concepts.first['code'], codeSystem: valueset.first.concepts.first['code_system_name'] }
+             end
+      data_element.dataElementCodes << code
     end
   end
 end

--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -1,5 +1,5 @@
 module Cypress
-  module GoImport
+  module QRDAPostProcessor
     def self.replace_negated_codes(patient, bundle)
       patient.qdmPatient.dataElements.each do |de|
         select_negated_code(de, bundle) if de['negationRationale'] && de.codes.find { |c| c.codeSystem == 'NA_VALUESET' }

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -1,14 +1,14 @@
 module Cypress
   class ScoopAndFilter
     def initialize(measures)
-      @relevant_codes = codes_in_measures(measures)
+      @valuesets = measures.collect(&:value_sets).flatten
+      @relevant_codes = codes_in_measures
       @de_category_statuses_for_measures = get_non_demographic_category_statuses(measures)
     end
 
     # return an array of all of the concepts in all of the valueset for the measure
-    def codes_in_measures(measures)
-      valuesets = measures.collect(&:value_sets).flatten
-      code_list = valuesets.collect(&:concepts).flatten
+    def codes_in_measures
+      code_list = @valuesets.collect(&:concepts).flatten
       code_list.map { |cl| { code: cl.code, codeSystem: cl.code_system_name } }
     end
 
@@ -46,8 +46,10 @@ module Cypress
     end
 
     def replace_negated_code_with_valueset(data_element)
-      negated_valueset = ValueSet.where('concepts.code': data_element.codes.first.code,
-                                        'concepts.code_system_name': data_element.codes.first.codeSystem).first
+      negated_valueset = @valuesets.where('concepts.code': data_element.codes.first.code,
+                                          'concepts.code_system_name': data_element.codes.first.codeSystem).first
+      # If more than one valueset (in the measures uses the code, it is not possible for scoop and filter to know which valueset to negate)
+      return if negated_valueset.size > 1
       # If the first three characters of the valueset oid is drc, this is a direct reference code, not a valueset.  Do not negate a valueset here.
       return if negated_valueset.oid[0, 3] == 'drc'
       data_element.dataElementCodes = [{ code: negated_valueset.oid, codeSystem: 'NA_VALUESET' }]

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -24,6 +24,8 @@ module Cypress
       patient.qdmPatient.dataElements.each do |data_element|
         # keep if data_element code and codesystem is in one of the relevant_codes
         data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, codeSystem: de_code.codeSystem) }
+        # Do not try to replace with negated valueset if all codes are removed
+        next if data_element.dataElementCodes.blank?
         replace_negated_code_with_valueset(data_element) if data_element.respond_to?('negationRationale') && data_element.negationRationale
       end
       # keep data element if codes is not empty

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -48,6 +48,8 @@ module Cypress
     def replace_negated_code_with_valueset(data_element)
       negated_valueset = ValueSet.where('concepts.code': data_element.codes.first.code,
                                         'concepts.code_system_name': data_element.codes.first.codeSystem).first
+      # If the first three characters of the valueset oid is drc, this is a direct reference code, not a valueset.  Do not negate a valueset here.
+      return if negated_valueset.oid[0, 3] == 'drc'
       data_element.dataElementCodes = [{ code: negated_valueset.oid, codeSystem: 'NA_VALUESET' }]
     end
   end

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -41,7 +41,7 @@ module Validators
 
     def parse_record(doc, options)
       patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-      Cypress::GoImport.replace_negated_codes(patient, @bundle)
+      Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
       patient
     rescue
       add_error('File failed import', file_name: options[:file_name])

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -4,8 +4,8 @@ require 'fileutils'
 class PatientZipperTest < ActiveSupport::TestCase
   setup do
     pt = FactoryBot.create(:product_test_static_result)
-    patient = FactoryBot.create(:static_test_patient, bundleId: pt.bundle.id)
-    patient.save
+    @static_patient = FactoryBot.create(:static_test_patient, bundleId: pt.bundle.id)
+    @static_patient.save
     @patients = Patient.all.to_a.select { |p| p.gender == 'F' }
 
     prov = Provider.default_provider
@@ -32,6 +32,53 @@ class PatientZipperTest < ActiveSupport::TestCase
     end
     File.delete(file.path)
     assert_equal @patients.count, count, 'Zip file has wrong number of records'
+  end
+
+  test 'Should create valid qrda file with a negated valueset' do
+    format = :qrda
+    filename = "pTest-#{Time.now.to_i}.qrda.zip"
+    file = Tempfile.new(filename)
+
+    patient = @static_patient
+    modified_procedure = patient.qdmPatient.procedures.first
+    modified_procedure.negationRationale = modified_procedure.codes.first
+    original_code = modified_procedure.codes.first.code
+    patient.save
+
+    Cypress::PatientZipper.zip(file, [patient], format)
+    file.close
+
+    count = 0
+    Zip::ZipFile.foreach(file.path) do |zip_entry|
+      if zip_entry.name.include?('.xml') && !zip_entry.name.include?('__MACOSX')
+        doc = Nokogiri::XML(zip_entry.get_input_stream, &:strict)
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        assert_equal 1, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 1 negated code in the exported QRDA'
+        confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
+        count += 1
+      end
+    end
+    File.delete(file.path)
+    assert_equal 1, count, 'Zip should contain 1 QRDA file for the patient with a negated valueset'
+  end
+
+  def confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
+    negated_oid = ValueSet.where('concepts.code': original_code).first.oid
+    imported_patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+    imported_patient.update(_type: CQM::VendorPatient)
+    cloned_import = imported_patient.clone
+    codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
+    assert_equal false, codefound, 'code should not be found prior to replace_negated_codes'
+    Cypress::GoImport.replace_negated_codes(imported_patient, patient.bundle)
+    codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
+    assert codefound, 'replaced code should equal original code'
+    assert imported_patient.save
+    APP_CONSTANTS['version_config']['~>2018.0.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
+    Cypress::GoImport.replace_negated_codes(cloned_import, patient.bundle)
+    codefound = cloned_import.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
+    assert codefound, 'replaced code should equal default code'
+    assert cloned_import.save
   end
 
   test 'Should create valid qrda file' do

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -70,12 +70,12 @@ class PatientZipperTest < ActiveSupport::TestCase
     cloned_import = imported_patient.clone
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert_equal false, codefound, 'code should not be found prior to replace_negated_codes'
-    Cypress::GoImport.replace_negated_codes(imported_patient, patient.bundle)
+    Cypress::QRDAPostProcessor.replace_negated_codes(imported_patient, patient.bundle)
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert codefound, 'replaced code should equal original code'
     assert imported_patient.save
     APP_CONSTANTS['version_config']['~>2018.0.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
-    Cypress::GoImport.replace_negated_codes(cloned_import, patient.bundle)
+    Cypress::QRDAPostProcessor.replace_negated_codes(cloned_import, patient.bundle)
     codefound = cloned_import.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
     assert codefound, 'replaced code should equal default code'
     assert cloned_import.save


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code