### PR TITLE
add table of error messages for cat III

### DIFF
--- a/app/views/products/report/_failing_measure_tests.html.erb
+++ b/app/views/products/report/_failing_measure_tests.html.erb
@@ -31,7 +31,26 @@
     </strong>
     <ul>
       <% execution = c3 ? task.most_recent_execution.sibling_execution : task.most_recent_execution %>
-      <% execution.execution_errors.each do |err| %>
+      <% errors = execution.execution_errors %>
+      <!-- C2 Tasks have complex error messages for population/demographic errors -->
+      <% if task.is_a? C2Task
+        collected_errors = collected_errors(execution)
+        collected_errors.files.each do |file_name, error_result| %>
+          <% error_result.each do |error_type, error_hash| %>
+            <% message_title = error_type == 'Other Warnings' || error_type == 'CMS Warnings' ? 'Warning' : 'Error' %>
+            <% if error_type == "Reporting" %>
+              <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
+              <% pop_errors = population_data_errors(error_hash.execution_errors - report_sup_data_errors, 'population') %>
+              <% pop_sum_errors = population_data_errors(error_hash.execution_errors - pop_errors, 'population_sum') %>
+              <% non_pop_errors = error_hash.execution_errors - report_sup_data_errors - pop_errors - pop_sum_errors %>
+              <% errors = errors - report_sup_data_errors - pop_errors - pop_sum_errors - non_pop_errors %>
+              <%= render partial: 'test_executions/results/error_table', locals: { errors: non_pop_errors, message_title: message_title } %>
+              <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors + pop_errors + pop_sum_errors, pop_errors_hash: population_error_hash(pop_errors + pop_sum_errors, report_sup_data_errors) } %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% end %>
+      <% errors.each do |err| %>
         <li>
           <%= err.message %>
           <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>

