### PR TITLE
Add a error message when api_measure_eval test fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,15 @@ env:
     - MONGODB=3.4.5
   matrix:
   - TEST_SUITE=integration
-  - TEST_SUITE=cucumber-product-tests
-  - TEST_SUITE=cucumber-admin-users
-  - TEST_SUITE=cucumber-record
-  - TEST_SUITE=cucumber-product-vendor
-  - TEST_SUITE=audit
   - TEST_SUITE=units
   - TEST_SUITE=controllers
   - TEST_SUITE=helpers
   - TEST_SUITE=jobs
+  - TEST_SUITE=audit
+  - TEST_SUITE=cucumber-product-tests
+  - TEST_SUITE=cucumber-product-vendor
+  - TEST_SUITE=cucumber-admin-users
+  - TEST_SUITE=cucumber-record
 script:
   - 'if [ ${TEST_SUITE} = "cucumber-admin-users" ]; then
       bundle exec cucumber features/admin/;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,16 +36,16 @@ env:
   global:
     - MONGODB=3.4.5
   matrix:
-  - TEST_SUITE=integration
+  - TEST_SUITE=cucumber-product-tests
+  - TEST_SUITE=cucumber-product-vendor
+  - TEST_SUITE=cucumber-admin-users
+  - TEST_SUITE=cucumber-record
   - TEST_SUITE=units
   - TEST_SUITE=controllers
   - TEST_SUITE=helpers
   - TEST_SUITE=jobs
   - TEST_SUITE=audit
-  - TEST_SUITE=cucumber-product-tests
-  - TEST_SUITE=cucumber-product-vendor
-  - TEST_SUITE=cucumber-admin-users
-  - TEST_SUITE=cucumber-record
+  - TEST_SUITE=integration
 script:
   - 'if [ ${TEST_SUITE} = "cucumber-admin-users" ]; then
       bundle exec cucumber features/admin/;

--- a/app/assets/javascripts/xml_navigator.js
+++ b/app/assets/javascripts/xml_navigator.js
@@ -44,13 +44,13 @@
     this.action(tgt);
   }
   Navigator.prototype.prev = function() {
-    this.index = this.index  - 1;
+    this.index -= 1;
     if(isNaN(this.index)|| this.index < 0){this.index=0;}
     var tgt = $(this.targets[this.index]).attr('href');
     this.action(tgt);
   }
   Navigator.prototype.next = function() {
-    this.index = this.index +1 ;
+    this.index += 1;
     if(isNaN(this.index) || this.index >= this.targets.length) { this.index = this.targets.length - 1;}
     var tgt = $(this.targets[this.index]).attr('href');
     this.action(tgt);

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -275,10 +275,9 @@ module Cypress
       race_xpath = '/cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:patient/cda:raceCode/@code'
       gender_xpath = '/cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:patient/cda:administrativeGenderCode/@code'
       ethnic_xpath = '/cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:patient/cda:ethnicGroupCode/@code'
-      # Currently, with randomization off, all payers are expected to be returned
-      # payer_xpath = %(/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/
-      #   cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']/cda:value/@code)
-      # payer_value = doc.at_xpath(payer_xpath).value if doc.at_xpath(payer_xpath)
+      payer_xpath = %(/cda:ClinicalDocument/cda:component/cda:structuredBody/cda:component/cda:section/
+        cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']/cda:value/@code)
+      payer_value = doc.at_xpath(payer_xpath).value if doc.at_xpath(payer_xpath)
       if filters.key?('age')
         age_filter_holder = filters['age']
         counter += 1 if compare_age(doc, age_filter_holder, creation_time)
@@ -287,9 +286,7 @@ module Cypress
       counter += 1 if filters.value?(doc.at_xpath(race_xpath).value)
       counter += 1 if filters.value?(doc.at_xpath(gender_xpath).value)
       counter += 1 if filters.value?(doc.at_xpath(ethnic_xpath).value)
-      # Currently, with randomization off, all payers are expected to be returned
-      counter += 1 if filters.key?('payer')
-      # counter += 1 if filters.value?(get_payer_name(payer_value))
+      counter += 1 if filters.value?(get_payer_name(payer_value))
       filters['age'] = age_filter_holder if age_filter_holder
       return true if counter == 2
     end

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -308,11 +308,11 @@ module Cypress
     def get_payer_name(payer_code)
       case payer_code
       when '1'
-        'Medicare'
+        1
       when '2'
-        'Medicaid'
+        2
       when '349'
-        'Other'
+        349
       end
     end
 

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -67,15 +67,15 @@ module Admin
         upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'bundles', 'minimal_bundle_qdm_5_4.zip'), 'application/zip')
         perform_enqueued_jobs do
           post :create, params: { file: upload }
