### PR TITLE
(cypress_v5) measure titles were not wrapping well, since they were very long with…

### DIFF
--- a/app/helpers/records_helper.rb
+++ b/app/helpers/records_helper.rb
@@ -140,6 +140,6 @@ module RecordsHelper
   def measure_display_name(measure, population_set_hash)
     cms_id = measure.cms_id
     population_set_display = population_set_hash[:stratification_id] || population_set_hash[:population_set_id]
-    "#{cms_id} - #{population_set_display}"
+    "#{cms_id} - #{population_set_display.tr('_', ' ')}"
   end
 end


### PR DESCRIPTION
…out spaces

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code