### PR TITLE
Name Randomizer can crash if last name had be replaced with initial t…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,22 +30,37 @@ before_script:
   - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB}.tgz -O /tmp/mongodb.tgz
   - tar -xvf /tmp/mongodb.tgz
   - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
+  - ${PWD}/mongodb-linux-x86_64-${MONGODB}/bin/mongod --setParameter cursorTimeoutMillis=3600000 --setParameter maxBSONDepth=500 --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
   - cp ./.travis/mongoid.yml ./config/mongoid.yml
 env:
   global:
     - MONGODB=3.4.5
   matrix:
-  - TEST_SUITE=cucumber
+  - TEST_SUITE=integration
+  - TEST_SUITE=cucumber-product-tests
+  - TEST_SUITE=cucumber-product-vendor
+  - TEST_SUITE=cucumber-admin-users
+  - TEST_SUITE=cucumber-record
   - TEST_SUITE=audit
-  - TEST_SUITE=models
   - TEST_SUITE=controllers
   - TEST_SUITE=helpers
   - TEST_SUITE=jobs
   - TEST_SUITE=units
 script:
-  - 'if [ ${TEST_SUITE} = "cucumber" ]; then
-      bundle exec cucumber;
+  - 'if [ ${TEST_SUITE} = "cucumber-admin-users" ]; then
+      bundle exec cucumber features/admin/;
+      bundle exec cucumber features/users/;
+    elif [ ${TEST_SUITE} = "cucumber-product-vendor" ]; then
+      bundle exec cucumber features/products/;
+      bundle exec cucumber features/vendors/;
+    elif [ ${TEST_SUITE} = "cucumber-record" ]; then
+      bundle exec cucumber features/records/;
+    elif [ ${TEST_SUITE} = "cucumber-product-tests" ]; then
+      bundle exec cucumber features/checklist_tests/;
+      bundle exec cucumber features/filtering_tests/;
+      bundle exec cucumber features/measure_tests/;
+      bundle exec cucumber features/multi_measure_tests/;
+      bundle exec cucumber features/program_tests/;
     elif [ ${TEST_SUITE} = "audit" ]; then
       bundle exec bundle-audit check --update &&
       bundle exec overcommit --sign &&

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -3,8 +3,9 @@ module Cypress
     def self.randomize_patient_name_first(patient, augmented_patients, random: Random.new)
       patients = patient.product_test ? patient.product_test.patients : []
       original_given_name = patient.givenNames
-      new_given_name = original_given_name.clone
       loop do
+        # Each time, start with original name
+        new_given_name = original_given_name.clone
         # Try to create a new random name
         new_given_name = random_given_name(patient, original_given_name, random: random)
         # Verify that the new random name, does not conflict with an existing Augmented Patient
@@ -35,8 +36,9 @@ module Cypress
     def self.randomize_patient_name_last(patient, augmented_patients, random: Random.new)
       patients = patient.product_test ? patient.product_test.patients : []
       original_family_name = patient.familyName
-      new_family_name = original_family_name.clone
       loop do
+        # Each time, start with original name
+        new_family_name = original_family_name.clone
         # Try to create a new random name
         case random.rand(2)
         when 0 then new_family_name = patient.familyName[0] # replace with initial

--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -7,7 +7,7 @@ module Cypress
         # Each time, start with original name
         new_given_name = original_given_name.clone
         # Try to create a new random name
-        new_given_name = random_given_name(patient, original_given_name, random: random)
+        new_given_name = random_given_name(patient, new_given_name, random: random)
         # Verify that the new random name, does not conflict with an existing Augmented Patient
         patient.givenNames = new_given_name if name_unique?(new_given_name, patient.familyName, patients, augmented_patients)
         # Break when a new unique name is found


### PR DESCRIPTION
…… (#1253)

* Name Randomizer can crash if last name had be replaced with initial that was not unique

* break up cucumber

* do it with the first name too

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code