### PR TITLE
Add api evaluator as a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,14 +38,14 @@ env:
   matrix:
   - TEST_SUITE=integration
   - TEST_SUITE=cucumber-product-tests
-  - TEST_SUITE=cucumber-product-vendor
   - TEST_SUITE=cucumber-admin-users
   - TEST_SUITE=cucumber-record
+  - TEST_SUITE=cucumber-product-vendor
   - TEST_SUITE=audit
+  - TEST_SUITE=units
   - TEST_SUITE=controllers
   - TEST_SUITE=helpers
   - TEST_SUITE=jobs
-  - TEST_SUITE=units
 script:
   - 'if [ ${TEST_SUITE} = "cucumber-admin-users" ]; then
       bundle exec cucumber features/admin/;

--- a/Gemfile
+++ b/Gemfile
@@ -137,6 +137,8 @@ group :test do
   gem 'minitest-reporters'
   gem 'mocha', require: false
   gem 'simplecov', require: false
+  gem 'vcr'
+  gem 'webmock'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
-    cqm-models (2.0.0)
+    cqm-models (2.0.1)
     cqm-parsers (2.0.1)
       activesupport (~> 5.0)
       builder (~> 3.1)
@@ -154,6 +154,8 @@ GEM
       zip-zip (~> 0.3)
     cqm-validators (2.0.1)
       nokogiri (~> 1.10.3)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.5)
     cucumber (3.0.2)
       builder (>= 2.1.2)
