### PR TITLE
Export an entry for each valueset a negated code is part of

### DIFF
--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -20,23 +20,35 @@ module Cypress
 
     def scoop_and_filter(patient)
       demographic_criteria = patient.qdmPatient.dataElements.collect { |de| de if de.qdmCategory == 'patient_characteristic' }.compact
+      # If a negated code belongs to multiple valuesets, we need to add a cloned entry for each valueset.
+      # This array stores the cloned entries to be added
+      multi_vs_negation_elements = []
       patient.qdmPatient.dataElements.keep_if { |de| data_element_used_by_measure(de) }
       patient.qdmPatient.dataElements.each do |data_element|
-        # keep if data_element code and codesystem is in one of the relevant_codes
-        data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, codeSystemOid: de_code.codeSystemOid) }
-        # Do not try to replace with negated valueset if all codes are removed
-        next if data_element.dataElementCodes.blank?
-
-        add_description_to_data_element(data_element)
-        replace_negated_code_with_valueset(data_element) if data_element.respond_to?('negationRationale') && data_element.negationRationale
+        scoop_and_filter_data_element_codes(data_element, multi_vs_negation_elements)
       end
       # keep data element if codes is not empty
       patient.qdmPatient.dataElements.keep_if { |data_element| data_element.dataElementCodes.present? }
       patient.qdmPatient.dataElements.concat(demographic_criteria)
+      patient.qdmPatient.dataElements.concat(multi_vs_negation_elements)
       patient
     end
 
     private
+
+    # Method to remove codes from a data element that are not relevant to measure.
+    # Multi_vs_negation_elements is an array of cloned elements to add to patient record to capture all of the negated valuesets
+    def scoop_and_filter_data_element_codes(data_element, multi_vs_negation_elements)
+      # keep if data_element code and codesystem is in one of the relevant_codes
+      data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, codeSystemOid: de_code.codeSystemOid) }
+      # Do not try to replace with negated valueset if all codes are removed
+      return if data_element.dataElementCodes.blank?
+
+      add_description_to_data_element(data_element)
+      return unless data_element.respond_to?('negationRationale') && data_element.negationRationale
+
+      replace_negated_code_with_valueset(data_element, multi_vs_negation_elements)
+    end
 
     def data_element_category_and_status(data_element)
       { category: data_element.qdmCategory, status: data_element['qdmStatus'] }
@@ -55,13 +67,22 @@ module Cypress
       de.description = vs.display_name
     end
 
-    def replace_negated_code_with_valueset(data_element)
+    # For negated elements, replace codes (that aren't direct reference codes) with valuesets.
+    # If a code is in multiple valuesets, create new entries to be added to record
+    def replace_negated_code_with_valueset(data_element, multi_vs_negation_elements)
       de = data_element
       neg_vs = @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.codeSystemOid } }
-      # If more than one valueset (in the measures uses the code, it is not possible for scoop and filter to know which valueset to negate)
-      return if neg_vs.size > 1
 
       negated_valueset = neg_vs.first
+      neg_vs.drop(1).each do |additional_vs|
+        next if additional_vs.oid[0, 3] == 'drc'
+
+        de_for_additional_vs = data_element.clone
+        de_for_additional_vs.id = QDM::Id.new(value: BSON::ObjectId.new.to_s)
+        de_for_additional_vs.dataElementCodes = [{ code: additional_vs.oid, codeSystemOid: '1.2.3.4.5.6.7.8.9.10' }]
+        multi_vs_negation_elements << de_for_additional_vs
+      end
+
       # If the first three characters of the valueset oid is drc, this is a direct reference code, not a valueset.  Do not negate a valueset here.
       return if negated_valueset.oid[0, 3] == 'drc'
 

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -87,7 +87,7 @@ class PatientZipperTest < ActiveSupport::TestCase
         doc = Nokogiri::XML(zip_entry.get_input_stream, &:strict)
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        assert_equal 2, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 1 negated code in the exported QRDA'
+        assert_equal 2, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 2 negated valusets in the exported QRDA'
         count += 1
       end
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code