### PR TITLE
Restrict DataElements to having single DataElementCode

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,11 +43,13 @@ Metrics/ClassLength:
     - 'lib/cypress/api_measure_evaluator.rb'
     - 'lib/cypress/cql_bundle_importer.rb'
     - 'lib/cypress/demographics_randomizer.rb'
+    - 'lib/cypress/population_clone_job.rb'
 Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
   Max: 32
   Exclude:
+    - 'lib/cypress/population_clone_job.rb'
     - 'test/**/*.rb'
 Metrics/ModuleLength:
   Max: 110

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -18,6 +18,7 @@ class Vendor
   field :address, type: String
   field :state, type: String
   field :zip, type: String
+  field :preferred_code_systems, type: Hash, default: {}
   field :favorite_user_ids, type: Array, default: []
 
   validates :name, presence: true, uniqueness: { message: 'Vendor name was already taken. Please choose another.' }

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -113,7 +113,7 @@ module Cypress
         else
           # if the vendor has a preference, loop through in order
           vendor_preference.each do |vp|
-            # find data element codes that match the preference 
+            # find data element codes that match the preference
             pc = entry.dataElementCodes.map { |dec| dec if dec['codeSystem'] == vp }.compact
             # if none found, look for the next one
             next if pc.blank?

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -105,6 +105,8 @@ module Cypress
     def restrict_entry_codes(cloned_patient)
       # Loop through every data element
       cloned_patient.qdmPatient.dataElements.each do |entry|
+        next if entry.dataElementCodes.blank?
+
         # look up if the vendor has a preferred_code_system for the qdmCategory
         vendor_preference = @test.product.vendor.preferred_code_systems[entry.qdmCategory]
         # if the vendor does not have a preference, pick the first code

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -14,6 +14,105 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
     assert_equal 10, Patient.where(correlation_id: @pt.id).count
   end
 
+  def test_preferred_code_procedure_without_vendor_perference
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    original_patient = @pt.patients.first
+    original_procedure_codes = original_patient.qdmPatient.procedures.first.dataElementCodes
+    # There are two codes in the original patients procedure
+    assert_equal 2, original_procedure_codes.size
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+  end
+
+  def test_preferred_code_procedure_with_vendor_perference_snomedct
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    vendor = @pt.product.vendor
+    vendor.preferred_code_systems['procedure'] = ['SNOMEDCT']
+    vendor.save
+    @pt.patients
+    original_patient = @pt.patients.first
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+    # The cloned code should be from the SNOMEDCT code system
+    assert_equal 'SNOMEDCT', cloned_procedure_codes[0].codeSystem
+  end
+
+  def test_preferred_code_procedure_with_vendor_perference_cpt
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    vendor = @pt.product.vendor
+    vendor.preferred_code_systems['procedure'] = ['CPT']
+    vendor.save
+    @pt.patients
+    original_patient = @pt.patients.first
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+    # The cloned code should be from the CPT code system
+    assert_equal 'CPT', cloned_procedure_codes[0].codeSystem
+  end
+
+  def test_preferred_code_procedure_with_vendor_perference_not_found
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    vendor = @pt.product.vendor
+    vendor.preferred_code_systems['procedure'] = ['FAKECS']
+    vendor.save
+    @pt.patients
+    original_patient = @pt.patients.first
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+    # The cloned code should not be from the FAKECS code system
+    assert_not_equal 'FAKECS', cloned_procedure_codes[0].codeSystem
+  end
+
+  def test_preferred_code_procedure_with_ordered_vendor_perference_snomedct_first
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    vendor = @pt.product.vendor
+    vendor.preferred_code_systems['procedure'] = %w[SNOMEDCT CPT]
+    vendor.save
+    @pt.patients
+    original_patient = @pt.patients.first
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+    # The cloned code should be from the SNOMEDCT code system
+    assert_equal 'SNOMEDCT', cloned_procedure_codes[0].codeSystem
+  end
+
+  def test_preferred_code_procedure_with_ordered_vendor_perference_cpt_first
+    pcj = Cypress::PopulationCloneJob.new('test_id' => @pt.id)
+    pcj.find_patients_to_clone
+    vendor = @pt.product.vendor
+    vendor.preferred_code_systems['procedure'] = %w[CPT SNOMEDCT]
+    vendor.save
+    @pt.patients
+    original_patient = @pt.patients.first
+    cloned_patient = original_patient.clone
+    pcj.restrict_entry_codes(cloned_patient)
+    cloned_procedure_codes = cloned_patient.qdmPatient.procedures.first.dataElementCodes
+    # There should only be one codes in the cloned patients procedure
+    assert_equal 1, cloned_procedure_codes.size
+    # The cloned code should be from the SNOMEDCT code system
+    assert_equal 'CPT', cloned_procedure_codes[0].codeSystem
+  end
+
   def test_assigns_default_provider
     # ids passed in should clone just the 1 record
     sample_patient = @pt.bundle.patients.sample


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code