### PR TITLE
Apparently, the vsac value set codes includes some duplicates. remove…

### DIFF
--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -59,7 +59,7 @@ module ChecklistTestsHelper
 
     return [] unless vs&.first
 
-    vs.first.concepts.map { |con| [con.display_name, con.code] }
+    vs.first.concepts.map { |con| [con.display_name, con.code] }.uniq
   end
 
   def direct_reference_code?(valueset)


### PR DESCRIPTION
… them from the view.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-539
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code