### PR TITLE
relatedTo elements in same file

### DIFF
--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -14,8 +14,8 @@ module Cypress
       patient1 = patient.clone
       patient2 = patient.clone
 
-      non_pc_de = patient.qdmPatient.dataElements.reject{ |de| de.qdmCategory == 'patient_characteristic' }
-      sorted_de_groups = sort_groups_by_start_time(find_relatedTo_de(non_pc_de))
+      non_pc_de = patient.qdmPatient.dataElements.reject { |de| de.qdmCategory == 'patient_characteristic' }
+      sorted_de_groups = sort_groups_by_start_time(find_related_to_de(non_pc_de))
 
       # Find a date that splits the data_elements such that at least 1 is in each patient
       split_date = find_split_date(sorted_de_groups, effective_date, measure_period_start, random)
@@ -24,23 +24,26 @@ module Cypress
         patient1, patient2 = set_split_data_elements(sorted_de_groups, patient1, patient2, split_date)
       else
         # set all patient1 data elements
-        patient1.qdmPatient.dataElements = patient.qdmPatient.dataElements
+        patient1.qdmPatient.dataElements = non_pc_de
         patient2.qdmPatient.dataElements = []
       end
+      patients_with_characteristics(patient1, patient2, patient_char_de)
+    end
+
+    def self.patients_with_characteristics(patient1, patient2, patient_char_de)
       patient1.qdmPatient.dataElements.concat patient_char_de
       patient2.qdmPatient.dataElements.concat patient_char_de
-
       [patient1, patient2]
     end
 
-    #note: also adds any related to elements, which may not be in the same date split
+    # note: also adds any related to elements, which may not be in the same date split
     def self.set_split_data_elements(sorted_de_groups, patient1, patient2, split_date)
       patient1.qdmPatient.dataElements = []
       patient2.qdmPatient.dataElements = []
       sorted_de_groups.take_while { |group| de_before_date(group.first, split_date) }.each do |group|
         patient1.qdmPatient.dataElements.concat group
       end
-      data_elements.drop_while { |group| de_before_date(group.first, split_date) }.each do |group|
+      sorted_de_groups.drop_while { |group| de_before_date(group.first, split_date) }.each do |group|
         patient2.qdmPatient.dataElements.concat group
       end
       [patient1, patient2]
@@ -52,11 +55,11 @@ module Cypress
 
     def self.split_by_type(patient, effective_date, measure_period_start, random)
       patient_char_de = patient.qdmPatient.get_data_elements('patient_characteristic')
-      non_pc_de = patient.qdmPatient.dataElements.reject{ |de| de.qdmCategory == 'patient_characteristic' }
-      de_groups = find_relatedTo_de(non_pc_de)
+      non_pc_de = patient.qdmPatient.dataElements.reject { |de| de.qdmCategory == 'patient_characteristic' }
+      de_groups = find_related_to_de(non_pc_de)
 
       # Collect unique data element categories from each related group
-      de_categories = de_groups.map{ |group| group.first }.collect(&:qdmCategory).uniq.shuffle(random: random)
+      de_categories = de_groups.map(&:first).collect(&:qdmCategory).uniq.shuffle(random: random)
 
       # If there's only 1 data element category, split by date instead
       return split_by_date(patient, effective_date, measure_period_start, random) if de_categories.count < 2
@@ -70,23 +73,20 @@ module Cypress
       patient1.qdmPatient.dataElements = de_for_category(de_groups, de_categories, 0, split_point)
       patient2.qdmPatient.dataElements = de_for_category(de_groups, de_categories, split_point, de_categories.size)
 
-      patient1.qdmPatient.dataElements.concat patient_char_de
-      patient2.qdmPatient.dataElements.concat patient_char_de
-
-      [patient1, patient2]
+      patients_with_characteristics(patient1, patient2, patient_char_de)
     end
 
-    #note: also adds any related to elements, which may not be the same category
+    # note: also adds any related to elements, which may not be the same category
     def self.de_for_category(de_groups, categories, start_point, end_point)
       data_elements = []
       categories[start_point...end_point].each do |cat|
-        category_groups = de_groups.select{ |group| group.first.qdmCategory == cat}
+        category_groups = de_groups.select { |group| group.first.qdmCategory == cat }
         data_elements.concat(category_groups.flatten)
       end
       data_elements
     end
 
