### PR TITLE
Default negated codes field is codeSystem not code_system_oid

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -30,10 +30,10 @@ version_config:
       default_negation_codes:
         2.16.840.1.113883.3.526.3.1184:
           code: "854901"
-          codeSystem: "RxNorm"
+          codeSystem: "2.16.840.1.113883.6.88"
         2.16.840.1.113883.3.526.3.1174:
           code: "854901"
-          codeSystem: "RxNorm"
+          codeSystem: "2.16.840.1.113883.6.88"
       CMSQRDA3SchematronValidator_warnings:
       CMSQRDA1HQRSchematronValidator_warnings:
 

--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -12,7 +12,7 @@ module Cypress
       # If Cypress has a default code selected, use it.  Otherwise, use the first in the valueset.
       code = if bundle.default_negation_codes && bundle.default_negation_codes[negated_vs]
                { code: bundle.default_negation_codes[negated_vs]['code'],
-                 codeSystemOid: bundle.default_negation_codes[negated_vs]['code_system_oid'] }
+                 codeSystemOid: bundle.default_negation_codes[negated_vs]['codeSystem'] }
              else
                valueset = ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
                { code: valueset.first.concepts.first['code'], codeSystemOid: valueset.first.concepts.first['code_system_oid'] }


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code