### PR TITLE
MutliMeasureTasks should only appear for status for an EH or EP test,…

### DIFF
--- a/lib/cypress/product_status_values.rb
+++ b/lib/cypress/product_status_values.rb
@@ -9,14 +9,16 @@ module Cypress
 
     def ep_status_values(product)
       h = {}
-      h['EP Measure Test'] = Hash[%w[passing failing errored not_started total].zip(product_test_statuses(product.product_tests.multi_measure_tests,
+      ep_measure_tests = product.product_tests.multi_measure_tests.where(name: 'EP Measures')
+      h['EP Measure Test'] = Hash[%w[passing failing errored not_started total].zip(product_test_statuses(ep_measure_tests,
                                                                                                           'MultiMeasureCat3Task'))]
       h
     end
 
     def eh_status_values(product)
       h = {}
-      h['EH Measure Test'] = Hash[%w[passing failing errored not_started total].zip(product_test_statuses(product.product_tests.multi_measure_tests,
+      eh_measure_tests = product.product_tests.multi_measure_tests.where(name: 'EH Measures')
+      h['EH Measure Test'] = Hash[%w[passing failing errored not_started total].zip(product_test_statuses(eh_measure_tests,
                                                                                                           'MultiMeasureCat1Task'))]
       h
     end


### PR DESCRIPTION
… not both

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code