### PR TITLE
(4.0.3) Name collisions

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -124,7 +124,7 @@ class ProductTest
     # choose up to 3 duplicate patients
     dups.sample(random.rand(1..3), :random => random).each do |pat|
       prng_repeat = Random.new(rand_seed.to_i)
-      dup_pat, pat_augments, old_pat = pat.duplicate_randomization(:random => prng_repeat)
+      dup_pat, pat_augments, old_pat = pat.duplicate_randomization(augmented_patients, :random => prng_repeat)
       # only add if augmented patient validates
       if car.validate_calculated_results(dup_pat, :effective_date => effective_date, :orig_product_patient => old_pat)
         augmented_patients << pat_augments

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -4,23 +4,21 @@ module Cypress
   # can randomize name, race, ethnicity, address, and insurance provider.  To randomize all
   # demographics, call Cypress::DemographicsRandomizer.randomize(record)
   class DemographicsRandomizer
-    def self.randomize(patient, prng, allow_dups = false)
-      # TODO: R2P: change to patient name and model throughout file
-      randomize_name(patient, prng, allow_dups)
+    def self.randomize(patient, prng, patients = [], allow_dups = false)
+      randomize_name(patient, prng, patients, allow_dups)
       randomize_race(patient, prng)
       randomize_ethnicity(patient, prng)
       randomize_address(patient)
       randomize_insurance_provider(patient)
     end
 
-    # TODO: redundant with patient (formerly record) name randomization methods
-    def self.randomize_name(patient, prng, allow_dups = false)
-      @used_names ||= []
+    # Pass in an array of patients that you would like to maintain uniqueness
+    def self.randomize_name(patient, prng, patients = [], allow_dups = false)
+      used_names = patients.map { |p| "#{p.first_names}-#{p.familyName}" }
       loop do
         assign_random_name(patient, prng)
-        break if allow_dups || @used_names.index("#{patient.first_names}-#{patient.familyName}").nil?
+        break if allow_dups || used_names.index("#{patient.first_names}-#{patient.familyName}").nil?
       end
-      @used_names << "#{patient.first_names}-#{patient.familyName}"
     end
 
     def self.assign_random_name(patient, prng)

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -15,14 +15,12 @@ module Cypress
 
     # TODO: redundant with patient (formerly record) name randomization methods
     def self.randomize_name(patient, prng, allow_dups = false)
-      gender = patient.gender
-      @used_names ||= {}
-      @used_names[gender] ||= []
+      @used_names ||= []
       loop do
         assign_random_name(patient, prng)
-        break if allow_dups || @used_names[gender].index("#{patient.first_names}-#{patient.familyName}").nil?
+        break if allow_dups || @used_names.index("#{patient.first_names}-#{patient.familyName}").nil?
       end
-      @used_names[gender] << "#{patient.first_names}-#{patient.familyName}"
+      @used_names << "#{patient.first_names}-#{patient.familyName}"
     end
 
     def self.assign_random_name(patient, prng)

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -9,10 +9,11 @@ module Cypress
       when 2 # nickname
         patient.givenNames.each_index do |idx|
           nicknames = NAMES_RANDOM['nicknames'][patient.gender][patient.givenNames[idx]]
+          patients = patient.product_test ? patient.product_test.patients : []
           patient.givenNames[idx] = safe_nickname(nicknames,
                                                   patient.givenNames[idx],
                                                   patient.familyName,
-                                                  patient.product_test.patients,
+                                                  patients,
                                                   random: random)
         end
       end

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -9,8 +9,11 @@ module Cypress
       when 2 # nickname
         patient.givenNames.each_index do |idx|
           nicknames = NAMES_RANDOM['nicknames'][patient.gender][patient.givenNames[idx]]
-          # if no nicknames, use first initial
-          patient.givenNames[idx] = nicknames.blank? ? patient.givenNames[idx][0] : nicknames.sample(random: random)
+          patient.givenNames[idx] = safe_nickname(nicknames,
+                                                  patient.givenNames[idx],
+                                                  patient.familyName,
+                                                  patient.product_test.patients,
+                                                  random: random)
         end
       end
       patient
@@ -30,6 +33,14 @@ module Cypress
       name_pos = random.rand(name.length - 1) + 1
       name[name_pos] = name[name_pos] != lsamples[0] ? lsamples[0] : lsamples[1]
       name
