### PR TITLE
Display name on Previous/Next if CMS id does not exist

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -183,6 +183,11 @@ class ProductTest
     end
   end
 
+  # The name to display on a button to view this test (e.g., Previous/Next Test)
+  def button_short_name
+    cms_id.nil? ? name : cms_id
+  end
+
   def start_date
     Time.at(measure_period_start).in_time_zone
   end

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -13,10 +13,10 @@
 <% unless @task.is_a?(C1ChecklistTask) || @task.is_a?(C3ChecklistTask) %>
   <div class="panel clearfix">
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'prev').id), :method => :get, :class => "btn btn-default pull-left" do %>
-      <%= icon('fas fa-fw', 'step-backward', :"aria-hidden" => true) %> Previous Test: <%= iterate_task(@task, 'prev').product_test.cms_id %>
+      <%= icon('fas fa-fw', 'step-backward', :"aria-hidden" => true) %> Previous Test: <%= iterate_task(@task, 'prev').product_test.button_short_name %>
     <% end %>
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'next').id), :method => :get, :class => "btn btn-default pull-right" do %>
-      Next Test: <%= iterate_task(@task, 'next').product_test.cms_id %> <%= icon('fas fa-fw', 'step-forward', :"aria-hidden" => true) %>
+      Next Test: <%= iterate_task(@task, 'next').product_test.button_short_name %> <%= icon('fas fa-fw', 'step-forward', :"aria-hidden" => true) %>
     <% end %>
   </div>
 <% end %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code