### PR TITLE
changes in build script to fix the network interface issue

### DIFF
--- a/contrib/scripts/cleanup.sh
+++ b/contrib/scripts/cleanup.sh
@@ -3,10 +3,5 @@
 # Ubuntu 16.04 introduces a new feature that causes ethernet device names to
 # no longer be consistent, which causes problems with exported vms.
 # This works around the issue by turning the feature off.
-echo 'GRUB_CMDLINE_LINUX="biosdevname=0 net.ifnames=0"' >> /etc/default/grub
-grub-mkconfig -o /boot/grub/grub.cfg
+echo -e 'network:\n  version: 2\n  renderer: networkd\n  ethernets:\n    all:\n      match:\n        name: e*\n      dhcp4: yes\n'  > /etc/netplan/01-netcfg.yaml
 
-echo 'auto eth0' >> /etc/network/interfaces
-echo 'iface eth0 inet dhcp' >> /etc/network/interfaces
-echo 'auto eth1' >> /etc/network/interfaces
-echo 'iface eth1 inet manual' >> /etc/network/interfaces


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code