### PR TITLE
Only allow bundles > 2019 to be loaded

### DIFF
--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -45,8 +45,8 @@ module Cypress
       bundle_versions = Hash[* Bundle.where(deprecated: false).collect { |b| [b.version, b.id] }.flatten]
 
       # no bundles before 2018 and no non-deprecated bundles with same year
-      old_year_err = 'Please use bundles for year 2018 or later.'
-      raise old_year_err if bundle.version[0..3].to_i < 2018
+      old_year_err = 'Please use bundles for year 2019 or later.'
+      raise old_year_err if bundle.version[0..3].to_i < 2019
 
       same_year_err = "A non-deprecated bundle with year #{bundle.version[0..3]} already exists in the database. Please deprecate previous bundles."
       raise same_year_err unless bundle_versions.select { |vers, _id| vers[0..3] == bundle.version[0..3] }.empty?


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

<img width="53" alt="image" src="https://user-images.githubusercontent.com/8173551/63787554-08e5cf80-c8c2-11e9-9757-64a951068ec2.png">


**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-571
- [ ] Internal ticket links to this PR 
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code