### PR TITLE
Use vendor patient templates

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,7 +39,7 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
     - 'app/models/product.rb'
-    - 'lib/cypress/ext/patient.rb'
+    - 'lib/ext/patient.rb'
     - 'lib/cypress/api_measure_evaluator.rb'
     - 'lib/cypress/cql_bundle_importer.rb'
     - 'lib/cypress/demographics_randomizer.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
     - 'app/models/product.rb'
+    - 'lib/cypress/ext/patient.rb'
     - 'lib/cypress/api_measure_evaluator.rb'
     - 'lib/cypress/cql_bundle_importer.rb'
     - 'lib/cypress/demographics_randomizer.rb'

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -158,9 +158,7 @@ class Product
 
   # This is a convenience function to return patients IDs where bundle years are matched up to current bundle
   def vendor_patient_ids
-    return vendor.patients.where(bundleId: bundle.id).pluck(:id) if vendor_patient
-
-    []
+    vendor.patients.where(bundleId: bundle.id).pluck(:id)
   end
 
   # - - - - - - - - - #

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -156,6 +156,13 @@ class Product
     super
   end
 
+  # This is a convenience function to return patients IDs where bundle years are matched up to current bundle
+  def vendor_patient_ids
+    return vendor.patients.where(bundleId: bundle.id).pluck(:id) if vendor_patient
+
+    []
+  end
+
   # - - - - - - - - - #
   #   P R I V A T E   #
   # - - - - - - - - - #

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -230,38 +230,32 @@ class ProductTest
 
   # Returns a listing of all ids for patients in the IPP
   def patients_in_ipp_and_greater
-    # TODO: if using template_ids in multiple places, make it into a private variable or something
-    template_ids = gather_patient_ids
     # search thru all the patients for those IDs (that will be a where sort of query)
     # replace bundle.patients with a set where all the IDs are from our gather_patient_ids thing
     # #bundle.patients.where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.IPP": true).pluck(:_id)