-    #sorts by first data element in group
+    # sorts by first data element in group
     def self.sort_groups_by_start_time(de_groups)
       # sort by start date (in convert start_date equivalent to authorDatetime)
       de_groups.sort_by { |de_group| data_element_time(de_group.first) }
@@ -100,7 +100,7 @@ module Cypress
 
     def self.find_split_date(sorted_de_groups, effective_date, measure_period_start, random)
       # sorted_de = sort_by_start_time(patient.qdmPatient.dataElements)
-      sorted_de = sorted_de_groups.map{ |group| group.first }
+      sorted_de = sorted_de_groups.map(&:first)
       first_date = find_first_date_after(sorted_de, measure_period_start)
       last_date = find_last_date_before(sorted_de, effective_date)
       if first_date && last_date && (first_date != last_date)
@@ -123,23 +123,19 @@ module Cypress
       data_element_time(sorted_de.last)
     end
 
-    #find de with relate_to reference and group accordingly
-    #essentially identifies sets of data elements that are "connected"
-    #each list in the result is a different connected set
-    def self.find_relatedTo_de(data_elements)
+    # find de with relate_to reference and group accordingly
+    # essentially identifies sets of data elements that are "connected"
+    # each list in the result is a different connected set
+    def self.find_related_to_de(data_elements)
       grouped_de = []
-      added = data_elements.map {|de| false}
+      added = data_elements.map { |_de| false }
       data_elements.each_with_index do |de, index|
-        unless added[index]
-          grouped_de.push([de])
-          added[index] = true
-          #iterate through relatedTo and find each match in the data element list
-          if de.respond_to?(:relatedTo)
-            de.relatedTo.each do |related|
-              group_reference(related, grouped_de, data_elements, added)
-            end
-          end
-        end
+        next if added[index]
+
+        grouped_de.push([de])
+        added[index] = true
+        # iterate through relatedTo and find each match in the data element list
+        de.relatedTo.each { |related| group_reference(related, grouped_de, data_elements, added) } if de.respond_to?(:relatedTo)
       end
       grouped_de
     end
@@ -147,29 +143,28 @@ module Cypress
     def self.group_reference(related, grouped_de, data_elements, added)
       match_idx = data_elements.index { |x| x.id.value == related.value }
 
-      #if can't find reference
+      # if can't find reference
       return unless match_idx
-      #check if match has been added already
+
+      # check if match has been added already
       if added[match_idx]
-        #find match in grouped_de sublists (all but this *latest* one)
+        # find match in grouped_de sublists (all but this *latest* one)
         group_idx = grouped_de.index { |group| group.include?(data_elements[match_idx]) }
-        if(group_idx && group_idx < grouped_de.count-1)
-          #note: if in this (latest in grouped_de) sublist, there is a cycle
-          #pop entire sublist and add to sublist for latest in grouped_de
+        if group_idx && group_idx < grouped_de.count - 1
+          # note: if in this (latest in grouped_de) sublist, there is a cycle
+          # pop entire sublist and add to sublist for latest in grouped_de
           group = grouped_de.delete_at(group_idx)
           grouped_de.last.concat(group)
         end
 
       else
-        #add match to sublist for latest in grouped_de
+        # add match to sublist for latest in grouped_de
         grouped_de.last.push(data_elements[match_idx])
-        #update added
+        # update added
         added[match_idx] = true
-        #check match for relatedTo's and repeat for children
+        # check match for relatedTo's and repeat for children
         if data_elements[match_idx].respond_to?(:relatedTo)
-          data_elements[match_idx].relatedTo.each do |ref|
-            group_reference(ref, grouped_de, data_elements, added)
-          end
+          data_elements[match_idx].relatedTo.each { |ref| group_reference(ref, grouped_de, data_elements, added) }
         end
       end
     end

--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -14,17 +14,17 @@ module Cypress
       patient1 = patient.clone
       patient2 = patient.clone
 
-      # Find a date that splits the data_elements such that at least 1 is in each patient
-      split_date = find_split_date(patient, effective_date, measure_period_start, random)
+      non_pc_de = patient.qdmPatient.dataElements.reject{ |de| de.qdmCategory == 'patient_characteristic' }
+      sorted_de_groups = sort_groups_by_start_time(find_relatedTo_de(non_pc_de))
 
