### PR TITLE
count measure, and multi-measure tests when reporting status for down…

### DIFF
--- a/app/views/products/_bulk_download.html.erb
+++ b/app/views/products/_bulk_download.html.erb
@@ -5,9 +5,8 @@
 # must specify local variable "product"
 #
 %>
-
-<% num_measure_tests = product.product_tests.measure_tests.count %>
-<% num_measure_tests_ready = product.product_tests.measure_tests.where(state: :ready).count %>
+<% num_measure_tests = product.product_tests.measure_tests.count + product.product_tests.multi_measure_tests.count %>
+<% num_measure_tests_ready = product.product_tests.measure_tests.where(state: :ready).count + product.product_tests.multi_measure_tests.where(state: :ready).count %>
 <% if num_measure_tests_ready == num_measure_tests %>
   <p>This download contains a folder for each measure selected for this product. Inside these folders are XML documents for each patient associated with that measure.</p>
   <%= form_for product, url: patients_vendor_product_path(product.vendor_id, product), :html => { :method => 'GET' } do |f| %>

--- a/lib/cypress/create_total_test_zip.rb
+++ b/lib/cypress/create_total_test_zip.rb
@@ -3,12 +3,19 @@ module Cypress
     def self.create_total_test_zip(product, criteria_list, filtering_list, format = 'qrda')
       file = Tempfile.new("all-patients-#{Time.now.to_i}")
       Zip::ZipOutputStream.open(file.path) do |z|
+        add_multi_measure_zips(z, product.product_tests.multi_measure_tests, format)
         add_measure_zips(z, product.product_tests.measure_tests, format)
         add_checklist_zips(z, product.product_tests.checklist_tests, criteria_list)
         add_filtering_zips(z, product.product_tests.filtering_tests, format, filtering_list) unless product.product_tests.filtering_tests.empty?
         add_html_files(z, product.product_tests) unless product.c2_test
       end
       file
+    end
+
+    def self.add_multi_measure_zips(z, multi_measure_tests, format)
+      multi_measure_tests.each do |pt|
+        CreateDownloadZip.add_file_to_zip(z, "#{pt.name}_#{pt.id}.#{format}.zip".tr(' ', '_'), pt.patient_archive.read)
+      end
     end
 
     def self.add_measure_zips(z, measure_tests, format)
@@ -38,7 +45,7 @@ module Cypress
     def self.add_html_files(z, tests)
       tests.each do |pt|
         unless pt[:html_archive].nil? || (pt.is_a? FilteringTest)
-          CreateDownloadZip.add_file_to_zip(z, "#{pt.cms_id}_#{pt.id}.html.zip".tr(' ', '_'),
+          CreateDownloadZip.add_file_to_zip(z, "#{pt.button_short_name}_#{pt.id}.html.zip".tr(' ', '_'),
                                             pt.html_archive.read)
         end
       end

--- a/test/unit/lib/create_download_zip_test.rb
+++ b/test/unit/lib/create_download_zip_test.rb
@@ -24,4 +24,20 @@ class CreateDownloadZipTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'Should create appropriate zip for cvu' do
+    product_cvu = FactoryBot.create(:product_static_bundle)
+
+    pt = product_cvu.product_tests.build({ name: 'mtest', measure_ids: product_cvu.measure_ids }, MultiMeasureTest)
+    pt.save
+    pt.generate_patients
+    pt.create_tasks
+    pt.archive_patients if pt.patient_archive.path.nil?
+    pt.save!
+    file = Cypress::CreateTotalTestZip.create_total_test_zip(product_cvu, nil, nil, 'qrda')
+
+    Zip::File.open(file) do |zip_file|
+      assert_not_empty zip_file.glob("#{pt.name}_#{pt.id}.qrda.zip")
+    end
+  end
 end


### PR DESCRIPTION
…load all

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-541
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code