@@ -223,6 +225,7 @@ GEM
     gherkin (4.1.3)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.0)
     highline (1.7.10)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -419,6 +422,7 @@ GEM
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
+    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -482,6 +486,7 @@ GEM
     url (0.3.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
+    vcr (5.0.0)
     virtus (1.0.5)
       axiom-types (~> 0.1)
       coercible (~> 1.0)
@@ -495,6 +500,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webmock (3.7.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -578,8 +587,10 @@ DEPENDENCIES
   turbolinks!
   uglifier (>= 1.3.0)
   unicorn-rails
+  vcr
   vmstat
   web-console (~> 3.7.0)
+  webmock
 
 RUBY VERSION
    ruby 2.6.3p62

--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -72,7 +72,11 @@ module Cypress
         new_ir.save
         new_ir.patient.update_measure_relevance_hash(new_ir)
         new_ir.patient.save
-        tracker.log("Calculating (#{((index.to_f / total_count) * 100).to_i}% complete) ")
+        next unless (index % 100).zero?
+
+        log_message = "Calculating (#{((index.to_f / total_count) * 100).to_i}% complete) "
+        tracker.log(log_message)
+        puts "\r#{log_message}"
       end
     end
 

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -18,7 +18,7 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
   def retrieve_bundle
     VCR.use_cassette('bundle_download') do
       bundle_resource = RestClient::Request.execute(method: :get,
-                                                    url: 'https://cypress.healthit.gov/measure_bundles/test-bundle.zip',
+                                                    url: 'https://cypress.healthit.gov/measure_bundles/bundle-2019.1.0.zip',
                                                     user: ENV['VSAC_USERNAME'],
                                                     password: ENV['VSAC_PASSWORD'],
                                                     raw_response: true,

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -1,0 +1,173 @@
+require 'test_helper'
+require 'vcr_setup.rb'
+
+class ApiMeasureEvaluatorTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+  include ActiveJob::TestHelper
+
+  # def setup
+  #   @vcr_options = {match_requests_on: [:method, :uri_no_st]}
+  # end
+
+  def test_complete_roundtrip_using_real_bundle
+    bundle_id = nil
+    measure_ids = []
+    FactoryBot.create(:admin_user)
+    @controller = ProductsController.new
+    for_each_logged_in_user([ADMIN]) do
+      perform_enqueued_jobs do
+        bundle_id = Cypress::CqlBundleImporter.import(import_bundle, Tracker.new, false).id.to_s
+        measure_ids = Measure.distinct(:hqmf_id).sample(10)
+        vendor = Vendor.find_or_create_by(name: 'MeasureEvaluationVendor')
+        post :create, params: { vendor_id: vendor.id, product: { name: 'MeasureEvaluationProduct', bundle_id: bundle_id, c1_test: true, c2_test: true, c3_test: true, c4_test: true, duplicate_patients: false, randomize_patients: true, measure_ids: measure_ids } }
+      end
+    end
+    product = Product.all.first
+    checklist_test = product.product_tests.build({ name: 'record sample test', measure_ids: measure_ids[0, 1] }, ChecklistTest)
+    product.save!
+    checklist_test.tasks.create!({}, C1ChecklistTask)
+    apime = Cypress::ApiMeasureEvaluator.new('test', 'test')
+    first_filter_test = FilteringTest.all.first
+    File.open('tmp/filter_patients.zip', 'wb') do |output|
+      output.write(first_filter_test.patient_archive.read)
+    end
+    sampled_filtering_tests = FilteringTest.all.sample(2)
+    sampled_filtering_tests.each do |ft|
+      product_test_hash = {}
+      for_each_logged_in_user([ADMIN]) do
+        @controller = ProductTestsController.new
+        get :show, params: { format: :json, product_id: ft.product.id, id: ft.id }
+        product_test_hash = JSON.parse(response.body)
+      end
+      file_name = "#{ft.id}.zip".tr(' ', '_')
+      Zip::ZipFile.open('tmp/filter_patients.zip') do |zipfile|
+        zipfile.entries.each do |entry|
+          doc = Nokogiri::XML(zipfile.read(entry))
+          doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+          doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+          next unless apime.filter_out_patients(doc, product_test_hash)
+
+          Zip::ZipFile.open("tmp/#{file_name}", Zip::File::CREATE) do |z|
+            z.get_output_stream(entry) { |f| f.puts zipfile.read(entry) }
+          end
+        end
+      end
+    end
+    sampled_filtering_tests.each do |ft|
+      @controller = TestExecutionsController.new
+      perform_enqueued_jobs do
+        for_each_logged_in_user([ADMIN]) do
+          cat_1_task = ft.tasks.where(_type: 'Cat1FilterTask').first
+          cat_3_task = ft.tasks.where(_type: 'Cat3FilterTask').first
+          calcuate_cat_3(ft, bundle_id)
+          post :create, params: { task_id: cat_1_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{ft.id}_only_ipp.zip"), 'application/zip') }
+          post :create, params: { task_id: cat_3_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{ft.id}.xml"), 'application/xml') }
+          File.delete("tmp/#{ft.id}_only_ipp.zip")
+          File.delete("tmp/#{ft.id}.zip")
+          File.delete("tmp/#{ft.id}.xml")
+        end
+      end
+    end
+    File.delete('tmp/filter_patients.zip')
+    MeasureTest.each do |mt|
+      @controller = TestExecutionsController.new
+      perform_enqueued_jobs do
+        for_each_logged_in_user([ADMIN]) do
+          cat_1_task = mt.tasks.where(_type: 'C1Task').first
+          cat_3_task = mt.tasks.where(_type: 'C2Task').first
+          file_name = "#{mt.id}.zip".tr(' ', '_')
+          File.open("tmp/#{file_name}", 'wb') do |output|
+            output.write(mt.patient_archive.read)
+          end
+          calcuate_cat_3(mt, bundle_id)
+          post :create, params: { task_id: cat_1_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{mt.id}_only_ipp.zip"), 'application/zip') }
+          post :create, params: { task_id: cat_3_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{mt.id}.xml"), 'application/xml') }
+          File.delete("tmp/#{mt.id}_only_ipp.zip")
+          File.delete("tmp/#{mt.id}.zip")
+          File.delete("tmp/#{mt.id}.xml")
+        end
+      end
+    end
+    assert_equal 0, TestExecution.where(state: 'failed').size
+  end
+
+  def calcuate_cat_3(product_test, bundle_id)
+    patient_id_file_map = {}
+
+    correlation_id = "#{product_test.id}_u"
+
+    import_cat1_zip(File.new("tmp/#{product_test.id}.zip"), patient_id_file_map, bundle_id)
+    do_calculation_cqm_execution(product_test, Patient.find(patient_id_file_map.values), correlation_id)
+
+    erc = Cypress::ExpectedResultsCalculator.new(Patient.find(patient_id_file_map.values), correlation_id, product_test.effective_date)
+    results = erc.aggregate_results_for_measures(product_test.measures)
+
+    cms_compatibility = product_test&.product&.c3_test
+    options = { provider: product_test.patients.first.providers.first, submission_program: cms_compatibility,
+                start_time: product_test.start_date, end_time: product_test.end_date }
+    xml = Qrda3R21.new(results, product_test.measures, options).render
+
+    Zip::ZipFile.open("tmp/#{product_test.id}.zip") do |zipfile|
+      zipfile.entries.each do |entry|
+        doc = Nokogiri::XML(zipfile.read(entry))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        next unless CQM::IndividualResult.where(patient_id: patient_id_file_map[entry.name]).size.positive?
+
+        Zip::ZipFile.open("tmp/#{product_test.id}_only_ipp.zip", Zip::File::CREATE) do |z|
+          z.get_output_stream(entry) { |f| f.puts zipfile.read(entry) }
+        end
+      end
+    end
+
+    Patient.find(patient_id_file_map.values).each(&:destroy)
+
+    File.write("tmp/#{product_test.id}.xml", xml)
+  end
+
+  def do_calculation_cqm_execution(product_test, patients, correlation_id)
+    measures = product_test.measures
+    calc_job = Cypress::CqmExecutionCalc.new(patients.map(&:qdmPatient), measures, correlation_id,
+                                             effectiveDateEnd: Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
+                                             effectiveDate: Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
+    calc_job.execute
+  end
+
+  def import_cat1_zip(zip, patient_id_file_map, bundle_id)
+    Zip::ZipFile.open(zip.path) do |zip_file|
+      zip_file.entries.each do |entry|
+        doc = build_document(zip_file.read(entry))
+        patient_id = import_cat1_file(doc, bundle_id)
+        patient_id_file_map[entry.name] = patient_id
+      end
+    end
+  end
+
+  def build_document(document)
+    doc = document.is_a?(Nokogiri::XML::Document) ? document : Nokogiri::XML(document.to_s)
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+    doc
+  end
+
+  def import_cat1_file(doc, bundle_id)
+    patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+    Cypress::QRDAPostProcessor.replace_negated_codes(patient, Bundle.find(bundle_id))
+    patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval')
+    patient.save!
+    patient.id
+  end
+
+  def import_bundle
+    VCR.use_cassette('bundle_download') do
+      bundle_resource = RestClient::Request.execute(method: :get,
+                                                    url: 'https://cypress.healthit.gov/measure_bundles/test-bundle.zip',
+                                                    user: ENV['VSAC_USERNAME'],
+                                                    password: ENV['VSAC_PASSWORD'],
+                                                    raw_response: true,
+                                                    headers: { accept: :zip })
+
+      return bundle_resource.file
+    end
+  end
+end

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -5,99 +5,117 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
   include ActiveJob::TestHelper
 
-  # def setup
-  #   @vcr_options = {match_requests_on: [:method, :uri_no_st]}
-  # end
-
   def test_complete_roundtrip_using_real_bundle
-    bundle_id = nil
-    measure_ids = []
-    FactoryBot.create(:admin_user)
-    @controller = ProductsController.new
-    for_each_logged_in_user([ADMIN]) do
-      perform_enqueued_jobs do
-        bundle_id = Cypress::CqlBundleImporter.import(import_bundle, Tracker.new, false).id.to_s
-        measure_ids = Measure.distinct(:hqmf_id).sample(10)
-        vendor = Vendor.find_or_create_by(name: 'MeasureEvaluationVendor')
-        post :create, params: { vendor_id: vendor.id, product: { name: 'MeasureEvaluationProduct', bundle_id: bundle_id, c1_test: true, c2_test: true, c3_test: true, c4_test: true, duplicate_patients: false, randomize_patients: true, measure_ids: measure_ids } }
-      end
-    end
-    product = Product.all.first
-    checklist_test = product.product_tests.build({ name: 'record sample test', measure_ids: measure_ids[0, 1] }, ChecklistTest)
-    product.save!
-    checklist_test.tasks.create!({}, C1ChecklistTask)
-    apime = Cypress::ApiMeasureEvaluator.new('test', 'test')
-    first_filter_test = FilteringTest.all.first
-    File.open('tmp/filter_patients.zip', 'wb') do |output|
-      output.write(first_filter_test.patient_archive.read)
-    end
-    sampled_filtering_tests = FilteringTest.all.sample(2)
-    sampled_filtering_tests.each do |ft|
-      product_test_hash = {}
-      for_each_logged_in_user([ADMIN]) do
-        @controller = ProductTestsController.new
-        get :show, params: { format: :json, product_id: ft.product.id, id: ft.id }
-        product_test_hash = JSON.parse(response.body)
-      end
-      file_name = "#{ft.id}.zip".tr(' ', '_')
-      Zip::ZipFile.open('tmp/filter_patients.zip') do |zipfile|
-        zipfile.entries.each do |entry|
-          doc = Nokogiri::XML(zipfile.read(entry))
-          doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-          doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-          next unless apime.filter_out_patients(doc, product_test_hash)
-
-          Zip::ZipFile.open("tmp/#{file_name}", Zip::File::CREATE) do |z|
-            z.get_output_stream(entry) { |f| f.puts zipfile.read(entry) }
-          end
-        end
-      end
-    end
-    sampled_filtering_tests.each do |ft|
-      @controller = TestExecutionsController.new
-      perform_enqueued_jobs do
-        for_each_logged_in_user([ADMIN]) do
-          cat_1_task = ft.tasks.where(_type: 'Cat1FilterTask').first
-          cat_3_task = ft.tasks.where(_type: 'Cat3FilterTask').first
-          calcuate_cat_3(ft, bundle_id)
-          post :create, params: { task_id: cat_1_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{ft.id}_only_ipp.zip"), 'application/zip') }
-          post :create, params: { task_id: cat_3_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{ft.id}.xml"), 'application/xml') }
-          File.delete("tmp/#{ft.id}_only_ipp.zip")
-          File.delete("tmp/#{ft.id}.zip")
-          File.delete("tmp/#{ft.id}.xml")
-        end
-      end
-    end
-    File.delete('tmp/filter_patients.zip')
-    MeasureTest.each do |mt|
-      @controller = TestExecutionsController.new
-      perform_enqueued_jobs do
-        for_each_logged_in_user([ADMIN]) do
-          cat_1_task = mt.tasks.where(_type: 'C1Task').first
-          cat_3_task = mt.tasks.where(_type: 'C2Task').first
-          file_name = "#{mt.id}.zip".tr(' ', '_')
-          File.open("tmp/#{file_name}", 'wb') do |output|
-            output.write(mt.patient_archive.read)
-          end
-          calcuate_cat_3(mt, bundle_id)
-          post :create, params: { task_id: cat_1_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{mt.id}_only_ipp.zip"), 'application/zip') }
-          post :create, params: { task_id: cat_3_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{mt.id}.xml"), 'application/xml') }
-          File.delete("tmp/#{mt.id}_only_ipp.zip")
-          File.delete("tmp/#{mt.id}.zip")
-          File.delete("tmp/#{mt.id}.xml")
-        end
-      end
-    end
+    @apime = Cypress::ApiMeasureEvaluator.new('test', 'test')
+    import_bundle_and_create_product(retrieve_bundle)
+    perform_filtering_tests
+    perform_measure_tests
     assert_equal 0, TestExecution.where(state: 'failed').size
   end
 
-  def calcuate_cat_3(product_test, bundle_id)
+  def retrieve_bundle
+    VCR.use_cassette('bundle_download') do
+      bundle_resource = RestClient::Request.execute(method: :get,
+                                                    url: 'https://cypress.healthit.gov/measure_bundles/test-bundle.zip',
+                                                    user: ENV['VSAC_USERNAME'],
+                                                    password: ENV['VSAC_PASSWORD'],
+                                                    raw_response: true,
+                                                    headers: { accept: :zip })
+
+      return bundle_resource.file
+    end
+  end
+
+  def import_bundle_and_create_product(bundle_zip)
+    # Create admin user
+    FactoryBot.create(:admin_user)
+    # Set controller to products controller
+    @controller = ProductsController.new
+    # As the Admin user, use the Products controller to create a product with C1/C2/C3 and C4 tests for 10 random measures
+    for_each_logged_in_user([ADMIN]) do
+      perform_enqueued_jobs do
+        # Import the bundle
+        @bundle = Cypress::CqlBundleImporter.import(bundle_zip, Tracker.new, false)
+        # Pick out 10 random measures
+        measure_ids = @bundle.measures.distinct(:hqmf_id).sample(10)
+        @vendor = Vendor.find_or_create_by(name: 'MeasureEvaluationVendor')
+        post :create, params: { vendor_id: @vendor.id, product: { name: 'MeasureEvaluationProduct', bundle_id: @bundle.id.to_s, c1_test: true, c2_test: true, c3_test: true, c4_test: true, duplicate_patients: false, randomize_patients: true, measure_ids: measure_ids } }
+      end
+    end
+    @product = Product.where(name: 'MeasureEvaluationProduct').first
+  end
+
+  def perform_filtering_tests
+    filtering_tests = @product.product_tests.filtering_tests
+    # Save the Filter Test Deck
+    File.open('tmp/filter_patients.zip', 'wb') do |output|
+      output.write(filtering_tests.first.patient_archive.read)
+    end
+    sampled_filtering_tests = filtering_tests.sample(2)
+    # Test 2 out of the 5 filtering tests
+    sampled_filtering_tests.each do |ft|
+      # Since were are leveraging the ApiMeasureEvaluator, it uses JSON returned from the API to find filter criteria, stored as filter_test_json
+      filter_test_parameters = {}
+      for_each_logged_in_user([ADMIN]) do
+        @controller = ProductTestsController.new
+        get :show, params: { format: :json, product_id: ft.product.id, id: ft.id }
+        filter_test_parameters = JSON.parse(response.body)
+      end
+      created_filtered_uploads(filter_test_parameters, ft)
+    end
+    sampled_filtering_tests.each do |ft|
+      upload_test_artifacts('Cat1FilterTask', 'Cat3FilterTask', ft)
+      delete_test_zip_files(ft)
+    end
+    File.delete('tmp/filter_patients.zip')
+  end
+
+  def created_filtered_uploads(filter_test_parameters, filter_test)
+    # Loop through filter test
+    Zip::ZipFile.open('tmp/filter_patients.zip') do |zipfile|
+      zipfile.entries.each do |entry|
+        doc = Nokogiri::XML(zipfile.read(entry))
+        doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+        next unless @apime.filter_out_patients(doc, filter_test_parameters)
+
+        Zip::ZipFile.open("tmp/#{filter_test.id}.zip", Zip::File::CREATE) do |z|
+          z.get_output_stream(entry) { |f| f.puts zipfile.read(entry) }
+        end
+      end
+    end
+  end
+
+  def perform_measure_tests
+    @product.product_tests.measure_tests.each do |mt|
+      File.open("tmp/#{mt.id}.zip", 'wb') do |output|
+        output.write(mt.patient_archive.read)
+      end
+      upload_test_artifacts('C1Task', 'C2Task', mt)
+      delete_test_zip_files(mt)
+    end
+  end
+
+  def upload_test_artifacts(cat_1_task_type, cat_3_task_type, product_test)
+    @controller = TestExecutionsController.new
+    perform_enqueued_jobs do
+      for_each_logged_in_user([ADMIN]) do
+        cat_1_task = product_test.tasks.where(_type: cat_1_task_type).first
+        cat_3_task = product_test.tasks.where(_type: cat_3_task_type).first
+        calcuate_and_create_test_uploads(product_test)
+        post :create, params: { task_id: cat_1_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{product_test.id}_only_ipp.zip"), 'application/zip') }
+        post :create, params: { task_id: cat_3_task.id, results: Rack::Test::UploadedFile.new(File.new("tmp/#{product_test.id}.xml"), 'application/xml') }
+      end
+    end
+  end
+
+  def calcuate_and_create_test_uploads(product_test)
     patient_id_file_map = {}
 
     correlation_id = "#{product_test.id}_u"
 
-    import_cat1_zip(File.new("tmp/#{product_test.id}.zip"), patient_id_file_map, bundle_id)
-    do_calculation_cqm_execution(product_test, Patient.find(patient_id_file_map.values), correlation_id)
+    import_cat1_zip(File.new("tmp/#{product_test.id}.zip"), patient_id_file_map)
+    @apime.do_calculation_cqm_execution(product_test, Patient.find(patient_id_file_map.values), correlation_id)
 
     erc = Cypress::ExpectedResultsCalculator.new(Patient.find(patient_id_file_map.values), correlation_id, product_test.effective_date)
     results = erc.aggregate_results_for_measures(product_test.measures)
@@ -125,49 +143,27 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
     File.write("tmp/#{product_test.id}.xml", xml)
   end
 
-  def do_calculation_cqm_execution(product_test, patients, correlation_id)
-    measures = product_test.measures
-    calc_job = Cypress::CqmExecutionCalc.new(patients.map(&:qdmPatient), measures, correlation_id,
-                                             effectiveDateEnd: Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
-                                             effectiveDate: Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
-    calc_job.execute
-  end
-
-  def import_cat1_zip(zip, patient_id_file_map, bundle_id)
+  def import_cat1_zip(zip, patient_id_file_map)
     Zip::ZipFile.open(zip.path) do |zip_file|
       zip_file.entries.each do |entry|
-        doc = build_document(zip_file.read(entry))
-        patient_id = import_cat1_file(doc, bundle_id)
+        doc = @apime.build_document(zip_file.read(entry))
+        patient_id = import_cat1_file(doc)
         patient_id_file_map[entry.name] = patient_id
       end
     end
   end
 
-  def build_document(document)
-    doc = document.is_a?(Nokogiri::XML::Document) ? document : Nokogiri::XML(document.to_s)
-    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
-    doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-    doc
-  end
-
-  def import_cat1_file(doc, bundle_id)
+  def import_cat1_file(doc)
     patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-    Cypress::QRDAPostProcessor.replace_negated_codes(patient, Bundle.find(bundle_id))
+    Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
     patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval')
     patient.save!
     patient.id
   end
 
-  def import_bundle
-    VCR.use_cassette('bundle_download') do
-      bundle_resource = RestClient::Request.execute(method: :get,
-                                                    url: 'https://cypress.healthit.gov/measure_bundles/test-bundle.zip',
-                                                    user: ENV['VSAC_USERNAME'],
-                                                    password: ENV['VSAC_PASSWORD'],
-                                                    raw_response: true,
-                                                    headers: { accept: :zip })
-
-      return bundle_resource.file
-    end
+  def delete_test_zip_files(test)
+    File.delete("tmp/#{test.id}_only_ipp.zip")
+    File.delete("tmp/#{test.id}.zip")
+    File.delete("tmp/#{test.id}.xml")
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ require 'minitest/autorun'
 require 'minitest/reporters'
 require 'mocha/setup'
 
-Minitest::Reporters.use!
+Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 # comment the previous line and uncomment the next one for test-by-test details
 # Minitest::Reporters.use! [Minitest::Reporters::SpecReporter.new]
 

--- a/test/vcr_setup.rb
+++ b/test/vcr_setup.rb
@@ -1,0 +1,22 @@
+require 'vcr'
+require 'webmock/minitest'
+
+# VCR records HTTP interactions to cassettes that can be replayed during unit tests
+# allowing for faster, more predictible web interactions
+VCR.configure do |c|
+  # This is where the various cassettes will be recorded to
+  c.cassette_library_dir = 'test/fixtures/vcr_cassettes'
+  c.hook_into :webmock
+  c.ignore_localhost = true
+
+  # To avoid storing plain text VSAC credentials or requiring the VSAC credentials
+  # be provided at every run of the rake tests, provide the VSAC_USERNAME and VSAC_PASSWORD
+  # whenever you need to record a cassette that requires valid credentials
+  ENV['VSAC_USERNAME'] = 'vcrtest' unless ENV['VSAC_USERNAME']
+  ENV['VSAC_PASSWORD'] = 'vcrpass' unless ENV['VSAC_PASSWORD']
+
+  # Ensure plain text passwords do not show up during logging
+  c.filter_sensitive_data('<VSAC_USERNAME>') { ENV['VSAC_USERNAME'] }
+  c.filter_sensitive_data('<VSAC_PASSWORD>') { URI.encode_www_form_component(ENV['VSAC_PASSWORD']) }
+  c.default_cassette_options = { record: :once }
+end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code