-      # Sort the data_elements from earliest to latest so we can split them more easily
-      data_elements = sort_by_start_time(patient.qdmPatient.dataElements)
+      # Find a date that splits the data_elements such that at least 1 is in each patient
+      split_date = find_split_date(sorted_de_groups, effective_date, measure_period_start, random)
 
       if split_date
-        patient1, patient2 = set_data_elements(data_elements, patient1, patient2, split_date)
+        patient1, patient2 = set_split_data_elements(sorted_de_groups, patient1, patient2, split_date)
       else
         # set all patient1 data elements
-        patient1.qdmPatient.dataElements = data_elements
+        patient1.qdmPatient.dataElements = patient.qdmPatient.dataElements
         patient2.qdmPatient.dataElements = []
       end
       patient1.qdmPatient.dataElements.concat patient_char_de
@@ -33,27 +33,30 @@ module Cypress
       [patient1, patient2]
     end
 
-    def self.set_data_elements(data_elements, patient1, patient2, split_date)
+    #note: also adds any related to elements, which may not be in the same date split
+    def self.set_split_data_elements(sorted_de_groups, patient1, patient2, split_date)
       patient1.qdmPatient.dataElements = []
       patient2.qdmPatient.dataElements = []
-      data_elements.take_while { |de| de_before_split_date(de, split_date) }.each do |de|
-        patient1.qdmPatient.dataElements.push de
+      sorted_de_groups.take_while { |group| de_before_date(group.first, split_date) }.each do |group|
+        patient1.qdmPatient.dataElements.concat group
       end
-      data_elements.drop_while { |de| de_before_split_date(de, split_date) }.each do |de|
-        patient2.qdmPatient.dataElements.push de
+      data_elements.drop_while { |group| de_before_date(group.first, split_date) }.each do |group|
+        patient2.qdmPatient.dataElements.concat group
       end
       [patient1, patient2]
     end
 
-    def self.de_before_split_date(de, split_date)
-      # R2P TODO: how to split patient characteristic data elements?
-      data_element_time(de) < split_date
+    def self.de_before_date(de, date)
+      data_element_time(de) < date
     end
 
     def self.split_by_type(patient, effective_date, measure_period_start, random)
-      # Collect unique data element categories from the patient with populated entries
-      de_categories = patient.qdmPatient.dataElements.collect(&:qdmCategory).uniq.shuffle(random: random)
-      de_categories.delete('patient_characteristic')
+      patient_char_de = patient.qdmPatient.get_data_elements('patient_characteristic')
+      non_pc_de = patient.qdmPatient.dataElements.reject{ |de| de.qdmCategory == 'patient_characteristic' }
+      de_groups = find_relatedTo_de(non_pc_de)
+
+      # Collect unique data element categories from each related group
+      de_categories = de_groups.map{ |group| group.first }.collect(&:qdmCategory).uniq.shuffle(random: random)
 
       # If there's only 1 data element category, split by date instead
       return split_by_date(patient, effective_date, measure_period_start, random) if de_categories.count < 2
@@ -64,29 +67,29 @@ module Cypress
       # Find a split point so each cloned patient gets at least one data element category (hence, at least one entry)
       split_point = random.rand(1..(de_categories.size - 1))
 
-      patient1 = set_patient_de_for_category(patient1, patient, de_categories, 0, split_point)
-      patient2 = set_patient_de_for_category(patient2, patient, de_categories, split_point, de_categories.size)
+      patient1.qdmPatient.dataElements = de_for_category(de_groups, de_categories, 0, split_point)
+      patient2.qdmPatient.dataElements = de_for_category(de_groups, de_categories, split_point, de_categories.size)
+
+      patient1.qdmPatient.dataElements.concat patient_char_de
+      patient2.qdmPatient.dataElements.concat patient_char_de
 
       [patient1, patient2]
     end
 
-    def self.set_patient_de_for_category(new_patient, old_patient, categories, start_point, end_point)
-      new_patient.qdmPatient.dataElements = []
+    #note: also adds any related to elements, which may not be the same category
+    def self.de_for_category(de_groups, categories, start_point, end_point)
+      data_elements = []
       categories[start_point...end_point].each do |cat|