+    end
+
+    def self.safe_nickname(nicknames, given_name, family_name, patients, random: Random.new)
+      # if no nicknames, use first initial
+      return given_name[0] if nicknames.blank?
+      nickname = nicknames.sample(random: random)
+      # if nickname collides with a name in the patient list, use first initial
+      patients.none? { |p| "#{p.first_names}-#{p.familyName}" == "#{nickname}-#{family_name}" } ? nickname : given_name[0]
     end
   end
 end

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -1,29 +1,41 @@
 module Cypress
   class NameRandomizer
-    def self.randomize_patient_name_first(patient, random: Random.new)
-      case random.rand(3) # random chooses how to modify the field
-      when 0 then patient.givenNames = [patient.givenNames[0][0]] # replace with only first initial
-      when 1
-        rand_idx = random.rand(patient.givenNames.count)
-        patient.givenNames[rand_idx] = replace_random_char(patient.givenNames[rand_idx].clone, random: random) # insert incorrect letter
-      when 2 # nickname
-        patient.givenNames.each_index do |idx|
-          nicknames = NAMES_RANDOM['nicknames'][patient.gender][patient.givenNames[idx]]
-          patients = patient.product_test ? patient.product_test.patients : []
-          patient.givenNames[idx] = safe_nickname(nicknames,
-                                                  patient.givenNames[idx],
-                                                  patient.familyName,
-                                                  patients,
-                                                  random: random)
+    def self.randomize_patient_name_first(patient, augmented_patients, random: Random.new)
+      original_given_name = patient.givenNames
+      new_given_name = original_given_name.clone
+      loop do
+        case random.rand(3) # random chooses how to modify the field
+        when 0 then new_given_name = [original_given_name[0][0]] # replace with only first initial
+        when 1
+          rand_idx = random.rand(original_given_name.count)
+          new_given_name[rand_idx] = replace_random_char(original_given_name[rand_idx].clone, random: random) # insert incorrect letter
+        when 2 # nickname
+          original_given_name.each_index do |idx|
+            nicknames = NAMES_RANDOM['nicknames'][patient.gender][original_given_name[idx]]
+            patients = patient.product_test ? patient.product_test.patients : []
+            new_given_name[idx] = safe_nickname(nicknames,
+                                                original_given_name[idx],
+                                                patient.familyName,
+                                                patients,
+                                                random: random)
+          end
         end
+        patient.givenNames = new_given_name unless augmented_patients.any? { |ap| ap[:first][1] == new_given_name && ap[:last][0] == patient.familyName }
+        break if patient.givenNames != original_given_name
       end
       patient
     end
 
-    def self.randomize_patient_name_last(patient, random: Random.new)
-      case random.rand(2)
-      when 0 then patient.familyName = patient.familyName[0] # replace with initial
-      when 1 then patient.familyName = replace_random_char(patient.familyName.clone, random: random) # insert incorrect letter
+    def self.randomize_patient_name_last(patient, augmented_patients, random: Random.new)
+      original_family_name = patient.familyName
+      new_family_name = original_family_name.clone
+      loop do
+        case random.rand(2)
+        when 0 then patient.familyName = patient.familyName[0] # replace with initial
+        when 1 then patient.familyName = replace_random_char(patient.familyName.clone, random: random) # insert incorrect letter
+        end
+        patient.familyName = new_family_name unless augmented_patients.any? { |ap| ap[:last][1] == new_family_name && ap[:first][0] == patient.givenNames }
+        break if patient.familyName != original_family_name
       end
       patient
     end

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -1,41 +1,54 @@
 module Cypress
   class NameRandomizer
     def self.randomize_patient_name_first(patient, augmented_patients, random: Random.new)
-      original_given_name = patient.givenNames
-      new_given_name = original_given_name.clone
+      original_gn = patient.givenNames
+      new_gn = original_gn.clone
       loop do
