### PR TITLE
encode error message in ascii prior to export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,7 +337,7 @@ GEM
       pry (>= 0.9.10, < 0.13.0)
     psych (3.1.0)
     public_suffix (3.0.3)
-    rack (2.0.7)
+    rack (2.0.8)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.2.3)

--- a/app/views/products/report/_failing_measure_tests.html.erb
+++ b/app/views/products/report/_failing_measure_tests.html.erb
@@ -52,7 +52,7 @@
       <% end %>
       <% errors.each do |err| %>
         <li>
-          <%= err.message %>
+          <%= err.message.encode('ASCII', invalid: :replace, undef: :replace) %>
           <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>
         </li>
       <% end %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code