-          @vendor.reload
-          assert_equal orig_bundle_count + 1, Bundle.count, 'Should have added 1 new Bundle'
-          # Default Code Systems for encounter will now have 2 code systems
-          assert_equal 2, Settings.current.default_code_systems['encounter'].size
-          assert_equal 2, @vendor.preferred_code_systems['encounter'].size
-          # The new code system will be added to the end
-          assert_equal '2.16.840.1.113883.6.96', Settings.current.default_code_systems['encounter'].last
-          assert_equal '2.16.840.1.113883.6.96', @vendor.preferred_code_systems['encounter'].last
         end
+        @vendor.reload
+        assert_equal orig_bundle_count + 1, Bundle.count, 'Should have added 1 new Bundle'
+        # Default Code Systems for encounter will now have 2 code systems
+        assert_equal 2, Settings.current.default_code_systems['encounter'].size
+        assert_equal 2, @vendor.preferred_code_systems['encounter'].size
+        # The new code system will be added to the end
+        assert_equal '2.16.840.1.113883.6.96', Settings.current.default_code_systems['encounter'].last
+        assert_equal '2.16.840.1.113883.6.96', @vendor.preferred_code_systems['encounter'].last
       end
     end
 

--- a/test/controllers/admin/bundles_controller_test.rb
+++ b/test/controllers/admin/bundles_controller_test.rb
@@ -46,13 +46,13 @@ module Admin
         upload = Rack::Test::UploadedFile.new(Rails.root.join('test', 'fixtures', 'bundles', 'minimal_bundle_qdm_5_4.zip'), 'application/zip')
         perform_enqueued_jobs do
           post :create, params: { file: upload }
-          assert_performed_jobs 2
-          assert_equal orig_bundle_count + 1, Bundle.count, 'Should have added 1 new Bundle'
-          # Default Code Systems will not be empty after to loading bundle
-          assert_not Settings.current.default_code_systems.empty?
-          assert orig_measure_count < Measure.count, 'Should have added new measures in the bundle'
-          assert orig_patient_count < Patient.count, 'Should have added new patients in the bundle'
         end
+        assert_performed_jobs 2
+        assert_equal orig_bundle_count + 1, Bundle.count, 'Should have added 1 new Bundle'
+        # Default Code Systems will not be empty after to loading bundle
+        assert_not Settings.current.default_code_systems.empty?
+        assert orig_measure_count < Measure.count, 'Should have added new measures in the bundle'
+        assert orig_patient_count < Patient.count, 'Should have added new patients in the bundle'
       end
     end
 
@@ -111,6 +111,7 @@ module Admin
         inactive_bundle = Bundle.where('$or' => [{ 'active' => false }, { :active.exists => false }]).sample
 
         post :set_default, params: { id: inactive_bundle._id }
+        assert_response 302
 
         active_bundle.reload
         inactive_bundle.reload

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -11,7 +11,8 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
     import_bundle_and_create_product(retrieve_bundle)
     perform_filtering_tests
     perform_measure_tests
-    assert_equal 0, TestExecution.where(state: 'failed').size
+    failed_tests = TestExecution.where(state: 'failed')
+    assert failed_tests.empty?, "Test failed for #{failed_tests.first.task.product_test.cms_id} - #{failed_tests.collect { |ft| ft.execution_errors.collect(&:message) }}" unless failed_tests.empty?
   end
 
   # Get bundle from the demo server.  Use VCR if available


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code