### PR TITLE
need to pass in expected_result and reported_result to generate error…

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,7 @@ Metrics/ParameterLists:
   Exclude:
     - 'app/helpers/records_helper.rb'
     - 'lib/cypress/data_criteria_attribute_builder.rb'
+    - 'lib/validators/expected_results_validator.rb'
 Metrics/PerceivedComplexity:
   Max: 10
   Exclude:

--- a/lib/validators/expected_results_validator.rb
+++ b/lib/validators/expected_results_validator.rb
@@ -66,7 +66,7 @@ module Validators
       if !reported_result.empty? && !reported_result.key?(pop_key)
         generate_could_not_find_population_error_message(measure.hqmf_id, population_id, pop_key, pop_set_hash, stratification_id)
       elsif (expected_result[pop_key] != reported_result[pop_key]) && !reported_result.empty?
-        generate_does_not_match_population_error_message(measure.hqmf_id, population_id, pop_key, stratification_id)
+        generate_does_not_match_population_error_message(measure.hqmf_id, population_id, pop_key, stratification_id, expected_result, reported_result)
       end
     end
 
@@ -77,7 +77,7 @@ module Validators
       add_error(message, location: '/', measure_id: measure_id, population_id: population_id, stratification: stratification_id)
     end
 
-    def generate_does_not_match_population_error_message(measure_id, population_id, pop_key, stratification_id)
+    def generate_does_not_match_population_error_message(measure_id, population_id, pop_key, stratification_id, expected_result, reported_result)
       err = %(Expected #{pop_key} value #{expected_result[pop_key]}
       does not match reported value #{reported_result[pop_key]})
       error_details = { type: 'population', population_id: population_id, stratification: stratification_id,


### PR DESCRIPTION
… message

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code