### PR TITLE
(4.0.3) Do not try to replace with negated valueset if all codes are removed

### DIFF
--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -43,6 +43,8 @@ module Cypress
       patient.dataElements.each do |data_element|
         # keep if data_element code and codesystem is in one of the relevant_codes
         data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, codeSystem: de_code.codeSystem) }
+        # Do not try to replace with negated valueset if all codes are removed
+        next if data_element.dataElementCodes.blank?
         replace_negated_code_with_valueset(data_element) if data_element.respond_to?('negationRationale') && data_element.negationRationale
       end
       # keep data element if codes is not empty


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code