### PR TITLE
changes to enable product report on debug mode

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -31,7 +31,9 @@ class ApplicationController < ActionController::Base
   end
 
   def require_admin_atl
-    raise CanCan::AccessDenied.new, 'Forbidden' unless current_user.user_role?(:admin) || current_user.user_role?(:atl)
+    return if current_user.user_role?(:admin) || current_user.user_role?(:atl) || Settings.current.enable_debug_features
+
+    raise CanCan::AccessDenied.new, 'Forbidden'
   end
 
   private

--- a/app/views/application/_header_product.html.erb
+++ b/app/views/application/_header_product.html.erb
@@ -13,7 +13,7 @@
       <%= button_to edit_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
         <%= icon('fas fa-fw', 'wrench', :"aria-hidden" => true) %> Edit Product
       <% end %>
-      <% if current_user.user_role?(:atl) || current_user.user_role?(:admin) %>
+      <% if current_user.user_role?(:atl) || current_user.user_role?(:admin) || Settings.current.enable_debug_features  %>
         <% unless product.supplemental_test_artifact.file.nil? %>
           <%= button_to supplemental_test_artifact_vendor_product_path(product.vendor_id, product), :method => :get, :class => "btn btn-default" do %>
             <%= icon('fas fa-fw', 'download', :"aria-hidden" => true) %> Download Supplemental Test Artifact

--- a/test/controllers/products_controller_test.rb
+++ b/test/controllers/products_controller_test.rb
@@ -199,13 +199,16 @@ class ProductsControllerTest < ActionController::TestCase
   # report
 
   test 'should generate a report' do
-    for_each_logged_in_user([ADMIN, ATL]) do
+    for_each_logged_in_user([ADMIN, ATL, OWNER, VENDOR]) do
       get :report, params: { format: :format_does_not_matter, vendor_id: @vendor.id, id: @first_product.id }
       assert_response :success, "#{@user.email} should have access "
     end
   end
 
   test 'should restrict access to report to unauthorized users' do
+    settings = Settings.first
+    settings.enable_debug_features = false
+    settings.save!
     for_each_logged_in_user([OWNER, VENDOR, OTHER_VENDOR]) do
       get :report, params: { vendor_id: @vendor.id, id: @first_product.id }
       assert_response 401
@@ -230,6 +233,9 @@ class ProductsControllerTest < ActionController::TestCase
   end
 
   test 'should restrict access to supplemental test artifacts to unauthorized users' do
+    settings = Settings.first
+    settings.enable_debug_features = false
+    settings.save!
     for_each_logged_in_user([OWNER, VENDOR, OTHER_VENDOR]) do
       @first_product.supplemental_test_artifact = Rails.root.join('app', 'assets', 'images', 'cypress_bg_cropped.png').open
       @first_product.save


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code