-        old_cat_des = old_patient.qdmPatient.get_data_elements(cat)
-        old_cat_des.each { |de| new_patient.qdmPatient.dataElements.push de }
+        category_groups = de_groups.select{ |group| group.first.qdmCategory == cat}
+        data_elements.concat(category_groups.flatten)
       end
-      # always add patient characteristics
-      old_cat_des = old_patient.qdmPatient.get_data_elements('patient_characteristic')
-      old_cat_des.each { |de| new_patient.qdmPatient.dataElements.push de }
-      new_patient
+      data_elements
     end
 
-    def self.sort_by_start_time(data_elements)
-      data_elements.keep_if { |de| de.qdmCategory != 'patient_characteristic' }
-      # TODO: R2P: check there's an attribute reader for highClosed (and lowClosed)
+    #sorts by first data element in group
+    def self.sort_groups_by_start_time(de_groups)
       # sort by start date (in convert start_date equivalent to authorDatetime)
-      data_elements.sort_by { |de| data_element_time(de) }
+      de_groups.sort_by { |de_group| data_element_time(de_group.first) }
     end
 
     def self.data_element_time(data_element)
@@ -95,9 +98,9 @@ module Cypress
       return data_element.authorDatetime if data_element['authorDatetime']
     end
 
-    def self.find_split_date(patient, effective_date, measure_period_start, random)
-      sorted_de = sort_by_start_time(patient.qdmPatient.dataElements)
-
+    def self.find_split_date(sorted_de_groups, effective_date, measure_period_start, random)
+      # sorted_de = sort_by_start_time(patient.qdmPatient.dataElements)
+      sorted_de = sorted_de_groups.map{ |group| group.first }
       first_date = find_first_date_after(sorted_de, measure_period_start)
       last_date = find_last_date_before(sorted_de, effective_date)
       if first_date && last_date && (first_date != last_date)
@@ -118,6 +121,57 @@ module Cypress
         return data_element_time(des[0]) if data_element_time(des[1]) > date
       end
       data_element_time(sorted_de.last)
+    end
+
+    #find de with relate_to reference and group accordingly
+    #essentially identifies sets of data elements that are "connected"
+    #each list in the result is a different connected set
+    def self.find_relatedTo_de(data_elements)
+      grouped_de = []
+      added = data_elements.map {|de| false}
+      data_elements.each_with_index do |de, index|
+        unless added[index]
+          grouped_de.push([de])
+          added[index] = true
+          #iterate through relatedTo and find each match in the data element list
+          if de.respond_to?(:relatedTo)
+            de.relatedTo.each do |related|
+              group_reference(related, grouped_de, data_elements, added)
+            end
+          end
+        end
+      end
+      grouped_de
+    end
+
+    def self.group_reference(related, grouped_de, data_elements, added)
+      match_idx = data_elements.index { |x| x.id.value == related.value }
+
+      #if can't find reference
+      return unless match_idx
+      #check if match has been added already
+      if added[match_idx]
+        #find match in grouped_de sublists (all but this *latest* one)
+        group_idx = grouped_de.index { |group| group.include?(data_elements[match_idx]) }
+        if(group_idx && group_idx < grouped_de.count-1)
+          #note: if in this (latest in grouped_de) sublist, there is a cycle
+          #pop entire sublist and add to sublist for latest in grouped_de
+          group = grouped_de.delete_at(group_idx)
+          grouped_de.last.concat(group)
+        end
+
+      else
+        #add match to sublist for latest in grouped_de
+        grouped_de.last.push(data_elements[match_idx])
+        #update added
+        added[match_idx] = true
+        #check match for relatedTo's and repeat for children
+        if data_elements[match_idx].respond_to?(:relatedTo)
+          data_elements[match_idx].relatedTo.each do |ref|
+            group_reference(ref, grouped_de, data_elements, added)
+          end
+        end
+      end
     end
   end
 end

