### PR TITLE
Report issues. Checkmark is incompatible.  Only show appropriate CMS …

### DIFF
--- a/app/views/products/report/_cvu_plus_report.html.erb
+++ b/app/views/products/report/_cvu_plus_report.html.erb
@@ -57,7 +57,9 @@
     <tbody>
       <% %w[HQR_PI HQR_IQR HQR_PI_IQR HQR_IQR_VOL MIPS_GROUP MIPS_INDIV MIPS_VIRTUALGROUP CPCPLUS].each do |test| %>
           <tr>
-              <% task = @product.product_tests.cms_program_tests.where(cms_program: test ).first.tasks.first %>
+              <% ptest = @product.product_tests.cms_program_tests.where(cms_program: test ) %>
+              <% next if ptest.empty? %>
+              <% task = ptest.first.tasks.first %>
               <td class='text-left'><%= task.product_test.name %></td>
               <td class='text-center'><%= render partial: 'products/report/status_icon', locals: { passing: task.passing? } %></td>
           </tr>

--- a/app/views/products/report/_status_icon.html.erb
+++ b/app/views/products/report/_status_icon.html.erb
@@ -4,5 +4,5 @@
 
 %>
 
-<span aria-hidden="true" class='<%= passing ? 'text-success' : 'text-danger' %>'><%= passing ? '✓' : 'X' %></span>
+<span aria-hidden="true" class='<%= passing ? 'text-success' : 'text-danger' %>'><%= passing ? '&#10003;'.html_safe : '&#10060;'.html_safe %></span>
 <span class="sr-only"><%= passing ? 'passing' : 'failing' %></span>


### PR DESCRIPTION
…Program tests

The checkmark in the status icon was causing this error in production

<img width="1117" alt="Screen Shot 2019-07-22 at 2 23 50 PM" src="https://user-images.githubusercontent.com/8173551/61655519-ba269380-ac8c-11e9-906d-f99ec40c1dbf.png">



Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code