### PR TITLE
need positive contrast when no circle

### DIFF
--- a/app/assets/stylesheets/cypress/_tables.scss
+++ b/app/assets/stylesheets/cypress/_tables.scss
@@ -19,6 +19,11 @@
       color: $navbar-inverse-link-color;
       font-weight: normal;
     }
+
+    .result-text-positive-contrast {
+      color: $state-success-text;
+      font-weight: normal;
+    }
   }
 
   .empty-marker {

--- a/app/views/test_executions/_expected_result_icon.html.erb
+++ b/app/views/test_executions/_expected_result_icon.html.erb
@@ -1,7 +1,7 @@
 <% if result && result.positive? %>
   <span class="sr-only">Pass</span>
   <span class="result-marker">
-    <strong class="result-text"><span class="sr-only">value of </span><%= result %></strong>
+    <strong class="result-text-positive-contrast"><span class="sr-only">value of </span><%= result %></strong>
   </span>
 <% else %>
   <span class="sr-only">Fail</span>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code