### PR TITLE
No longer wipe out fields in IndividualResult

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - nvm install 10.0
   - nvm use stable
   - npm install -g eslint
-  - git clone -b master https://github.com/projecttacoma/cqm-execution-service.git /tmp/cqm-execution-service
+  - git clone -b master https://github.com/projecttacoma/cqm-execution-service.git#individual_result_mod /tmp/cqm-execution-service
 before_script:
   - git config --global user.email "travis@travis.ci"
   - git config --global user.name "Travis CI"

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'bson_ext'
 gem 'mustache'
 gem 'os'
 
-gem 'cqm-models', '~> 1.1.1.0'
+gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models.git', branch: 'individual_result_mods'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers.git', branch: 'drc_code_system'
 gem 'cqm-reports', '~> 1.0.0.0'
 gem 'cqm-validators', '~> 1.0.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/projecttacoma/cqm-models.git
+  revision: 8309c4357151e3098fc4ca198a1480e13359e28c
+  branch: individual_result_mods
+  specs:
+    cqm-models (1.1.1.0)
+
+GIT
   remote: https://github.com/projecttacoma/cqm-parsers.git
   revision: 386e36da55b1e979637664d991459bb2b3bcab51
   branch: drc_code_system
@@ -147,7 +154,6 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    cqm-models (1.1.1.0)
     cqm-reports (1.0.0.0)
       cqm-models (~> 1.1.1.0)
       erubis (~> 2.7.0)
@@ -528,7 +534,7 @@ DEPENDENCIES
   carrierwave (~> 0.11.2)
   carrierwave-mongoid
   codecov
-  cqm-models (~> 1.1.1.0)
+  cqm-models!
   cqm-parsers!
   cqm-reports (~> 1.0.0.0)
   cqm-validators (~> 1.0.1.0)

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -76,10 +76,6 @@ module Cypress
       # individual_result = QDM::IndividualResult.new(individual_result)
       # when saving the individual result, include the provided correlation id
       individual_result['correlation_id'] = @correlation_id
-      # TODO: Fix in cqm-models and execution
-      # Temporary fix is to strip out unneeded data to prevent saving keys containing '.'
-      individual_result['extendedData'] = {}
-      individual_result['statement_results'] = {}
       individual_result['file_name'] = @options[:file_name] if @options[:file_name]
       individual_result
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code