-    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.IPP": true).pluck(:_id)
+    Patient.where(_id: gather_patient_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.IPP": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Numerator
   def patient_in_numerator
-    template_ids = gather_patient_ids
-    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true).pluck(:_id)
+    Patient.where(_id: gather_patient_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Denominator
   def patients_in_denominator_and_greater
-    template_ids = gather_patient_ids
-    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENOM": true).pluck(:_id)
+    Patient.where(_id: gather_patient_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENOM": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Measure Population
   def patients_in_measure_population_and_greater
-    template_ids = gather_patient_ids
-    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.MSRPOPL": true).pluck(:_id)
+    Patient.where(_id: gather_patient_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.MSRPOPL": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Measure Population
   def patients_in_high_value_populations
-    template_ids = gather_patient_ids
-    Patient.where(_id: template_ids).any_of({ "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true },
-                                            { "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEXCEP": true },
-                                            "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEX": true).pluck(:_id)
+    Patient.where(_id: gather_patient_ids).any_of({ "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true },
+                                                  { "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEXCEP": true },
+                                                  "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEX": true).pluck(:_id)
   end
 
   def master_patient_ids

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -236,6 +236,7 @@ class ProductTest
 
   # Returns a listing of all ids for patients in the IPP
   def patients_in_ipp_and_greater
+    # TODO: if using template_ids in multiple places, make it into a private variable or something
     template_ids = gather_patient_ids
     # search thru all the patients for those IDs (that will be a where sort of query)
     # replace bundle.patients with a set where all the IDs are from our gather_patient_ids thing
@@ -245,24 +246,28 @@ class ProductTest
 
   # Returns a listing of all ids for patients in the Numerator
   def patient_in_numerator
-    bundle.patients.where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true).pluck(:_id)
+    template_ids = gather_patient_ids
+    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Denominator
   def patients_in_denominator_and_greater
-    bundle.patients.where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENOM": true).pluck(:_id)
+    template_ids = gather_patient_ids
+    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENOM": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Measure Population
   def patients_in_measure_population_and_greater
-    bundle.patients.where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.MSRPOPL": true).pluck(:_id)
+    template_ids = gather_patient_ids
+    Patient.where(_id: template_ids).where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.MSRPOPL": true).pluck(:_id)
   end
 
   # Returns a listing of all ids for patients in the Measure Population
   def patients_in_high_value_populations
-    bundle.patients.any_of({ "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true },
-                           { "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEXCEP": true },
-                           "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEX": true).pluck(:_id)
+    template_ids = gather_patient_ids
+    Patient.where(_id: template_ids).any_of({ "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.NUMER": true },
+                                            { "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEXCEP": true },
+                                            "measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.DENEX": true).pluck(:_id)
   end
 
   def master_patient_ids

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -210,7 +210,7 @@ class ProductTest
       # then check if vendor and/or patients are included in product
       if product.vendor_patients
         # If so, add appropriate vendor patient ids
-        aggregate_id_list.concat product.vendor.patients.pluck(:id)
+        aggregate_id_list.concat product.vendor_patient_ids
       end
       if product.bundle_patients
         # If so, add appropriate bundle patient ids

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -230,8 +230,6 @@ class ProductTest
 
   # Returns a listing of all ids for patients in the IPP
   def patients_in_ipp_and_greater
-    # search thru all the patients for those IDs (that will be a where sort of query)
-    # replace bundle.patients with a set where all the IDs are from our gather_patient_ids thing
     Patient.find(gather_patient_ids).keep_if do |p|
       p.patient_relevant?(measures.pluck(:_id), ['IPP'])
     end.pluck(:_id)

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -52,7 +52,7 @@ module Cypress
       @test = ProductTest.find(options['test_id'])
       if options['patient_ids']
         # clone each of the patients identified in the :patient_ids parameter
-        @test.bundle.patients.find(options['patient_ids']).to_a
+        CQM::Patient.find(options['patient_ids']).to_a
       else
         @test.bundle.patients.where(correlation_id: nil).to_a
       end

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -61,7 +61,7 @@ module Cypress
     def randomize_ids(patients, prng)
       how_many = prng.rand(5) + 1
       randomization_ids = options['randomization_ids'].shuffle(random: prng)[0..how_many]
-      random_patients = @test.bundle.patients.find(randomization_ids).to_a
+      random_patients = Patient.find(randomization_ids).to_a
       random_patients.each do |patient|
         plus_minus = prng.rand(2).zero? ? 1 : -1 # use this to make move dates forward or backwards
         date_shift = prng.rand(1_944_000) * plus_minus # 1_944_000 = 60 secs per min * 60 min per hour * 24 hours in day * 10 days

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -150,6 +150,12 @@ module CQM
         end
       end
     end
+
+    def patient_relevant?(measure_ids, population_keys)
+      measure_relevance_hash.any? do |key, mrh|
+        (measure_ids.include? BSON::ObjectId.from_string(key)) && (population_keys.any? { |pop| mrh[pop] == true })
+      end
+    end
   end
 
   class BundlePatient < Patient; end

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -151,9 +151,12 @@ module CQM
       end
     end
 
+    # Return true if the patient is relevant for one of the population keys in one of the measures passed in
     def patient_relevant?(measure_ids, population_keys)
-      measure_relevance_hash.any? do |key, mrh|
-        (measure_ids.include? BSON::ObjectId.from_string(key)) && (population_keys.any? { |pop| mrh[pop] == true })
+      measure_relevance_hash.any? do |measure_key, mrh|
+        # Does the list of measure include the key from the measure relevance hash, and
+        # Does the measure relevance include a true value from on of the requested population keys.
+        (measure_ids.include? BSON::ObjectId.from_string(measure_key)) && (population_keys.any? { |pop| mrh[pop] == true })
       end
     end
   end

--- a/test/factories/patients.rb
+++ b/test/factories/patients.rb
@@ -93,6 +93,8 @@ FactoryBot.define do
       qdmPatient { FactoryBot.build(:qdm_patient) }
 
       after(:create) do |patient|
+        patient.measure_relevance_hash = {}
+        patient.measure_relevance_hash[Measure.find_by(bundle_id: patient.bundle.id, hqmf_id: 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE')._id.to_s] = { 'IPP' => true, 'MSRPOPL' => true }
         provider = create(:default_provider)
         patient.providers << provider
         patient.save!

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -220,6 +220,33 @@ class ProducTest < ActiveSupport::TestCase
     assert arrays_equivalent(checklist_tasks.collect(&:class), [C1ChecklistTask, C3ChecklistTask])
   end
 
+  def test_creates_product_tests_with_vendor_patients
+    exec_bundle = FactoryBot.create(:executable_bundle)
+    vendor_patient = FactoryBot.create(:vendor_test_patient, bundleId: exec_bundle.id, correlation_id: @vendor.id)
+    product = Product.new(vendor: @vendor, name: 'test_product', vendor_patients: true, bundle_patients: false, cvuplus: true, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'], bundle_id: exec_bundle.id)
+    product.update_with_tests({})
+    # we want to see if this set of patients includes a patient whose whose original_patient_id field matches our patient.id
+    # original_patient_id is the ID of the template
+    product.product_tests.each do |pt|
+      pt.patients.each { |pat| assert_equals pat.original_patient_id, vendor_patient.id }
+    end
+  end
+
+  def test_creates_product_tests_with_vendor_patients_and_bundle_patients
+    exec_bundle = FactoryBot.create(:executable_bundle)
+    vendor_patient = FactoryBot.create(:vendor_test_patient, bundleId: exec_bundle.id, correlation_id: @vendor.id)
+    product = Product.new(vendor: @vendor, name: 'test_product', vendor_patients: true, bundle_patients: true, cvuplus: true, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'], bundle_id: exec_bundle.id)
+    product.update_with_tests({})
+    exec_ids = exec_bundle.patients.pluck(:_id)
+    product.product_tests.each do |pt|
+      assert(pt.patients.any? { |pat| pat.original_patient_id == vendor_patient.id })
+      pt.patients.each do |pat|
+        # if it's not a vendor patient, we want to make sure it's a bundle patient
+        assert exec_ids.include? pat.original_patient_id if pat.original_patient_id != vendor_patient.id
+      end
+    end
+  end
+
   # def test_add_checklist_test_adds_correct_number_of_measures_for_checked_criteria
   #   measure_ids = ['40280381-4B9A-3825-014B-C1A59E160733', 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
   #   product = @vendor.products.create!(name: "my product #{rand}", measure_ids: measure_ids, c1_test: true, bundle_id: @bundle.id)


### PR DESCRIPTION
Updated to allow for a combination of Bundle/Vendor selection when using CVU+. When the user creates a product, product tests will be created using both or either vendor & bundle patients (as chosen by the user).

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-448
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code