-        case random.rand(3) # random chooses how to modify the field
-        when 0 then new_given_name = [original_given_name[0][0]] # replace with only first initial
-        when 1
-          rand_idx = random.rand(original_given_name.count)
-          new_given_name[rand_idx] = replace_random_char(original_given_name[rand_idx].clone, random: random) # insert incorrect letter
-        when 2 # nickname
-          original_given_name.each_index do |idx|
-            nicknames = NAMES_RANDOM['nicknames'][patient.gender][original_given_name[idx]]
-            patients = patient.product_test ? patient.product_test.patients : []
-            new_given_name[idx] = safe_nickname(nicknames,
-                                                original_given_name[idx],
-                                                patient.familyName,
-                                                patients,
-                                                random: random)
-          end
-        end
-        patient.givenNames = new_given_name unless augmented_patients.any? { |ap| ap[:first][1] == new_given_name && ap[:last][0] == patient.familyName }
-        break if patient.givenNames != original_given_name
+        # Try to create a new random name
+        new_gn = random_given_name(patient, original_gn, random: random)
+        # Verify that the new random name, does not conflict with an existing Augmented Patient
+        patient.givenNames = new_gn unless augmented_patients.any? { |ap| ap[:first][1] == new_gn[0] && ap[:last][0] == patient.familyName }
+        # Break when a new unique name is found
+        break if patient.givenNames != original_gn
       end
       patient
     end
 
+    def self.random_given_name(patient, original_given_name, random: Random.new)
+      updated_name = original_given_name.clone
+      case random.rand(3) # random chooses how to modify the field
+      when 0 then [updated_name[0][0]] # replace with only first initial
+      when 1
+        rand_idx = random.rand(updated_name.count)
+        updated_name[rand_idx] = replace_random_char(updated_name[rand_idx].clone, random: random) # insert incorrect letter
+        updated_name
+      when 2 # nickname
+        updated_name.each_index do |idx|
+          nicknames = NAMES_RANDOM['nicknames'][patient.gender][updated_name[idx]]
+          patients = patient.product_test ? patient.product_test.patients : []
+          updated_name[idx] = safe_nickname(nicknames,
+                                            updated_name[idx],
+                                            patient.familyName,
+                                            patients,
+                                            random: random)
+        end
+        updated_name
+      end
+    end
+
     def self.randomize_patient_name_last(patient, augmented_patients, random: Random.new)
-      original_family_name = patient.familyName
-      new_family_name = original_family_name.clone
+      original_fn = patient.familyName
+      new_fn = original_fn.clone
       loop do
+        # Try to create a new random name
         case random.rand(2)
         when 0 then patient.familyName = patient.familyName[0] # replace with initial
         when 1 then patient.familyName = replace_random_char(patient.familyName.clone, random: random) # insert incorrect letter
         end
-        patient.familyName = new_family_name unless augmented_patients.any? { |ap| ap[:last][1] == new_family_name && ap[:first][0] == patient.givenNames }
-        break if patient.familyName != original_family_name
+        # Verify that the new random name, does not conflict with an existing Augmented Patient
+        patient.familyName = new_fn unless augmented_patients.any? { |ap| ap[:last][1] == new_fn && ap[:first][0] == patient.givenNames }
+        # Break when a new unique name is found
+        break if patient.familyName != original_fn
       end
       patient
     end

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -75,7 +75,7 @@ module Cypress
       cloned_patient = patient.clone
       # TODO: R2P: use patient model
       unnumerify cloned_patient if patient.givenNames.map { |n| n =~ /\d/ }.any? || patient.familyName =~ /\d/
-      DemographicsRandomizer.randomize(cloned_patient, prng, allow_dups) if options['randomize_demographics']
+      DemographicsRandomizer.randomize(cloned_patient, prng, @test.patients, allow_dups) if options['randomize_demographics']
       # work around to replace 'Other' race codes in Cypress bundle. Pass in static seed for consistent results.
       DemographicsRandomizer.randomize_race(cloned_patient, Random.new(0)) if cloned_patient.race == '2131-1'
       patch_insurance_provider(patient)

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -44,10 +44,10 @@ module QDM
       { 'npis' => [provider.npi], 'tins' => [provider.tin] }
     end
 
-    def duplicate_randomization(random: Random.new)
+    def duplicate_randomization(augmented_patients, random: Random.new)
       patient = clone
       changed = { :original_patient_id => id, :first => [first_names, first_names], :last => [familyName, familyName] }
-      patient, changed = randomize_patient_name_or_birth(patient, changed, :random => random)
+      patient, changed = randomize_patient_name_or_birth(patient, changed, augmented_patients, :random => random)
       randomize_demographics(patient, changed, :random => random)
     end
 
