### PR TITLE
support an array of possible units

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -204,9 +204,12 @@ unit_matches:
   - hqmf_set_id : '7D374C6A-3821-4333-A1BC-4531005D77B8'
     de_type     : 'QDM::AssessmentPerformed'
     code_list_id: 'drc-4c33d7b8f32e35a207115db38533831b6f4ecd2459f3921a33641217cb04b75b' # drc 76516-4
-    unit        : 'weeks'
+    units       : 
+      - 'weeks'
+      - 'wk'
     # relevant for CMS105v8+ where Max( ... Ldl.result as Quantity) < 70 'mg/dL', "LDL-c"
   - hqmf_set_id : '1F503318-BB8D-4B91-AF63-223AE0A2328E'
     de_type     : 'QDM::LaboratoryTestPerformed'
     code_list_id: '2.16.840.1.113883.3.117.1.7.1.215'
-    unit        : 'mg/dL'
+    units        :
+      - 'mg/dL'

--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -68,11 +68,11 @@ module Cypress
       data_element_title = "#{data_element._type} (#{valueset.display_name})"
       # If a unit is not specified in the QRDA, it is imported as an Integer or Float.
       if (data_element.result.is_a? Integer) || (data_element.result.is_a? Float)
-        "Unspecified unit for #{data_element_title} does not match expected unit '#{expected_unit['unit']}'. " \
+        "Unspecified unit for #{data_element_title} does not match expected units (#{expected_unit['units'].join(', ')}). " \
         'Units must match measure-defined units. '
       # If a unit is specified in the QRDA, it is imported as a Quantity.  Check the Quantity's unit
-      elsif data_element.result._type == 'QDM::Quantity' && data_element.result.unit != expected_unit['unit']
-        "Unit '#{data_element.result.unit}' for #{data_element_title} does not match expected unit '#{expected_unit['unit']}'. " \
+      elsif data_element.result._type == 'QDM::Quantity' && !expected_unit['units'].include?(data_element.result.unit)
+        "Unit '#{data_element.result.unit}' for #{data_element_title} does not match expected units (#{expected_unit['units'].join(', ')}). " \
         'Units must match measure-defined units. '
       end
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code