### PR TITLE
Fix Turbolinks authenticity token failures, and fix a typo in action_modal.js

### DIFF
--- a/app/assets/javascripts/action_modal.js
+++ b/app/assets/javascripts/action_modal.js
@@ -9,7 +9,7 @@ ready = function() {
     $(this).find('.modal-body span.object_type').text($(e.relatedTarget).attr('data-object-type'));
     $(this).find('.modal-body strong.object_name').text($(e.relatedTarget).attr('data-object-name'));
     $(this).find('.modal-body span.object_action').text($(e.relatedTarget).attr('data-object-action'));
-    $(this).find('.modal-body input.confirm_object_name').attr('placeholder', $(e.relateTarget).attr('data-object-type'));
+    $(this).find('.modal-body input.confirm_object_name').attr('placeholder', $(e.relatedTarget).attr('data-object-type'));
 
     /* set data-form for modal to correct form */
     $('#modal_confirm_remove').data('form', $(e.relatedTarget).closest('form'));

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -32,6 +32,10 @@
 //= require local-time
 //= require_tree .
 
+$(document).on('page:load page:partial-load turbolinks:load', function () {
+  $.rails.refreshCSRFTokens();
+});
+
 $(function() {
   Turbolinks.ProgressBar.enable();
   $('.breadcrumb').breadcrumb();


### PR DESCRIPTION
This PR fixes an issue (found by @emc4131) where deleting a Vendor Patient after a Turbolinks page change would cause an `Invalid Authenticity Token` error. 

It also fixes a typo in `action_modal.js`

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code