@@ -64,13 +64,13 @@ module QDM
       givenNames.join(' ')
     end
 
-    def randomize_patient_name_or_birth(patient, changed, random: Random.new)
+    def randomize_patient_name_or_birth(patient, changed, augmented_patients, random: Random.new)
       case random.rand(3) # random chooses which part of the patient is modified
       when 0 # first name
-        patient = Cypress::NameRandomizer.randomize_patient_name_first(patient, :random => random)
+        patient = Cypress::NameRandomizer.randomize_patient_name_first(patient, augmented_patients, :random => random)
         changed[:first] = [first_names, patient.first_names]
       when 1 # last name
-        patient = Cypress::NameRandomizer.randomize_patient_name_last(patient, :random => random)
+        patient = Cypress::NameRandomizer.randomize_patient_name_last(patient, augmented_patients, :random => random)
         changed[:last] = [familyName, patient.familyName]
       when 2 # birthdate
         Cypress::DemographicsRandomizer.randomize_birthdate(patient, :random => random)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -41,12 +41,12 @@ class PatientTest < ActiveSupport::TestCase
       prng1 = Random.new(random)
       prng2 = Random.new(random)
 
-      r1 = Patient.new(familyName: 'Robert', givenNames: ['Johnson'], birthDatetime: DateTime.new(1985, 2, 18).utc)
+      r1 = Patient.new(familyName: 'Robert', givenNames: ['Johnson'], birthDatetime: DateTime.new(1985, 2, 18).utc, extendedData: {})
       r1.dataElements << QDM::PatientCharacteristicRace.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['races'].sample(random: prng1)['code'], 'code_system' => 'cdcrec' }])
       r1.dataElements << QDM::PatientCharacteristicEthnicity.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng1)['code'], 'code_system' => 'cdcrec' }])
       r1.dataElements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M', 'code_system' => 'AdministrativeGender' }])
 
-      r2 = Patient.new(familyName: 'Robert', givenNames: ['Johnson'], birthDatetime: DateTime.new(1985, 2, 18).utc)
+      r2 = Patient.new(familyName: 'Robert', givenNames: ['Johnson'], birthDatetime: DateTime.new(1985, 2, 18).utc, extendedData: {})
       r2.dataElements << QDM::PatientCharacteristicRace.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['races'].sample(random: prng2)['code'], 'code_system' => 'cdcrec' }])
       r2.dataElements << QDM::PatientCharacteristicEthnicity.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng2)['code'], 'code_system' => 'cdcrec' }])
       r2.dataElements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M', 'code_system' => 'AdministrativeGender' }])

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -52,8 +52,8 @@ class PatientTest < ActiveSupport::TestCase
       r2.dataElements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M', 'code_system' => 'AdministrativeGender' }])
 
       assert(record_demographics_equal?(r1, r2), 'The two records should be equal')
-      r1copy_set = r1.duplicate_randomization(random: prng1)
-      r2copy_set = r2.duplicate_randomization(random: prng2)
+      r1copy_set = r1.duplicate_randomization([], random: prng1)
+      r2copy_set = r2.duplicate_randomization([], random: prng2)
       assert(record_demographics_equal?(r1copy_set[0], r2copy_set[0]), 'The two records should be equal')
       assert_not(record_demographics_equal?(r1, r1copy_set[0]), 'The two records should not be equal')
       assert(record_birthyear_equal?(r1, r1copy_set[0]), 'The two records should always have the same birthyear')

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -54,6 +54,29 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     assert_equal @insurance_provider, @record['extendedData']['insurance_providers']
   end
 
+  def test_randomize_multiple_names
+    10.times do
+      NAMES_RANDOM['first']['M'] = ['Marion']
+      NAMES_RANDOM['first']['F'] = %w[Marion Jill]
+      NAMES_RANDOM['last'] = ['Smith']
+      patient_list = [@record]
+      record1 = @record.clone
+      record2 = @record.clone
+      record3 = @record.clone
+      record3.get_data_elements('patient_characteristic', 'gender').first.dataElementCodes.first['code'] = 'F'
+      Cypress::DemographicsRandomizer.randomize_name(record1, @prng, patient_list)
+      patient_list << record1
+      NAMES_RANDOM['first']['M'] = %w[Marion Jake]
+      Cypress::DemographicsRandomizer.randomize_name(record2, @prng, patient_list)
+      patient_list << record2
+      Cypress::DemographicsRandomizer.randomize_name(record3, @prng, patient_list)
+      patient_list << record3
+      assert_equal ['Marion'], record1.givenNames
+      assert_equal ['Jake'], record2.givenNames
+      assert_equal ['Jill'], record3.givenNames
+    end
+  end
+
   def test_randomize_race
     Cypress::DemographicsRandomizer.randomize_race(@record, @prng)
     assert_not_equal @original_race_code, @record.get_data_elements('patient_characteristic', 'race').first.dataElementCodes.first['code']