--- a/test/unit/lib/clinical_randomizer_test.rb
+++ b/test/unit/lib/clinical_randomizer_test.rb
@@ -40,12 +40,46 @@ class ClinicalRandomizerTest < ActiveSupport::TestCase
     @patient5.qdmPatient.dataElements.push QDM::EncounterPerformed.new(relevantPeriod: QDM::Interval.new(DateTime.new(2011, 4, 5, 10, 40, 0).utc, nil))
     @patient5.qdmPatient.dataElements.push QDM::PatientCharacteristicPayer.new(dataElementCodes: @payer_codes, relevantPeriod: QDM::Interval.new(@start, nil))
     @patient5.save!
+
+    @patient6 = BundlePatient.new(givenNames: ['SplitDate'], familyName: 'Related', bundleId: @bundle.id)
+    @patient6.qdmPatient.dataElements.push QDM::CommunicationPerformed.new(relatedTo: [QDM::Id.new(value: 'test_id')], relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 24, 20, 53, 20).utc, nil))
+    @patient6.qdmPatient.dataElements.push QDM::InterventionPerformed.new(id: QDM::Id.new(value: 'test_id'), relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
+    @patient6.qdmPatient.dataElements.push QDM::PatientCharacteristicPayer.new(dataElementCodes: @payer_codes, relevantPeriod: QDM::Interval.new(@start, nil))
+    @patient6.save!
+
+    @patient7 = BundlePatient.new(givenNames: ['SplitDate'], familyName: 'Reversed', bundleId: @bundle.id)
+    @patient7.qdmPatient.dataElements.push QDM::CommunicationPerformed.new(relatedTo: [QDM::Id.new(value: 'test_id')], relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 31, 23, 59, 59).utc, nil))
+    @patient7.qdmPatient.dataElements.push QDM::InterventionPerformed.new(id: QDM::Id.new(value: 'test_id'), relevantPeriod: QDM::Interval.new(DateTime.new(2011, 3, 24, 20, 53, 20).utc, nil))
+    @patient7.qdmPatient.dataElements.push QDM::PatientCharacteristicPayer.new(dataElementCodes: @payer_codes, relevantPeriod: QDM::Interval.new(@start, nil))
+    @patient7.save!
   end
 
   def test_split_by_date
-    date = Cypress::ClinicalRandomizer.find_split_date(@patient, @end, @start, Random.new)
+    sorted_de_groups = @patient.qdmPatient.dataElements.map { |de| [de] }
+    date = Cypress::ClinicalRandomizer.find_split_date(sorted_de_groups, @end, @start, Random.new)
     assert date > @start, 'Split date must be during the measurement period'
     assert date < @end, 'Split date must be before the effective date'
+  end
+
+  def test_randomize_by_date_related
+    r1, r2 = Cypress::ClinicalRandomizer.split_by_date(@patient6, @end, @start, Random.new)
+
+    assert_equal r1.qdmPatient.dataElements.length, 3, 'First split record should 3 entries because entries should not be split'
+    assert_equal r2.qdmPatient.dataElements.length, 1, 'Second split record should 1 entry for the patient characteristic payer'
+  end
+
+  def test_randomize_by_date_reversed_related
+    r1, r2 = Cypress::ClinicalRandomizer.split_by_date(@patient7, @end, @start, Random.new)
+
+    assert_equal r1.qdmPatient.dataElements.length, 3, 'First split record should 3 entries because entries should not be split'
+    assert_equal r2.qdmPatient.dataElements.length, 1, 'Second split record should 1 entry for the patient characteristic payer'
+  end
+
+  def test_randomize_by_type_related
+    r1, r2 = Cypress::ClinicalRandomizer.split_by_type(@patient6, @end, @start, Random.new)
+
+    assert_equal r1.qdmPatient.dataElements.length, 3, 'First split record should 3 entries because entries should not be split'
+    assert_equal r2.qdmPatient.dataElements.length, 1, 'Second split record should 1 entry for the patient characteristic payer'
   end
 
   def test_randomize_by_date
@@ -97,7 +131,6 @@ class ClinicalRandomizerTest < ActiveSupport::TestCase
 
   def test_entries_on_split_date
     record1, record2 = Cypress::ClinicalRandomizer.split_by_date(@patient4, @end, @start, Random.new)
-
     assert_equal 3, record1.qdmPatient.dataElements.length, 'Record should have both entries (and a payer)'
     assert_equal 1, record2.qdmPatient.dataElements.length, 'Second record should not have entries (other than payer)'
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-577
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code