--- a/test/factories/execution_error.rb
+++ b/test/factories/execution_error.rb
@@ -1,0 +1,350 @@
+FactoryBot.define do
+  factory :execution_error, class: ExecutionError do
+    test_execution
+
+    after(:build) do |ee|
+      ee[:validator_type] = ee.validation_type
+    end
+
+    factory :calculating_smoking_gun_validator do
+      msg_type { 'error' }
+      validation_type { 'result_validation' }
+      validator { 'Validators::CalculatingSmokingGunValidator' }
+      cms { false }
+
+      trait :compare_results do
+        message { 'Calculated value (0) for IPP (78A9F833-07AA-448F-B94F-B2C4D8BF4F3F) does not match expected value (1)' }
+      end
+
+      factory :calculating_smoking_gun_validator_compare_results, traits: [:compare_results]
+    end
+
+    factory :cat3_population_validator do
+      msg_type { 'error' }
+      validator { 'Validators::Cat3PopulationValidator' }
+      validation_type { 'result_validation' }
+      location { '/' }
+      cms { false }
+
+      trait :validate_populations do
+        message { 'Denominator value 2 is greater than Initial Population value 0 for measure d9c50230-f1c5-0137-ffa9-2cde48001122' }
+      end
+
+      factory :cat3_population_validator_validate_populations, traits: [:validate_populations]
+    end
+
+    factory :checklist_test do
+      msg_type { 'error' }
+      validator { 'qrda_cat1' }
+      cms { false }
+
+      trait :build_execution_errors_for_incomplete_checked_criteria do
+        message { 'CMS159v8 - patient_characteristic, expired not complete' }
+      end
+
+      factory :checklist_test_build_execution_errors_for_incomplete_checked_criteria, traits: [:build_execution_errors_for_incomplete_checked_criteria]
+    end
+
+    factory :cms_population_count_validator do
+      msg_type { 'error' }
+      validator { 'Validators::CMSPopulationCountValidator' }
+      validation_type { 'result_validation' }
+      cms { false }
+
+      trait :verify_all_codes_reported do
+        message { 'For CMS eligible clinicians and eligible professionals programs, all PAYER codes present in the value set must be reported,even if the count is zero. If an eCQM is episode-based, the count will reflect the patient count rather than the episode count.' }
+      end
+
+      factory :cms_population_count_validator_verify_all_codes_reported, traits: [:verify_all_codes_reported]
+    end
+
+    factory :cms_program_test do
+      msg_type { 'error' }
+      validator { 'Validators::ProgramCriteriaValidator' }
+      cms { false }
+
+      trait :build_execution_errors_for_incomplete_cms_criteria do
+        message { 'Tax Identification Number not complete' }
+      end
+
+      factory :cms_program_test_build_execution_errors_for_incomplete_cms_criteria, traits: [:build_execution_errors_for_incomplete_cms_criteria]
+    end
+
+    factory :cms_schematron_validator do
+      msg_type { 'error' }
+      validator { 'Validators::CMSQRDA3SchematronValidator' }
+      validation_type { 'xml_validation' }
+      location { '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]' }
+      cms { false }
+
+      trait :validate do
+        message { 'SHALL contain exactly one [1..1] templateId (CONF:CMS_1) such that it SHALL contain exactly one [1..1] @root=\"2.16.840.1.113883.10.20.27.1.2\" (CONF:CMS_2).SHALL contain exactly one [1..1] @extension=\"2019-05-01\" (CONF:CMS_3).' }
+      end
+
+      factory :cms_schematron_validator_validate, traits: [:validate]
+    end
+
+    factory :ehr_certification_id_validator do
+      msg_type { 'error' }
+      validator { 'Validators::EHRCertificationIdValidator' }
+      validation_type { 'result_validation' }
+      cms { false }
+
+      trait :validate do
+        message { 'CMS EHR Certification ID is required if Promoting Interoperability performance category (Promoting Interoperability Section (V2) identifier: urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01) is present in a QRDA III document. If CMS EHR Certification ID is not supplied, the score for the PI performance category will be 0.' }
+      end
+
+      factory :ehr_certification_id_validator_validate, traits: [:validate]
+    end
+
+    factory :encounter_validator do
+      msg_type { 'error' }
+      validator { 'Validators::EncounterValidator' }
+      validation_type { 'result_validation' }
+      location { '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]' }
+      cms { false }
+
+      trait :validate_encounter_start_end do
+        message { 'Encounter ends (4/23/2018 18:15) before start time (4/24/2018 17:00)' }
+      end
+
+      trait :get_time_value do
+        message { 'CMS_0075 - Fails validation check for Encounter Performed Admission Date (effectiveTime/low value)\n            as specified in Table 14: Valid Date/Time Format for HQR.' }
+      end
+
+      factory :encounter_validator_validate_encounter_start_end, traits: [:validate_encounter_start_end]
+      factory :encounter_validator_get_time_value, traits: [:get_time_value]
+    end
+
+    factory :expected_results_validator do
+      msg_type { 'error' }
+      validator { 'Validators::ExpectedResultsValidator' }
+      validation_type { 'result_validation' }
+      measure_id { '40280382-68D3-A5FE-0169-06FF09260E87' }
+      location { '/' }
+      cms { false }
+
+      trait :generate_could_not_find_population_error_message do
+        message { 'Could not find value for Population IPP' }
+        after(:build) do |ee|
+          ee[:population_id] = '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F'
+        end
+      end
+
+      trait :generate_could_not_find_population_stratification_error_message do
+        stratification { '30D23C7A-7947-4E36-B127-4AD51C371202' }
+        message { 'Could not find value for stratification 30D23C7A-7947-4E36-B127-4AD51C371202  for Population IPP' }
+        after(:build) do |ee|
+          ee[:population_id] = '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F'
+        end
+      end
+
+      trait :generate_does_not_match_population_error_message do
+        message { 'Expected IPP value 4\n      does not match reported value 3' }
+        after(:build) do |ee|
+          ee[:error_details] = { 'type' => 'population',
+                                 'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+                                 'stratification' => nil,
+                                 'expected_value' => 4,
+                                 'reported_value' => 3 }
+        end
+      end
+
+      factory :expected_results_validator_generate_could_not_find_population_error_message, traits: [:generate_could_not_find_population_error_message]
+      factory :expected_results_validator_generate_could_not_find_population_stratification_error_message, traits: [:generate_could_not_find_population_stratification_error_message]
+      factory :expected_results_validator_generate_does_not_match_population_error_message, traits: [:generate_does_not_match_population_error_message]
+    end
+
+    factory :expected_supplemental_results do
+      msg_type { 'error' }
+      validator { 'Validators::ExpectedSupplementalResults' }
+      validation_type { :result_validation }
+      measure_id { '40280382-68D3-A5FE-0169-06FF09260E87' }
+      location { '/' }
+      cms { false }
+
+      trait :check_supplemental_data_matches_pop_sums do
+        message { 'Reported IPP value 4 does not match sum 5 of supplemental key RACE values' }
+        after(:build) do |ee|
+          ee[:error_details] = { 'type' => 'population_sum',
+                                 'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+                                 'stratification' => nil,
+                                 'expected_value' => 4,
+                                 'reported_value' => 5 }
+        end
+      end
+
+      trait :add_sup_data_error do
+        message { 'supplemental data error' }
+        measure_id { '440280382-68D3-A5FE-0169-06FF09260E87' }
+        after(:build) do |ee|
+          ee[:error_details] = { 'type' => 'supplemental_data',
+                                 'population_key' => 'IPP',
+                                 'data_type' => 'RACE',
+                                 'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+                                 'code' => '1002-5',
+                                 'expected_value' => 1,
+                                 'reported_value' => 0 }
+        end
+      end
+
+      after(:build) do |ee|
+        ee[:validator_type] = :result_validation
+      end
+
+      factory :expected_supplemental_results_check_supplemental_data_matches_pop_sums, traits: [:check_supplemental_data_matches_pop_sums]
+      factory :expected_supplemental_results_add_sup_data_error, traits: [:add_sup_data_error]
+    end
+
+    factory :measure_period_validator do
+      msg_type { 'error' }
+      validator { 'Validators::MeasurePeriodValidator' }
+      validation_type { 'submission_validation' }
+      location { '/' }
+      cms { false }
+
+      trait :validate_start do
+        message { 'Reported Measurement Period should start on 20180101' }
+      end
+
+      factory :measure_period_validator_validate_start, traits: [:validate_start]
+    end
+
+    factory :program_criteria_validator do
+      msg_type { 'error' }
+      validator { 'Validators::ProgramCriteriaValidator' }
+      validation_type { 'xml_validation' }
+      location { '/' }
+      cms { false }
+
+      trait :patient_has_pcp_and_other_element do
+        message { 'The Patient Data Section QDM (V6) - CMS shall contain at least one Patient Characteristic Payer template and at least one entry template that is other than the Patient Characteristic Payer template.' }
+      end
+
+      factory :program_criteria_validator_patient_has_pcp_and_other_element, traits: [:patient_has_pcp_and_other_element]
+    end
+
+    factory :program_validator do
+      msg_type { 'error' }
+      validator { 'Validators::ProgramValidator' }
+      validation_type { 'result_validation' }
+      cms { false }
+
+      trait :validate do
+        message { "Expected to find program 'HQR_PI' but no program code was found." }
+      end
+
+      factory :program_validator_validate, traits: [:validate]
+    end
+
+    factory :provider_type_validator do
+      msg_type { 'error' }
+      validator { 'Validators::ProviderTypeValidator' }
+      validation_type { 'result_validation' }
+      cms { false }
+
+      trait :validate do
+        message { 'Provider specialties () do not match expected value (282N00000X)' }
+      end
+
+      factory :provider_type_validator_validate, traits: [:validate]
+    end
+
+    factory :qrda_cat1_validator do
+      validation_type { 'xml_validation' }
+      cms { false }
+
+      trait :cat1_r5 do
+        msg_type { 'error' }
+        validator { 'CqmValidators::Cat1R5' }
+        message { 'This template SHALL be contained by an Encounter Performed Act (V2) (CONF:3343-28803).' }
+        location { '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]' }
+      end
+
+      trait :qrda_qdm_template_validator do
+        msg_type { 'warning' }
+        validator { 'CqmValidators::QrdaQdmTemplateValidator' }
+        message { '[\"2.16.840.1.113883.10.20.24.3.133:2016-08-01\"] are not valid Patient Data Section QDM entries for this QRDA Version' }
+        location { '/*/*[19]/*/*[3]/*/*[9]' }
+      end
+
+      trait :validate_measures do
+        msg_type { 'error' }
+        validator { 'Validators::QrdaCat1Validator' }
+        message { 'Document does not state it is reporting measure 40280382-68D3-A5FE-0169-06FF09260E87  - Median time (in minutes) from admit decision time to time of departure from the emergency department for emergency department patients admitted to inpatient status' }
+        location { '/*/*[19]/*/*[3]/*/*[9]' }
+      end
+
+      factory :qrda_cat1_validator_cat1_r5, traits: [:cat1_r5]
+      factory :qrda_cat1_validator_qrda_qdm_template_validator, traits: [:qrda_qdm_template_validator]
+      factory :qrda_cat1_validator_validate_measures, traits: [:validate_measures]
+    end
+
+    factory :qrda_cat3_validator do
+      validation_type { 'xml_validation' }
+      msg_type { 'error' }
+      location { '/' }
+
+      trait :cat3_performance_rate do
+        validator { 'CqmValidators::Cat3PerformanceRate' }
+        message { 'Reported Performance Rate of 0.5 for Numerator A5976BE6-7F1C-419D-898D-7AFEB141A355 does not match expected value of 0.6.' }
+        cms { false }
+      end
+
+      trait :cat3_measure do
+        validator { 'CqmValidators::Cat3Measure' }
+        message { 'Invalid HQMF Set ID Found: 8455CD3E-DBB9-4E0C-8084-3ECE4068FE95' }
+        cms { false }
+      end
+
+      trait :cat3_r21 do
+        validator { 'Validators::CMSQRDA3SchematronValidator' }
+        message { 'This confidentialityCode SHALL contain exactly one [1..1] @code=\"N\" Normal (CodeSystem=> HL7Confidentiality urn=>oid=>2.16.840.1.113883.5.25) (CONF:CMS_4).' }
+        cms { true }
+      end
+
+      trait :cda do
+        validator { 'CqmValidators::CDA' }
+        message { "10:0: ERROR: Element '{urn:hl7-org:v3}templateId': This element is not expected. Expected is ( {urn:hl7-org:v3}code )." }
+        cms { true }
+      end
+
+      factory :qrda_cat3_validator_cat3_performance_rate, traits: [:cat3_performance_rate]
+      factory :qrda_cat3_validator_cat3_measure, traits: [:cat3_measure]
+      factory :qrda_cat3_validator_cat3_r21, traits: [:cat3_r21]
+      factory :qrda_cat3_validator_cda, traits: [:cda]
+    end
+
+    factory :smoking_gun_validator do
+      msg_type { 'error' }
+      validation_type { 'xml_validation' }
+      cms { false }
+
+      trait :errors do
+        message { 'Records for patients GREG ESTRADA, ADRIAN NORTON, SHEILA FORD not found in archive as expected' }
+      end
+
+      trait :validate_name do
+        validator { 'Validators::CalculatingSmokingGunValidator' }
+        message { "Patient name 'BRYAN SUMMERS' declared in file not found in test records" }
+      end
+
+      trait :validate_expected_results do
+        validator { 'Validators::CalculatingSmokingGunValidator' }
+        message { "Patient 'APRIL WELCH' not expected to be returned." }
+      end
+
+      factory :smoking_gun_validator_errors, traits: [:errors]
+      factory :smoking_gun_validator_validate_name, traits: [:validate_name]
+      factory :smoking_gun_validator_validate_expected_results, traits: [:validate_expected_results]
+    end
+
+    factory :test_execution_conditionally_add_task_specific_errors do
+      msg_type { 'error' }
+      validator { 'smoking_gun' }
+      validation_type { 'result_validation' }
+      cms { false }
+      message { '4 files expected but was 1' }
+    end
+  end
+end

