### PR TITLE
links on eCQI resource center are no longer padded

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -39,11 +39,6 @@ module ApplicationHelper
     cms_id[/#{start_marker}(.*?)#{end_marker}/m, 1].to_i
   end
 
-  # This will always return a three digit cms identifier, e.g., CMS9v3 => CMS009v3
-  def padded_cms_id(cms_id)
-    cms_id.sub(/(?<=cms)(\d{1,3})/i) { Regexp.last_match(1).rjust(3, '0') }
-  end
-
   # All "Master Patients" has medical records numbers that are UUIDs following this pattern "007f5da0-4d3a-0135-867f-20999b0ed66f".
   # These medical record numbers are set in the bundle. When patients are created for a test,
   # they have a medical record number like "757442430658921". This "keep_if" statement makes sure we only returning an id for a Master Patient.

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -9,13 +9,13 @@
   <% if (task.product_test.is_a? MeasureTest) || (task.product_test.is_a? FilteringTest) %>
     <strong>Measure: </strong><span><%= task.product_test_name %></span><br/>
     <strong>HQMF ID: </strong><span><%= task.measure_ids.join(',') %></span><br/>
-    <strong>CMS ID: </strong><span><%= task.product_test_cms_id%></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{padded_cms_id(task.product_test_cms_id)}", :target => "_blank", :id => "ecqm-link" %></span><br/>
+    <strong>CMS ID: </strong><span><%= task.product_test_cms_id%></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{task.product_test_cms_id}", :target => "_blank", :id => "ecqm-link" %></span><br/>
   <% end %>
 
   <% if (task.product_test.is_a? MultiMeasureTest) || (task.product_test.is_a? ChecklistTest) %>
     <strong>Measures: </strong><br/>
     <% task.product_test.measures.collect(&:cms_id).each do |cms_id| %>
-    <span><%= cms_id %></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{padded_cms_id(cms_id)}", :target => "_blank", :id => "ecqm-link" %></span><br/>
+    <span><%= cms_id %></span><span><%= link_to " (eCQM Specification)", "https://ecqi.healthit.gov/ecqm/measures/#{cms_id}", :target => "_blank", :id => "ecqm-link" %></span><br/>
     <% end %>
   <% end %>
 

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -191,10 +191,4 @@ class TestExecutionHelper < ActiveSupport::TestCase
     assert_equal [true, false, false, false], current_certifications('C1ChecklistTask', false)
     assert_equal [true, false, true, false], current_certifications('C1ChecklistTask', true)
   end
-
-  def test_padding_cms_id
-    assert_equal 'CMS002v5', padded_cms_id('CMS2v5')
-    assert_equal 'CMS020v5', padded_cms_id('CMS20v5')
-    assert_equal 'CMS200v5', padded_cms_id('CMS200v5')
-  end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code