--- a/test/unit/lib/name_randomizer_test.rb
+++ b/test/unit/lib/name_randomizer_test.rb
@@ -4,9 +4,18 @@ require 'fileutils'
 class NameRandomizerTest < ActiveSupport::TestCase
   setup do
     @pt = FactoryBot.create(:product_test_static_result)
-    record1 = Patient.new(givenNames: ['AA'], familyName: 'BB', extendedData: { 'correlation_id' => @pt.id })
-    record1.save
+    record1 = @pt.patients.first.clone
+    record1.update(givenNames: ['AA'], familyName: 'BB', extendedData: { 'correlation_id' => @pt.id })
     @prng = Random.new(Random.new_seed)
+  end
+
+  def test_randomize_augmented_record
+    augmented_patients = [{ first: %w[AA A], last: %w[BB BB] }]
+    patient_to_clone = @pt.patients.where(familyName: 'BB').first.clone
+    20.times do
+      Cypress::NameRandomizer.randomize_patient_name_first(patient_to_clone, augmented_patients, random: @prng)
+      assert_not_equal ['A'], patient_to_clone.givenNames
+    end
   end
 
   def test_randomize_no_nickname

--- a/test/unit/lib/name_randomizer_test.rb
+++ b/test/unit/lib/name_randomizer_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'fileutils'
+
+class NameRandomizerTest < ActiveSupport::TestCase
+  setup do
+    @pt = FactoryBot.create(:product_test_static_result)
+    record1 = Patient.new(givenNames: ['AA'], familyName: 'BB', extendedData: { 'correlation_id' => @pt.id })
+    record1.save
+    @prng = Random.new(Random.new_seed)
+  end
+
+  def test_randomize_no_nickname
+    nickname = Cypress::NameRandomizer.safe_nickname(nil, 'AAA', 'BB', @pt.patients, random: @prng)
+    assert_equal 'A', nickname
+  end
+
+  def test_randomize_matching_nickname
+    nickname = Cypress::NameRandomizer.safe_nickname(['AA'], 'AAA', 'BB', @pt.patients, random: @prng)
+    assert_equal 'A', nickname
+  end
+
+  def test_randomize_unique_nickname
+    nickname = Cypress::NameRandomizer.safe_nickname(['AAAA'], 'AAA', 'BB', @pt.patients, random: @prng)
+    assert_equal 'AAAA', nickname
+  end
+end

--- a/test/unit/lib/name_randomizer_test.rb
+++ b/test/unit/lib/name_randomizer_test.rb
@@ -19,17 +19,12 @@ class NameRandomizerTest < ActiveSupport::TestCase
   end
 
   def test_randomize_no_nickname
-    nickname = Cypress::NameRandomizer.safe_nickname(nil, 'AAA', 'BB', @pt.patients, random: @prng)
-    assert_equal 'A', nickname
-  end
-
-  def test_randomize_matching_nickname
-    nickname = Cypress::NameRandomizer.safe_nickname(['AA'], 'AAA', 'BB', @pt.patients, random: @prng)
+    nickname = Cypress::NameRandomizer.nickname(nil, 'AAA', random: @prng)
     assert_equal 'A', nickname
   end
 
   def test_randomize_unique_nickname
-    nickname = Cypress::NameRandomizer.safe_nickname(['AAAA'], 'AAA', 'BB', @pt.patients, random: @prng)
+    nickname = Cypress::NameRandomizer.nickname(['AAAA'], 'AAA', random: @prng)
     assert_equal 'AAAA', nickname
   end
 end


### PR DESCRIPTION
Previously, Demographics Randomizer used the instance variable @used_names for uniqueness.  This would maintain uniqueness across all tests created.

I updated this maintain uniqueness within the list of patients passed in.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code