### PR TITLE
when finding duplicate patients, use id, not qdmPatient.id

### DIFF
--- a/app/models/multi_measure_cat1_task.rb
+++ b/app/models/multi_measure_cat1_task.rb
@@ -16,8 +16,8 @@ class MultiMeasureCat1Task < Task
   end
 
   def patients
-    patient_ids = product_test.results.where('IPP' => { '$gt' => 0 }).collect(&:patient)
-    product_test.patients.in('_id' => patient_ids)
+    patient_ids = product_test.results.where('IPP' => { '$gt' => 0 }).collect(&:patient_id)
+    product_test.patients.find(patient_ids)
   end
 
   def good_results

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -111,7 +111,7 @@ class ProductTest
 
   def sample_and_duplicate_patients(pat_arr, ids, random: Random.new)
     car = ::Validators::CalculatingAugmentedRecords.new(measures, [], id)
-    dups = patients.in('qdmPatient._id' => ids).to_a
+    dups = patients.find(ids)
 
     pat_arr, dups = randomize_clinical_data(pat_arr, dups, random)
     # choose up to 3 duplicate patients

--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -29,7 +29,6 @@ module Cypress
       end
       patient1.qdmPatient.dataElements.concat patient_char_de
       patient2.qdmPatient.dataElements.concat patient_char_de
-      patient.qdmPatient.dataElements.concat patient_char_de
 
       [patient1, patient2]
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-537
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code