### PR TITLE
WIP (cypress_v5) Add percentage when importing vendor patients

### DIFF
--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -91,10 +91,11 @@ class VendorPatientUploadJob < ApplicationJob
     effective_date_end = Time.at(bundle.effective_date).in_time_zone.to_formatted_s(:number)
     effective_date = Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
     options = { 'effectiveDateEnd' => effective_date_end, 'effectiveDate' => effective_date, 'includeClauseResults' => true }
-    patient_ids.each_slice(20) do |patient_ids_slice|
+    patient_ids.each_slice(20).with_index do |patient_ids_slice, index|
       bundle.measures.each do |measure|
         SingleMeasureCalculationJob.perform_now(patient_ids_slice, measure.id.to_s, vendor_id, options)
       end
+      tracker.log("Importing (#{((((index + 1) * 20).to_f / patient_ids.size) * 100).to_i}% complete) ")
     end
     PatientAnalysisJob.perform_later(bundle.id.to_s, vendor_id)
   end


### PR DESCRIPTION
Uploading lots of vendor patients can take a really long time.  Provide some status.

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/8173551/61807935-7b1d4d00-ae08-11e9-9c9d-13b40be93718.png">


**Submitter:**
- [ ] This pull request describes why these changes were made.

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code