### PR TITLE
remove ref to cypress3 in css

### DIFF
--- a/app/assets/stylesheets/_globals.scss
+++ b/app/assets/stylesheets/_globals.scss
@@ -5,7 +5,7 @@
 @import 'font-awesome';
 
 // Turbolinks progress bar
-#cypress3::before {
+#cypress::before {
   background-color: $brand-primary-highlight;
   height: 6px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
 <!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress3" lang="en-US" class="no-js not-ie"><!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress" lang="en-US" class="no-js not-ie"><!--<![endif]-->
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/views/layouts/errors.html.erb
+++ b/app/views/layouts/errors.html.erb
@@ -2,7 +2,7 @@
 <!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
 <!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress3" lang="en-US" class="no-js not-ie error-page"><!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress" lang="en-US" class="no-js not-ie error-page"><!--<![endif]-->
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/app/views/layouts/report.html.erb
+++ b/app/views/layouts/report.html.erb
@@ -2,7 +2,7 @@
 <!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
 <!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
-<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress3" lang="en-US" class="no-js not-ie"><!--<![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress" lang="en-US" class="no-js not-ie"><!--<![endif]-->
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code