--- a/test/unit/product_report_test.rb
+++ b/test/unit/product_report_test.rb
@@ -17,437 +17,166 @@ class ProductReportTest < ActionController::TestCase
   end
 
   # Key is the Class the error is reported from
-  # 'method' is the method in the class that creates the error
+  # 'factory_name' is the factory used to generate the error message
   # 'report_text' is a subset of the error message that we will use to determine if it exists in the product report
-  # 'execution_error' is a hash created from generating the specific error in a real Cypress test.
   TEST_EXECUTION_ERROR_HASH = {
     'CalculatingSmokingGunValidator' => [
       {
-        'method' => 'compare_results',
         'report_text' => 'does not match expected value',
-        'execution_error' => {
-          'message' => 'Calculated value (0) for IPP (78A9F833-07AA-448F-B94F-B2C4D8BF4F3F) does not match expected value (1)',
-          'msg_type' => 'error',
-          'validator_type' => 'result_validation',
-          'validator' => 'Validators::CalculatingSmokingGunValidator',
-          'cms' => false
-        }
+        'factory_name' => :calculating_smoking_gun_validator_compare_results
       }
     ],
     'Cat3PopulationValidator' => [
       {
-        'method' => 'validate_populations',
-        'report_text' => 'greater than Initial Population',
-        'execution_error' => {
-          'message' => 'Denominator value 2 is greater than Initial Population value 0 for measure d9c50230-f1c5-0137-ffa9-2cde48001122',
-          'msg_type' => 'error',
-          'validator' => 'Validators::Cat3PopulationValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => true
-        }
+        'factory_name' => :cat3_population_validator_validate_populations,
+        'report_text' => 'greater than Initial Population'
       }
     ],
     'ChecklistTest' => [
       {
-        'method' => 'build_execution_errors_for_incomplete_checked_criteria',
-        'report_text' => 'CMS159v8 - patient_characteristic, expired not complete',
-        'execution_error' => {
-          'message' => 'CMS159v8 - patient_characteristic, expired not complete',
-          'msg_type' => 'error',
-          'validator' => 'qrda_cat1',
-          'cms' => false
-        }
+        'factory_name' => :checklist_test_build_execution_errors_for_incomplete_checked_criteria,
+        'report_text' => 'CMS159v8 - patient_characteristic, expired not complete'
       }
     ],
     'CMSPopulationCountValidator' => [
       {
-        'method' => 'verify_all_codes_reported',
-        'report_text' => 'all PAYER codes present',
-        'execution_error' => {
-          'message' => 'For CMS eligible clinicians and eligible professionals programs, all PAYER codes present in the value set must be reported,even if the count is zero. If an eCQM is episode-based, the count will reflect the patient count rather than the episode count.',
-          'msg_type' => 'error',
-          'validator' => 'Validators::CMSPopulationCountValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
-
+        'factory_name' => :cms_population_count_validator_verify_all_codes_reported,
+        'report_text' => 'all PAYER codes present'
       }
     ],
     'CMSProgramTest' => [
       {
-        'method' => 'build_execution_errors_for_incomplete_cms_criteria',
-        'report_text' => 'Tax Identification Number not complete',
-        'execution_error' => {
-          'message' => 'Tax Identification Number not complete',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ProgramCriteriaValidator',
-          'cms' => false
-        }
-
+        'factory_name' => :cms_program_test_build_execution_errors_for_incomplete_cms_criteria,
+        'report_text' => 'Tax Identification Number not complete'
       }
     ],
     'CMSSchematronValidator' => [
       {
-        'method' => 'validate',
-        'report_text' => 'CONF:CMS_3',
-        'execution_error' => {
-          'message' => 'SHALL contain exactly one [1..1] templateId (CONF:CMS_1) such that it SHALL contain exactly one [1..1] @root=\"2.16.840.1.113883.10.20.27.1.2\" (CONF:CMS_2).SHALL contain exactly one [1..1] @extension=\"2019-05-01\" (CONF:CMS_3).',
-          'msg_type' => 'error',
-          'validator' => 'Validators::CMSQRDA3SchematronValidator',
-          'validator_type' => 'xml_validation',
-          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
-          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
-          'cms' => false
-        }
-
+        'factory_name' => :cms_schematron_validator_validate,
+        'report_text' => 'CONF:CMS_3'
       }
     ],
     'EHRCertificationIdValidator' => [
       {
-        'method' => 'validate',
-        'report_text' => 'CMS EHR Certification ID',
-        'execution_error' => {
-          'message' => 'CMS EHR Certification ID is required if Promoting Interoperability performance category (Promoting Interoperability Section (V2) identifier: urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01) is present in a QRDA III document. If CMS EHR Certification ID is not supplied, the score for the PI performance category will be 0.',
-          'msg_type' => 'error',
-          'validator' => 'Validators::EHRCertificationIdValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
-
+        'factory_name' => :ehr_certification_id_validator_validate,
+        'report_text' => 'CMS EHR Certification ID'
       }
     ],
     'EncounterValidator' => [
       {
-        'method' => 'validate_encounter_start_end',
-        'report_text' => 'before start time',
-        'execution_error' => {
-          'message' => 'Encounter ends (4/23/2018 18:15) before start time (4/24/2018 17:00)',
-          'msg_type' => 'error',
-          'validator' => 'Validators::EncounterValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
-          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :encounter_validator_validate_encounter_start_end,
+        'report_text' => 'before start time'
       },
       {
-        'method' => 'get_time_value',
-        'report_text' => 'CMS_0075',
-        'execution_error' => {
-          'message' => 'CMS_0075 - Fails validation check for Encounter Performed Admission Date (effectiveTime/low value)\n            as specified in Table 14: Valid Date/Time Format for HQR.',
-          'msg_type' => 'error',
-          'validator' => 'Validators::EncounterValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
-          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :encounter_validator_get_time_value,
+        'report_text' => 'CMS_0075'
       }
     ],
     'ExpectedResultsValidator' => [
       {
-        'method' => 'generate_could_not_find_population_error_message',
-        'report_text' => 'Could not find value for Population IPP',
-        'execution_error' => {
-          'message' => 'Could not find value for Population IPP',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ExpectedResultsValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/',
-          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
-          'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
-          'stratification' => nil,
-          'cms' => false
-        }
+        'factory_name' => :expected_results_validator_generate_could_not_find_population_error_message,
+        'report_text' => 'Could not find value for Population IPP'
       },
       {
-        'method' => 'generate_could_not_find_population_error_message',
-        'report_text' => 'Could not find value for stratification',
-        'execution_error' => {
-          'message' => 'Could not find value for stratification 30D23C7A-7947-4E36-B127-4AD51C371202  for Population IPP',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ExpectedResultsValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/',
-          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
-          'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
-          'stratification' => '30D23C7A-7947-4E36-B127-4AD51C371202',
-          'cms' => false
-        }
+        'factory_name' => :expected_results_validator_generate_could_not_find_population_stratification_error_message,
+        'report_text' => 'Could not find value for stratification'
       },
       {
-        'method' => 'generate_does_not_match_population_error_message',
-        'report_text' => 'Expected IPP value',
-        'execution_error' => {
-          'message' => 'Expected IPP value 4\n      does not match reported value 3',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ExpectedResultsValidator',
-          'validator_type' => 'result_validation',
-          'location' => '/',
-          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
-          'error_details' => {
-            'type' => 'population',
-            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
-            'stratification' => nil,
-            'expected_value' => 4,
-            'reported_value' => 3
-          },
-          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :expected_results_validator_generate_does_not_match_population_error_message,
+        'report_text' => 'Expected IPP value'
       }
     ],
     'ExpectedSupplementalResults' => [
       {
-        'method' => 'check_supplemental_data_matches_pop_sums',
-        'report_text' => 'Reported IPP value',
-        'execution_error' => {
-          'message' => 'Reported IPP value 4 does not match sum 5 of supplemental key RACE values',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ExpectedSupplementalResults',
-          'validator_type' => 'result_validation',
-          'location' => '/',
-          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
-          'error_details' => {
-            'type' => 'population_sum',
-            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
-            'stratification' => nil,
-            'expected_value' => 4,
-            'reported_value' => 5
-          },
-          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :expected_supplemental_results_check_supplemental_data_matches_pop_sums,
+        'report_text' => 'Reported IPP value'
       },
       {
-        'method' => 'add_sup_data_error',
-        'report_text' => '1002-5',
-        'execution_error' => {
-          'message' => 'supplemental data error',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ExpectedSupplementalResults',
-          'validator_type' => :result_validation,
-          'location' => '/',
-          'measure_id' => '440280382-68D3-A5FE-0169-06FF09260E87',
-          'error_details' => {
-            'type' => 'supplemental_data',
-            'population_key' => 'IPP',
-            'data_type' => 'RACE',
-            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
-            'code' => '1002-5',
-            'expected_value' => 1,
-            'reported_value' => 0
-          },
-          'file_name' => '18_etech-qrda-cat3-11-14-2019-10-19-14.xml',
-          'cms' => false
-        }
+        'factory_name' => :expected_supplemental_results_add_sup_data_error,
+        'report_text' => '1002-5'
       }
     ],
     'MeasurePeriodValidator' => [
       {
-        'method' => 'validate_start',
-        'report_text' => 'Reported Measurement Period',
-        'execution_error' => {
-          'message' => 'Reported Measurement Period should start on 20180101',
-          'msg_type' => 'error',
-          'validator' => 'Validators::MeasurePeriodValidator',
-          'validator_type' => 'submission_validation',
-          'location' => '/',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => true
-        }
+        'factory_name' => :measure_period_validator_validate_start,
+        'report_text' => 'Reported Measurement Period'
       }
     ],
     'ProgramCriteriaValidator' => [
       {
-        'method' => 'patient_has_pcp_and_other_element',
-        'report_text' => 'contain at least one Patient Characteristic Payer template',
-        'execution_error' => {
-          'message' => 'The Patient Data Section QDM (V6) - CMS shall contain at least one Patient Characteristic Payer template and at least one entry template that is other than the Patient Characteristic Payer template.',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ProgramCriteriaValidator',
-          'validator_type' => 'xml_validation',
-          'cms' => false
-        }
-
+        'factory_name' => :program_criteria_validator_patient_has_pcp_and_other_element,
+        'report_text' => 'contain at least one Patient Characteristic Payer template'
       }
     ],
     'ProgramValidator' => [
       {
-        'method' => 'patient_has_pcp_and_other_element',
-        'report_text' => 'Expected to find program',
-        'execution_error' => {
-          'message' => "Expected to find program 'HQR_PI' but no program code was found.",
-          'msg_type' => 'error',
-          'validator' => 'Validators::ProgramValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
-
+        'factory_name' => :program_validator_validate,
+        'report_text' => 'Expected to find program'
       }
     ],
     'ProviderTypeValidator' => [
       {
-        'method' => 'validate',
-        'report_text' => 'Provider specialties',
-        'execution_error' => {
-          'message' => 'Provider specialties () do not match expected value (282N00000X)',
-          'msg_type' => 'error',
-          'validator' => 'Validators::ProviderTypeValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
-
+        'factory_name' => :provider_type_validator_validate,
+        'report_text' => 'Provider specialties'
       }
     ],
     'QrdaCat1Validator' => [
       {
-        'method' => 'Cat1R5',
-        'report_text' => 'CONF:3343',
-        'execution_error' => {
-          'message' => 'This template SHALL be contained by an Encounter Performed Act (V2) (CONF:3343-28803).',
-          'msg_type' => 'error',
-          'validator' => 'CqmValidators::Cat1R5',
-          'validator_type' => 'xml_validation',
-          'location' => '/*/*[19]/*/*[3]/*/*[9]',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :qrda_cat1_validator_cat1_r5,
+        'report_text' => 'CONF:3343'
       },
       {
-        'method' => 'QrdaQdmTemplateValidator',
-        'report_text' => 'are not valid Patient Data Section QDM entries',
-        'execution_error' => {
-          'message' => '[\"2.16.840.1.113883.10.20.24.3.133:2016-08-01\"] are not valid Patient Data Section QDM entries for this QRDA Version',
-          'msg_type' => 'warning',
-          'validator' => 'CqmValidators::QrdaQdmTemplateValidator',
-          'validator_type' => 'xml_validation',
-          'location' => '/*/*[19]/*/*[3]/*/*[9]',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :qrda_cat1_validator_qrda_qdm_template_validator,
+        'report_text' => 'are not valid Patient Data Section QDM entries'
       },
       {
-        'method' => 'validate_measures',
-        'report_text' => 'Document does not state it is reporting measure',
-        'execution_error' => {
-          'message' => 'Document does not state it is reporting measure 40280382-68D3-A5FE-0169-06FF09260E87  - Median time (in minutes) from admit decision time to time of departure from the emergency department for emergency department patients admitted to inpatient status',
-          'msg_type' => 'error',
-          'validator' => 'Validators::QrdaCat1Validator',
-          'validator_type' => 'xml_validation',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :qrda_cat1_validator_validate_measures,
+        'report_text' => 'Document does not state it is reporting measure'
       }
     ],
     'QrdaCat3Validator' => [
       {
-        'method' => 'Cat3PerformanceRate',
-        'report_text' => 'Reported Performance Rate',
-        'execution_error' => {
-          'message' => 'Reported Performance Rate of 0.5 for Numerator A5976BE6-7F1C-419D-898D-7AFEB141A355 does not match expected value of 0.6.',
-          'msg_type' => 'error',
-          'validator' => 'CqmValidators::Cat3PerformanceRate',
-          'validator_type' => 'xml_validation',
-          'location' => '/',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :qrda_cat3_validator_cat3_performance_rate,
+        'report_text' => 'Reported Performance Rate'
       },
       {
-        'method' => 'Cat3Measure',
-        'report_text' => 'Invalid HQMF Set ID',
-        'execution_error' => {
-          'message' => 'Invalid HQMF Set ID Found: 8455CD3E-DBB9-4E0C-8084-3ECE4068FE95',
-          'msg_type' => 'error',
-          'validator' => 'CqmValidators::Cat3Measure',
-          'validator_type' => 'xml_validation',
-          'location' => '/',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => false
-        }
+        'factory_name' => :qrda_cat3_validator_cat3_measure,
+        'report_text' => 'Invalid HQMF Set ID'
       },
       {
-        'method' => 'Cat3R21',
-        'report_text' => 'CONF',
-        'execution_error' => {
-          'message' => 'This confidentialityCode SHALL contain exactly one [1..1] @code=\"N\" Normal (CodeSystem=> HL7Confidentiality urn=>oid=>2.16.840.1.113883.5.25) (CONF:CMS_4).',
-          'msg_type' => 'error',
-          'validator' => 'Validators::CMSQRDA3SchematronValidator',
-          'validator_type' => 'xml_validation',
-          'location' => "/*[local-name()='ClinicalDocument' and namespace-uri()='urn=>hl7-org=>v3']/*[local-name()='confidentialityCode' and namespace-uri()='urn=>hl7-org=>v3']",
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => true
-        }
+        'factory_name' => :qrda_cat3_validator_cat3_r21,
+        'report_text' => 'CONF'
       },
       {
-        'method' => 'CDA',
-        'report_text' => 'urn:hl7-org:v3',
-        'execution_error' => {
-          'message' => "10:0: ERROR: Element '{urn:hl7-org:v3}templateId': This element is not expected. Expected is ( {urn:hl7-org:v3}code ).",
-          'msg_type' => 'error',
-          'validator' => 'CqmValidators::CDA',
-          'validator_type' => 'xml_validation',
-          'location' => '/',
-          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
-          'cms' => true
-        }
+        'factory_name' => :qrda_cat3_validator_cda,
+        'report_text' => 'urn:hl7-org:v3'
       }
     ],
     'SmokingGunValidator' => [
       {
-        'method' => 'errors',
-        'report_text' => 'not found in archive as expected',
-        'execution_error' => {
-          'message' => 'Records for patients GREG ESTRADA, ADRIAN NORTON, SHEILA FORD not found in archive as expected',
-          'msg_type' => 'error',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
+        'factory_name' => :smoking_gun_validator_errors,
+        'report_text' => 'not found in archive as expected'
       },
       {
-        'method' => 'validate_name',
-        'report_text' => 'not found in test records',
-        'execution_error' => {
-          'message' => "Patient name 'BRYAN SUMMERS' declared in file not found in test records",
-          'msg_type' => 'error',
-          'validator' => 'Validators::CalculatingSmokingGunValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
+        'factory_name' => :smoking_gun_validator_validate_name,
+        'report_text' => 'not found in test records'
       },
       {
-        'method' => 'validate_expected_results',
-        'report_text' => 'not expected to be returned',
-        'execution_error' => {
-          'message' => "Patient 'APRIL WELCH' not expected to be returned.",
-          'msg_type' => 'error',
-          'validator' => 'Validators::CalculatingSmokingGunValidator',
-          'validator_type' => 'result_validation',
-          'cms' => false
-        }
+        'factory_name' => :smoking_gun_validator_validate_expected_results,
+        'report_text' => 'not expected to be returned'
       }
     ],
     'TestExecution' => [
       {
-        'method' => 'conditionally_add_task_specific_errors',
-        'report_text' => '4 files expected but was 1',
-        'execution_error' => {
-          'message' => '4 files expected but was 1"',
-          'msg_type' => 'error',
-          'validator_type' => 'result_validation',
-          'validator' => 'smoking_gun',
-          'cms' => false
-        }
+        'factory_name' => :test_execution_conditionally_add_task_specific_errors,
+        'report_text' => '4 files expected but was 1'
       }
     ]
   }.freeze
 
   test 'should generate a report' do
     # Iterate through each validator
-    TEST_EXECUTION_ERROR_HASH.each do |validator, sample_errors|
+    TEST_EXECUTION_ERROR_HASH.each_value do |sample_errors|
       # Iterate through each sample_error for validator
       sample_errors.each do |sample_error_hash|
         # test file will be the generated report
@@ -455,7 +184,7 @@ class ProductReportTest < ActionController::TestCase
         # create a test execution to assign the error message to. We're just using C2 test execution or all errors
         te = @product_test.tasks.c2_task.test_executions.build(state: :failed, user: @user)
         # add error message
-        build_execution_error(te, sample_error_hash['execution_error'])
+        build_execution_error(te, sample_error_hash['factory_name'])
         te.save
         # Use product controller to generate report
         @controller = ProductsController.new
@@ -467,7 +196,7 @@ class ProductReportTest < ActionController::TestCase
         Zip::File.open(testfile.path, Zip::File::CREATE) do |zip|
           report_html = Nokogiri::HTML.parse(zip.read('product_report.html'))
           # search product_report to find 'report_text'.  This will assert that the report included the error message
-          assert report_html.at("ul:contains('#{sample_error_hash['report_text']}')"), "error with #{validator} in method #{sample_error_hash['method']}"
+          assert report_html.at("ul:contains('#{sample_error_hash['report_text']}')"), "error with factory #{sample_error_hash['factory_name']}"
         end
         # Clean up
         testfile.unlink
@@ -476,21 +205,11 @@ class ProductReportTest < ActionController::TestCase
     end
   end
 
-  def build_execution_error(test_execution, execution_error)
+  def build_execution_error(test_execution, factory_name)
     # A test execution needs an artifact, since we are always using a C2 test execution, create a Cat 3 artifact
     file_name = 'cat_III/ep_test_qrda_cat3_good.xml'
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', file_name))
     Artifact.create!(test_execution: test_execution, file: file)
-    test_execution.execution_errors.build(message: execution_error['message'],
-                                          msg_type: execution_error['msg_type'],
-                                          measure_id: execution_error['measure_id'],
-                                          validator_type: execution_error['validator_type'],
-                                          validator: execution_error['validator'],
-                                          stratification: execution_error['stratification'],
-                                          location: execution_error['location'],
-                                          file_name: file_name.split('/')[1],
-                                          cms: execution_error['msg_type'])
-    # error details is not actually part of the execution_error model, add it after
-    test_execution.execution_errors[0]['error_details'] = execution_error['error_details']
+    FactoryBot.create(factory_name, test_execution: test_execution, file_name: file_name.split('/')[1])
   end
 end

--- a/test/unit/product_report_test.rb
+++ b/test/unit/product_report_test.rb
@@ -1,0 +1,496 @@
+require 'test_helper'
+
+class ProductReportTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+  include ActiveJob::TestHelper
+
+  setup do
+    @user = FactoryBot.create(:atl_user)
+    @product_test = FactoryBot.create(:cv_product_test_static_result)
+    @first_product = @product_test.product
+    @product_test.tasks.create({}, C1Task)
+    @product_test.tasks.create({ expected_results: @product_test.expected_results }, C2Task)
+    @product_test.tasks.create({}, C3Cat1Task)
+    @product_test.tasks.create({}, C3Cat3Task)
+    @product_test.save
+    @vendor = @product_test.product.vendor
+  end
+
+  # Key is the Class the error is reported from
+  # 'method' is the method in the class that creates the error
+  # 'report_text' is a subset of the error message that we will use to determine if it exists in the product report
+  # 'execution_error' is a hash created from generating the specific error in a real Cypress test.
+  TEST_EXECUTION_ERROR_HASH = {
+    'CalculatingSmokingGunValidator' => [
+      {
+        'method' => 'compare_results',
+        'report_text' => 'does not match expected value',
+        'execution_error' => {
+          'message' => 'Calculated value (0) for IPP (78A9F833-07AA-448F-B94F-B2C4D8BF4F3F) does not match expected value (1)',
+          'msg_type' => 'error',
+          'validator_type' => 'result_validation',
+          'validator' => 'Validators::CalculatingSmokingGunValidator',
+          'cms' => false
+        }
+      }
+    ],
+    'Cat3PopulationValidator' => [
+      {
+        'method' => 'validate_populations',
+        'report_text' => 'greater than Initial Population',
+        'execution_error' => {
+          'message' => 'Denominator value 2 is greater than Initial Population value 0 for measure d9c50230-f1c5-0137-ffa9-2cde48001122',
+          'msg_type' => 'error',
+          'validator' => 'Validators::Cat3PopulationValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => true
+        }
+      }
+    ],
+    'ChecklistTest' => [
+      {
+        'method' => 'build_execution_errors_for_incomplete_checked_criteria',
+        'report_text' => 'CMS159v8 - patient_characteristic, expired not complete',
+        'execution_error' => {
+          'message' => 'CMS159v8 - patient_characteristic, expired not complete',
+          'msg_type' => 'error',
+          'validator' => 'qrda_cat1',
+          'cms' => false
+        }
+      }
+    ],
+    'CMSPopulationCountValidator' => [
+      {
+        'method' => 'verify_all_codes_reported',
+        'report_text' => 'all PAYER codes present',
+        'execution_error' => {
+          'message' => 'For CMS eligible clinicians and eligible professionals programs, all PAYER codes present in the value set must be reported,even if the count is zero. If an eCQM is episode-based, the count will reflect the patient count rather than the episode count.',
+          'msg_type' => 'error',
+          'validator' => 'Validators::CMSPopulationCountValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+
+      }
+    ],
+    'CMSProgramTest' => [
+      {
+        'method' => 'build_execution_errors_for_incomplete_cms_criteria',
+        'report_text' => 'Tax Identification Number not complete',
+        'execution_error' => {
+          'message' => 'Tax Identification Number not complete',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ProgramCriteriaValidator',
+          'cms' => false
+        }
+
+      }
+    ],
+    'CMSSchematronValidator' => [
+      {
+        'method' => 'validate',
+        'report_text' => 'CONF:CMS_3',
+        'execution_error' => {
+          'message' => 'SHALL contain exactly one [1..1] templateId (CONF:CMS_1) such that it SHALL contain exactly one [1..1] @root=\"2.16.840.1.113883.10.20.27.1.2\" (CONF:CMS_2).SHALL contain exactly one [1..1] @extension=\"2019-05-01\" (CONF:CMS_3).',
+          'msg_type' => 'error',
+          'validator' => 'Validators::CMSQRDA3SchematronValidator',
+          'validator_type' => 'xml_validation',
+          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
+          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
+          'cms' => false
+        }
+
+      }
+    ],
+    'EHRCertificationIdValidator' => [
+      {
+        'method' => 'validate',
+        'report_text' => 'CMS EHR Certification ID',
+        'execution_error' => {
+          'message' => 'CMS EHR Certification ID is required if Promoting Interoperability performance category (Promoting Interoperability Section (V2) identifier: urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01) is present in a QRDA III document. If CMS EHR Certification ID is not supplied, the score for the PI performance category will be 0.',
+          'msg_type' => 'error',
+          'validator' => 'Validators::EHRCertificationIdValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+
+      }
+    ],
+    'EncounterValidator' => [
+      {
+        'method' => 'validate_encounter_start_end',
+        'report_text' => 'before start time',
+        'execution_error' => {
+          'message' => 'Encounter ends (4/23/2018 18:15) before start time (4/24/2018 17:00)',
+          'msg_type' => 'error',
+          'validator' => 'Validators::EncounterValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
+          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'get_time_value',
+        'report_text' => 'CMS_0075',
+        'execution_error' => {
+          'message' => 'CMS_0075 - Fails validation check for Encounter Performed Admission Date (effectiveTime/low value)\n            as specified in Table 14: Valid Date/Time Format for HQR.',
+          'msg_type' => 'error',
+          'validator' => 'Validators::EncounterValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/*/*[19]/*/*[3]/*/*[8]/*/*[3]/*/*[7]',
+          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
+          'cms' => false
+        }
+      }
+    ],
+    'ExpectedResultsValidator' => [
+      {
+        'method' => 'generate_could_not_find_population_error_message',
+        'report_text' => 'Could not find value for Population IPP',
+        'execution_error' => {
+          'message' => 'Could not find value for Population IPP',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ExpectedResultsValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/',
+          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
+          'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+          'stratification' => nil,
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'generate_could_not_find_population_error_message',
+        'report_text' => 'Could not find value for stratification',
+        'execution_error' => {
+          'message' => 'Could not find value for stratification 30D23C7A-7947-4E36-B127-4AD51C371202  for Population IPP',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ExpectedResultsValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/',
+          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
+          'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+          'stratification' => '30D23C7A-7947-4E36-B127-4AD51C371202',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'generate_does_not_match_population_error_message',
+        'report_text' => 'Expected IPP value',
+        'execution_error' => {
+          'message' => 'Expected IPP value 4\n      does not match reported value 3',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ExpectedResultsValidator',
+          'validator_type' => 'result_validation',
+          'location' => '/',
+          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
+          'error_details' => {
+            'type' => 'population',
+            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+            'stratification' => nil,
+            'expected_value' => 4,
+            'reported_value' => 3
+          },
+          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
+          'cms' => false
+        }
+      }
+    ],
+    'ExpectedSupplementalResults' => [
+      {
+        'method' => 'check_supplemental_data_matches_pop_sums',
+        'report_text' => 'Reported IPP value',
+        'execution_error' => {
+          'message' => 'Reported IPP value 4 does not match sum 5 of supplemental key RACE values',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ExpectedSupplementalResults',
+          'validator_type' => 'result_validation',
+          'location' => '/',
+          'measure_id' => '40280382-68D3-A5FE-0169-06FF09260E87',
+          'error_details' => {
+            'type' => 'population_sum',
+            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+            'stratification' => nil,
+            'expected_value' => 4,
+            'reported_value' => 5
+          },
+          'file_name' => 'CMS111v8_5dd549f2c1c388f14a018d9b.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'add_sup_data_error',
+        'report_text' => '1002-5',
+        'execution_error' => {
+          'message' => 'supplemental data error',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ExpectedSupplementalResults',
+          'validator_type' => :result_validation,
+          'location' => '/',
+          'measure_id' => '440280382-68D3-A5FE-0169-06FF09260E87',
+          'error_details' => {
+            'type' => 'supplemental_data',
+            'population_key' => 'IPP',
+            'data_type' => 'RACE',
+            'population_id' => '78A9F833-07AA-448F-B94F-B2C4D8BF4F3F',
+            'code' => '1002-5',
+            'expected_value' => 1,
+            'reported_value' => 0
+          },
+          'file_name' => '18_etech-qrda-cat3-11-14-2019-10-19-14.xml',
+          'cms' => false
+        }
+      }
+    ],
+    'MeasurePeriodValidator' => [
+      {
+        'method' => 'validate_start',
+        'report_text' => 'Reported Measurement Period',
+        'execution_error' => {
+          'message' => 'Reported Measurement Period should start on 20180101',
+          'msg_type' => 'error',
+          'validator' => 'Validators::MeasurePeriodValidator',
+          'validator_type' => 'submission_validation',
+          'location' => '/',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => true
+        }
+      }
+    ],
+    'ProgramCriteriaValidator' => [
+      {
+        'method' => 'patient_has_pcp_and_other_element',
+        'report_text' => 'contain at least one Patient Characteristic Payer template',
+        'execution_error' => {
+          'message' => 'The Patient Data Section QDM (V6) - CMS shall contain at least one Patient Characteristic Payer template and at least one entry template that is other than the Patient Characteristic Payer template.',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ProgramCriteriaValidator',
+          'validator_type' => 'xml_validation',
+          'cms' => false
+        }
+
+      }
+    ],
+    'ProgramValidator' => [
+      {
+        'method' => 'patient_has_pcp_and_other_element',
+        'report_text' => 'Expected to find program',
+        'execution_error' => {
+          'message' => "Expected to find program 'HQR_PI' but no program code was found.",
+          'msg_type' => 'error',
+          'validator' => 'Validators::ProgramValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+
+      }
+    ],
+    'ProviderTypeValidator' => [
+      {
+        'method' => 'validate',
+        'report_text' => 'Provider specialties',
+        'execution_error' => {
+          'message' => 'Provider specialties () do not match expected value (282N00000X)',
+          'msg_type' => 'error',
+          'validator' => 'Validators::ProviderTypeValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+
+      }
+    ],
+    'QrdaCat1Validator' => [
+      {
+        'method' => 'Cat1R5',
+        'report_text' => 'CONF:3343',
+        'execution_error' => {
+          'message' => 'This template SHALL be contained by an Encounter Performed Act (V2) (CONF:3343-28803).',
+          'msg_type' => 'error',
+          'validator' => 'CqmValidators::Cat1R5',
+          'validator_type' => 'xml_validation',
+          'location' => '/*/*[19]/*/*[3]/*/*[9]',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'QrdaQdmTemplateValidator',
+        'report_text' => 'are not valid Patient Data Section QDM entries',
+        'execution_error' => {
+          'message' => '[\"2.16.840.1.113883.10.20.24.3.133:2016-08-01\"] are not valid Patient Data Section QDM entries for this QRDA Version',
+          'msg_type' => 'warning',
+          'validator' => 'CqmValidators::QrdaQdmTemplateValidator',
+          'validator_type' => 'xml_validation',
+          'location' => '/*/*[19]/*/*[3]/*/*[9]',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'validate_measures',
+        'report_text' => 'Document does not state it is reporting measure',
+        'execution_error' => {
+          'message' => 'Document does not state it is reporting measure 40280382-68D3-A5FE-0169-06FF09260E87  - Median time (in minutes) from admit decision time to time of departure from the emergency department for emergency department patients admitted to inpatient status',
+          'msg_type' => 'error',
+          'validator' => 'Validators::QrdaCat1Validator',
+          'validator_type' => 'xml_validation',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => false
+        }
+      }
+    ],
+    'QrdaCat3Validator' => [
+      {
+        'method' => 'Cat3PerformanceRate',
+        'report_text' => 'Reported Performance Rate',
+        'execution_error' => {
+          'message' => 'Reported Performance Rate of 0.5 for Numerator A5976BE6-7F1C-419D-898D-7AFEB141A355 does not match expected value of 0.6.',
+          'msg_type' => 'error',
+          'validator' => 'CqmValidators::Cat3PerformanceRate',
+          'validator_type' => 'xml_validation',
+          'location' => '/',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'Cat3Measure',
+        'report_text' => 'Invalid HQMF Set ID',
+        'execution_error' => {
+          'message' => 'Invalid HQMF Set ID Found: 8455CD3E-DBB9-4E0C-8084-3ECE4068FE95',
+          'msg_type' => 'error',
+          'validator' => 'CqmValidators::Cat3Measure',
+          'validator_type' => 'xml_validation',
+          'location' => '/',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'Cat3R21',
+        'report_text' => 'CONF',
+        'execution_error' => {
+          'message' => 'This confidentialityCode SHALL contain exactly one [1..1] @code=\"N\" Normal (CodeSystem=> HL7Confidentiality urn=>oid=>2.16.840.1.113883.5.25) (CONF:CMS_4).',
+          'msg_type' => 'error',
+          'validator' => 'Validators::CMSQRDA3SchematronValidator',
+          'validator_type' => 'xml_validation',
+          'location' => "/*[local-name()='ClinicalDocument' and namespace-uri()='urn=>hl7-org=>v3']/*[local-name()='confidentialityCode' and namespace-uri()='urn=>hl7-org=>v3']",
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => true
+        }
+      },
+      {
+        'method' => 'CDA',
+        'report_text' => 'urn:hl7-org:v3',
+        'execution_error' => {
+          'message' => "10:0: ERROR: Element '{urn:hl7-org:v3}templateId': This element is not expected. Expected is ( {urn:hl7-org:v3}code ).",
+          'msg_type' => 'error',
+          'validator' => 'CqmValidators::CDA',
+          'validator_type' => 'xml_validation',
+          'location' => '/',
+          'file_name' => '_5dd80db0c1c3880a07f2c0ce.debug.xml',
+          'cms' => true
+        }
+      }
+    ],
+    'SmokingGunValidator' => [
+      {
+        'method' => 'errors',
+        'report_text' => 'not found in archive as expected',
+        'execution_error' => {
+          'message' => 'Records for patients GREG ESTRADA, ADRIAN NORTON, SHEILA FORD not found in archive as expected',
+          'msg_type' => 'error',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'validate_name',
+        'report_text' => 'not found in test records',
+        'execution_error' => {
+          'message' => "Patient name 'BRYAN SUMMERS' declared in file not found in test records",
+          'msg_type' => 'error',
+          'validator' => 'Validators::CalculatingSmokingGunValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+      },
+      {
+        'method' => 'validate_expected_results',
+        'report_text' => 'not expected to be returned',
+        'execution_error' => {
+          'message' => "Patient 'APRIL WELCH' not expected to be returned.",
+          'msg_type' => 'error',
+          'validator' => 'Validators::CalculatingSmokingGunValidator',
+          'validator_type' => 'result_validation',
+          'cms' => false
+        }
+      }
+    ],
+    'TestExecution' => [
+      {
+        'method' => 'conditionally_add_task_specific_errors',
+        'report_text' => '4 files expected but was 1',
+        'execution_error' => {
+          'message' => '4 files expected but was 1"',
+          'msg_type' => 'error',
+          'validator_type' => 'result_validation',
+          'validator' => 'smoking_gun',
+          'cms' => false
+        }
+      }
+    ]
+  }.freeze
+
+  test 'should generate a report' do
+    # Iterate through each validator
+    TEST_EXECUTION_ERROR_HASH.each do |validator, sample_errors|
+      # Iterate through each sample_error for validator
+      sample_errors.each do |sample_error_hash|
+        # test file will be the generated report
+        testfile = Tempfile.new(['report', '.zip'])
+        # create a test execution to assign the error message to. We're just using C2 test execution or all errors
+        te = @product_test.tasks.c2_task.test_executions.build(state: :failed, user: @user)
+        # add error message
+        build_execution_error(te, sample_error_hash['execution_error'])
+        te.save
+        # Use product controller to generate report
+        @controller = ProductsController.new
+        for_each_logged_in_user([ATL]) do
+          get :report, params: { format: :format_does_not_matter, vendor_id: @vendor.id, id: @first_product.id }
+          testfile.write response.body
+        end
+        # Open zipfile to find report
+        Zip::File.open(testfile.path, Zip::File::CREATE) do |zip|
+          report_html = Nokogiri::HTML.parse(zip.read('product_report.html'))
+          # search product_report to find 'report_text'.  This will assert that the report included the error message
+          assert report_html.at("ul:contains('#{sample_error_hash['report_text']}')"), "error with #{validator} in method #{sample_error_hash['method']}"
+        end
+        # Clean up
+        testfile.unlink
+        te.execution_errors.destroy
+      end
+    end
+  end
+
+  def build_execution_error(test_execution, execution_error)
+    # A test execution needs an artifact, since we are always using a C2 test execution, create a Cat 3 artifact
+    file_name = 'cat_III/ep_test_qrda_cat3_good.xml'
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', file_name))
+    Artifact.create!(test_execution: test_execution, file: file)
+    test_execution.execution_errors.build(message: execution_error['message'],
+                                          msg_type: execution_error['msg_type'],
+                                          measure_id: execution_error['measure_id'],
+                                          validator_type: execution_error['validator_type'],
+                                          validator: execution_error['validator'],
+                                          stratification: execution_error['stratification'],
+                                          location: execution_error['location'],
+                                          file_name: file_name.split('/')[1],
+                                          cms: execution_error['msg_type'])
+    # error details is not actually part of the execution_error model, add it after
+    test_execution.execution_errors[0]['error_details'] = execution_error['error_details']
+  end
+end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code