### PR TITLE
Find an appropriate data element description with scoop and filter

### DIFF
--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -57,6 +57,7 @@
 
   <div class="col-md-6">
     <!--h2>Patient Details</h2-->
-    <%= QdmPatient.new(@record, false).render.html_safe %>
+    <% sf_patient = @record.clone %>
+    <%= QdmPatient.new(Cypress::ScoopAndFilter.new(@measures).scoop_and_filter(sf_patient), false).render.html_safe %>
   </div>
 </div>

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -95,10 +95,12 @@ end
 Then(/^the user sees details$/) do
   page.assert_text "Cypress Certification Patient Test Record: #{@patient.first_names} #{@patient.familyName}"
   page.assert_text @patient.gender
-  @patient.qdmPatient.dataElements.each do |data_criteria|
+  @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
+  sf_patient = @patient.clone
+  Cypress::ScoopAndFilter.new(@measures).scoop_and_filter(sf_patient)
+  sf_patient.qdmPatient.dataElements.each do |data_criteria|
     page.assert_text data_criteria['description']
   end
-  @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
   @measures.each do |m|
     page.assert_text m.description
   end
@@ -142,10 +144,12 @@ end
 Then(/^the user should see vendor patient details$/) do
   page.assert_text "Cypress Certification Patient Test Record: #{@patient.first_names} #{@patient.familyName}"
   page.assert_text @patient.gender
-  @patient.qdmPatient.dataElements.each do |data_criteria|
+  @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
+  sf_patient = @patient.clone
+  Cypress::ScoopAndFilter.new(@measures).scoop_and_filter(sf_patient)
+  sf_patient.qdmPatient.dataElements.each do |data_criteria|
     page.assert_text data_criteria['description']
   end
-  @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
   @measures.each do |m|
     page.assert_text m.cms_id
   end

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -27,6 +27,7 @@ module Cypress
         # Do not try to replace with negated valueset if all codes are removed
         next if data_element.dataElementCodes.blank?
 
+        add_description_to_data_element(data_element)
         replace_negated_code_with_valueset(data_element) if data_element.respond_to?('negationRationale') && data_element.negationRationale
       end
       # keep data element if codes is not empty
@@ -44,6 +45,14 @@ module Cypress
     # returns true if a patients data element is used by a measure
     def data_element_used_by_measure(data_element)
       @de_category_statuses_for_measures.include?(category: data_element['qdmCategory'], status: data_element['qdmStatus'])
+    end
+
+    def add_description_to_data_element(data_element)
+      de = data_element
+      vsets = @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.codeSystemOid } }
+      # A data element may have codes from multiple valusets, pick the first valueset for the description
+      vs = vsets.first
+      de.description = vs.display_name
     end
 
     def replace_negated_code_with_valueset(data_element)


### PR DESCRIPTION
Adds 'text' to xml 
<img width="721" alt="image" src="https://user-images.githubusercontent.com/8173551/60831438-968d2480-a187-11e9-9363-164db20c043c.png">

and adds  to html

<img width="568" alt="image" src="https://user-images.githubusercontent.com/8173551/60831613-f388da80-a187-11e9-972d-2730a2feb48b.png">

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Code diff has been done and been reviewed
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code