### PR TITLE
Incomplete status

### DIFF
--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -55,6 +55,7 @@ class ChecklistTest < ProductTest
     return 'not_started' if criterias.count == criterias.count { |criteria| criteria.complete?.nil? }
     # incomplete if no files have been uploaded
     return 'incomplete' if tasks.c1_checklist_task.most_recent_execution.nil?
+
     pass_count = criterias.count(&:complete?)
     pass_count == criterias.count ? 'passed' : 'failed'
   end

--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -53,7 +53,8 @@ class ChecklistTest < ProductTest
   def measure_status(measure_id)
     criterias = checked_criteria.select { |criteria| criteria.measure_id == measure_id.to_s }
     return 'not_started' if criterias.count == criterias.count { |criteria| criteria.complete?.nil? }
-
+    # incomplete if no files have been uploaded
+    return 'incomplete' if tasks.c1_checklist_task.most_recent_execution.nil?
     pass_count = criterias.count(&:complete?)
     pass_count == criterias.count ? 'passed' : 'failed'
   end

--- a/app/views/application/_checklist_status_display.html.erb
+++ b/app/views/application/_checklist_status_display.html.erb
@@ -38,6 +38,8 @@
               <strong class = 'text-success'>Passing</strong>
             <% when 'failed' %>
               <strong class = 'text-danger'>Failing</strong>
+            <% when 'incomplete' %>
+              <strong class = 'text-info'>Incomplete</strong>
             <% when 'not_started' %>
               <strong class = 'text-info'>Not Started</strong>
             <% end %>

--- a/test/models/checklist_test_test.rb
+++ b/test/models/checklist_test_test.rb
@@ -114,6 +114,10 @@ class ChecklistTestTest < ActiveJob::TestCase
     assert_equal 'not_started', @test.measure_status(measure_id)
     @test.checked_criteria.first.code_complete = false
     @test.checked_criteria.first.code = '123'
+    assert_equal 'incomplete', @test.measure_status(measure_id)
+    # check if file uploaded
+    task = checklist_test.tasks.create!({}, C1ChecklistTask)
+    task.test_executions.create(state: :failed, user: user)
     assert_equal 'failed', @test.measure_status(measure_id)
     @test.checked_criteria.each do |criteria|
       criteria.code_complete = true

--- a/test/models/checklist_test_test.rb
+++ b/test/models/checklist_test_test.rb
@@ -114,9 +114,9 @@ class ChecklistTestTest < ActiveJob::TestCase
     assert_equal 'not_started', @test.measure_status(measure_id)
     @test.checked_criteria.first.code_complete = false
     @test.checked_criteria.first.code = '123'
+    task = @test.tasks.create!({}, C1ChecklistTask)
     assert_equal 'incomplete', @test.measure_status(measure_id)
-    # check if file uploaded
-    task = checklist_test.tasks.create!({}, C1ChecklistTask)
+    user = User.create(email: 'vendor@test.com', password: 'TestTest!', password_confirmation: 'TestTest!', terms_and_conditions: '1')
     task.test_executions.create(state: :failed, user: user)
     assert_equal 'failed', @test.measure_status(measure_id)
     @test.checked_criteria.each do |criteria|


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-453
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code