### PR TITLE
(4.0.3) Negate a Valueset

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'os'
 gem 'cql_qdm_patientapi'
 gem 'cqm-converter', '~> 0.3.6'
 gem 'cqm-models', '~> 0.8.4'
-gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'qrda_updates_for_patch'
+gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'v0.2.x'
 gem 'cqm-validators', '~> 0.1.0'
 gem 'health-data-standards', '~> 4.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,8 +23,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-parsers.git
-  revision: 8ef367522e8fc636d2dfcc175cabbd455ba28b1e
-  branch: qrda_updates_for_patch
+  revision: d44d50c7f2a00da64122e6ab70c2b201055b38b3
+  branch: v0.2.x
   specs:
     cqm-parsers (0.2.2)
       activesupport (~> 4.2.0)
@@ -607,4 +607,4 @@ RUBY VERSION
    ruby 2.4.5p335
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/lib/cypress/go_import.rb
+++ b/lib/cypress/go_import.rb
@@ -10,13 +10,13 @@ module Cypress
       negated_element = data_element.dataElementCodes.map { |dec| dec if dec.codeSystem == 'NA_VALUESET' }.first
       negated_vs = negated_element.code
       # If Cypress has a default code selected, use it.  Otherwise, use the first in the valueset.
-      negated_code = if bundle.default_negation_codes && bundle.default_negation_codes[negated_vs]
-                       QDM::Code.new(bundle.default_negation_codes[negated_vs]['code'], bundle.default_negation_codes[negated_vs]['codeSystem'])
-                     else
-                       valueset = HealthDataStandards::SVS::ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
-                       QDM::Code.new(valueset.first.concepts.first['code'], valueset.first.concepts.first['code_system_name'])
-                     end
-      data_element.dataElementCodes << negated_code
+      code = if bundle.default_negation_codes && bundle.default_negation_codes[negated_vs]
+               { code: bundle.default_negation_codes[negated_vs]['code'], codeSystem: bundle.default_negation_codes[negated_vs]['codeSystem'] }
+             else
+               valueset = HealthDataStandards::SVS::ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
+               { code: valueset.first.concepts.first['code'], codeSystem: valueset.first.concepts.first['code_system_name'] }
+             end
+      data_element.dataElementCodes << code
     end
   end
 end

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -43,11 +43,20 @@ module Cypress
       patient.dataElements.each do |data_element|
         # keep if data_element code and codesystem is in one of the relevant_codes
         data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, codeSystem: de_code.codeSystem) }
+        replace_negated_code_with_valueset(data_element) if data_element.respond_to?('negationRationale') && data_element.negationRationale
       end
       # keep data element if codes is not empty
       patient.dataElements.keep_if { |data_element| data_element.dataElementCodes.present? }
       patient.dataElements.concat(demographic_criteria)
       patient
+    end
+
+    private
+
+    def replace_negated_code_with_valueset(data_element)
+      negated_valueset = HealthDataStandards::SVS::ValueSet.where('concepts.code': data_element.codes.first.code,
+                                                                  'concepts.code_system_name': data_element.codes.first.codeSystem).first
+      data_element.dataElementCodes = [{ code: negated_valueset.oid, codeSystem: 'NA_VALUESET' }]
     end
   end
 end

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -4,8 +4,8 @@ require 'fileutils'
 class PatientZipperTest < ActiveSupport::TestCase
   setup do
     pt = FactoryBot.create(:product_test_static_result)
-    patient = FactoryBot.create(:static_test_patient, bundleId: pt.bundle.id)
-    patient.save
+    @static_patient = FactoryBot.create(:static_test_patient, bundleId: pt.bundle.id)
+    @static_patient.save
     @patients = Patient.all.to_a.select { |p| p.gender == 'F' }
 
     prov = Provider.default_provider
@@ -32,6 +32,52 @@ class PatientZipperTest < ActiveSupport::TestCase
     end
     File.delete(file.path)
     assert_equal @patients.count, count, 'Zip file has wrong number of records'
+  end
+
+  test 'Should create valid qrda file with a negated valueset' do
+    format = :qrda
+    filename = "pTest-#{Time.now.to_i}.qrda.zip"
+    file = Tempfile.new(filename)
+
+    patient = @static_patient
+    modified_procedure = patient.procedures.first
+    modified_procedure.negationRationale = modified_procedure.codes.first
+    original_code = modified_procedure.codes.first.code
+    patient.save
+
+    Cypress::PatientZipper.zip(file, [patient], format)
+    file.close
+
+    count = 0
+    Zip::ZipFile.foreach(file.path) do |zip_entry|
+      if zip_entry.name.include?('.xml') && !zip_entry.name.include?('__MACOSX')
+        doc = Nokogiri::XML(zip_entry.get_input_stream, &:strict)
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        assert_equal 1, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 1 negated code in the exported QRDA'
+        confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
+        count += 1
+      end
+    end
+    File.delete(file.path)
+    assert_equal 1, count, 'Zip should contain 1 QRDA file for the patient with a negated valueset'
+  end
+
+  def confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
+    negated_oid = HealthDataStandards::SVS::ValueSet.where('concepts.code': original_code).first.oid
+    imported_patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+    cloned_import = imported_patient.clone
+    codefound = imported_patient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
+    assert_equal false, codefound, 'code should not be found prior to replace_negated_codes'
+    Cypress::GoImport.replace_negated_codes(imported_patient, patient.bundle)
+    codefound = imported_patient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
+    assert codefound, 'replaced code should equal original code'
+    assert imported_patient.save
+    APP_CONSTANTS['version_config']['~>2018.0.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
+    Cypress::GoImport.replace_negated_codes(cloned_import, patient.bundle)
+    codefound = cloned_import.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
+    assert codefound, 'replaced code should equal default code'
+    assert cloned_import.save
   end
 
   test 'Should create valid qrda file' do


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @mayerm94
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code