### PR TITLE
Vendor patient mng

### DIFF
--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -38,13 +38,19 @@ class Bundle
   end
 
   def deprecate
+    # destroy results of bundle patients
     results.destroy
+    # destroy results of vendor patients created for bundle
+    Patient.where(_type: 'CQM::VendorPatient', bundleId: id.to_s).each { |pt| pt.calculation_results.destroy }
     FileUtils.rm(mpl_path) if File.exist?(mpl_path)
     update(deprecated: true, active: false)
   end
 
   def destroy
+    # destroy bundle patients
     patients.destroy
+    # destroy vendor patients created for bundle
+    Patient.where(_type: 'CQM::VendorPatient', bundleId: id.to_s).destroy_all
     Product.where(bundle_id: id).destroy_all
     FileUtils.rm(mpl_path) if File.exist?(mpl_path)
     delete

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -105,10 +105,13 @@ module Admin
     end
 
     test 'should be able to remove bundle' do
+      FactoryBot.create(:vendor_test_patient,
+                        bundleId: @static_bundle._id, correlation_id: @vendor.id)
       for_each_logged_in_user([ADMIN]) do
         orig_bundle_count = Bundle.count
         orig_measure_count = Measure.count
         orig_patient_count = Patient.count
+        orig_vendor_patient_count = CQM::VendorPatient.count
         orig_results_count = QDM::IndividualResult.count
         id = @static_bundle.id
 
@@ -118,6 +121,7 @@ module Admin
         assert_equal orig_bundle_count - 1, Bundle.count, 'Should have deleted Bundle'
         assert orig_measure_count > Measure.count, 'Should have removed measures in the bundle'
         assert orig_patient_count > Patient.count, 'Should have removed patients in the bundle'
+        assert orig_vendor_patient_count > CQM::VendorPatient.count, 'Should have vendor patients for the bundle'
         assert orig_results_count > QDM::IndividualResult.count, 'Should have removed individual results in the bundle'
       end
     end


### PR DESCRIPTION
This PR covers the database portion of vendor patient management. Deletion of a bundle should result in bundle patients and vendor patients being deleted, as well as results for both sets of patients. Deprecation should result in bundle and vendor patients being kept, but their results being deleted. 

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [X] This pull request describes why these changes were made.
- [X] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-457
- [X] Internal ticket links to this PR
- [X] Code diff has been done and been reviewed
- [X] Tests are included and test edge cases
- [X] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code