### PR TITLE
Error pages for nginx, when cypress not available

### DIFF
--- a/public/errors/404.html
+++ b/public/errors/404.html
@@ -1,4 +1,3 @@
-
 <!DOCTYPE HTML>
 <!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
 <!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->

--- a/public/errors/404.html
+++ b/public/errors/404.html
@@ -1,0 +1,30 @@
+
+<!DOCTYPE HTML>
+<!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
+<!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress" lang="en-US" class="no-js not-ie error-page"><!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>404 Error</title>
+  <meta name="description" content="" />
+  <meta name="keywords" content="" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <link rel="stylesheet" media="all" href="/assets/application-3600e9b8935c1fb1550f3808e774de3fe071cdd98ef902f86721adae5bd93e50.css" data-turbolinks-track="true" />
+  <script src="/assets/application-52cac13c6814ef8cb218d663834a2d10d1792409dc37f071ccfd142d456326dd.js" data-turbolinks-track="true"></script>
+</head>
+<body>
+  <main aria-label="main section" id="main-content" class="container" role="main">
+    <div class="error-message">
+      <h1 class="text-primary">Page Not Found</h1>
+<p class="text-center text-info">
+  <strong>
+    <i aria-hidden="true" class="fas fa-3x fa-question-circle"></i>
+  </strong>
+</p>
+<p class="lead">We're sorry but Cypress can't find this page. You might have followed a bad link or mis-typed a URL.</p>
+    </div>
+  </main>
+</body>
+</html>

--- a/public/errors/50x.html
+++ b/public/errors/50x.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML>
+<!--[if lt IE 8]><html class="no-js oldIE" lang="en-US"><![endif]-->
+<!--[if IE 8]><html class="no-js lt-ie9" lang="en-US"><![endif]-->
+<!--[if IE 9]><html class="no-js ie9" lang="en-US"><![endif]-->
+<!--[if (gt IE 9)|!(IE)]><!--><html id="cypress" lang="en-US" class="no-js not-ie error-page"><!--<![endif]-->
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>500 Error</title>
+  <meta name="description" content="" />
+  <meta name="keywords" content="" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <link rel="stylesheet" media="all" href="/assets/application-3600e9b8935c1fb1550f3808e774de3fe071cdd98ef902f86721adae5bd93e50.css" data-turbolinks-track="true" />
+  <script src="/assets/application-52cac13c6814ef8cb218d663834a2d10d1792409dc37f071ccfd142d456326dd.js" data-turbolinks-track="true"></script>
+</head>
+<body>
+  <main aria-label="main section" id="main-content" class="container" role="main">
+    <div class="error-message">
+      <h1 class="text-primary">Server Error</h1>
+<p class="text-center text-info">
+  <strong>
+    <i aria-hidden="true" class="fas fa-3x fa-exclamation-circle"></i>
+  </strong>
+</p>
+<p class="lead">Something went wrong with this request. This is likely a problem with Cypress rather than a mistake on your part.</p>
+
+    </div>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code