### PR TITLE
Simplify Error tables.  Limit to only Errors and Warnings

### DIFF
--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -36,23 +36,18 @@ module TestExecutionsHelper
   end
 
   # returns the number of each type of error
-  def get_error_counts(execution, task)
-    h = Hash[['QRDA Errors', 'Reporting Errors', 'Submission Errors', 'Warnings'].zip(get_error_counts_helper(execution))]
-    h.except!('Submission Errors', 'Warnings') unless task.product_test.product.c3_test
-    h
+  def get_error_counts(execution)
+    Hash[%w[Errors Warnings].zip(get_error_counts_helper(execution))]
   end
 
   def get_error_counts_helper(execution)
-    return ['--', '--', '--'] unless execution&.failing?
+    return ['--', '--'] unless execution&.failing?
 
-    qrda = execution.execution_errors.qrda_errors.count
-    reporting = execution.execution_errors.reporting_errors.count
-    submit_errors = submit_warnings = 0
-    if execution.sibling_execution
-      submit_errors = execution.sibling_execution.execution_errors.only_errors.count
-      submit_warnings = execution.sibling_execution.execution_errors.only_warnings.count
-    end
-    [qrda, reporting, submit_errors, submit_warnings]
+    errors = execution.execution_errors.only_errors.count
+    errors += execution.sibling_execution.execution_errors.only_errors.count if execution.sibling_execution
+    warnings = execution.execution_errors.only_warnings.count
+    warnings += execution.sibling_execution.execution_errors.only_warnings.count if execution.sibling_execution
+    [errors, warnings]
   end
 
   def date_of_execution(execution)

--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -27,42 +27,6 @@ class ExecutionError
     by_type(:warning).entries
   end
 
-  def self.only_cms_warnings
-    by_type(:warning).where(cms: true).entries
-  end
-
-  def self.non_cms_warnings
-    by_type(:warning).where(cms: false).entries
-  end
-
-  # only if validator is one of 'CDA SDTC Validator', 'QRDA Cat 1 R3 Validator', 'QRDA Cat 1 Validator', or 'QRDA Cat 3 Validator'
-  #   or if validator type is xml_validation
-  def self.qrda_errors
-    valid_strings = %w[CDA\ SDTC\ Validator QRDA\ Cat\ 1\ R3\ Validator QRDA\ Cat\ 1\ Validator QRDA\ Cat\ 3\ Validator]
-    only_errors.select do |execution_error|
-      true if (execution_error.has_attribute?('validator') &&
-               valid_strings.include?(execution_error[:validator])) ||
-              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :xml_validation)
-    end
-  end
-
-  # only if validator is one of 'Cat 1 Measure ID Validator' or 'Cat 3 Measure ID Validator'
-  #   or if validator type is result_validation
-  def self.reporting_errors
-    only_errors.select do |execution_error|
-      true if (execution_error.has_attribute?('validator') &&
-               %w[Cat\ 1\ Measure\ ID\ Validator Cat\ 3\ Measure\ ID\ Validator].include?(execution_error[:validator])) ||
-              (execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :result_validation)
-    end
-  end
-
-  # only if validator type is submission_validation
-  def self.submission_errors
-    only_errors.select do |execution_error|
-      true if execution_error.has_attribute?('validator_type') && execution_error[:validator_type] == :submission_validation
-    end
-  end
-
   def empty_location_or_c3_error?
     location.nil? || location == '/' || %w[C3Cat1Task C3Cat3Task].include?(test_execution.task._type)
   end

--- a/app/views/products/report/_failing_measure_tests.html.erb
+++ b/app/views/products/report/_failing_measure_tests.html.erb
@@ -37,16 +37,13 @@
         collected_errors = collected_errors(execution)
         collected_errors.files.each do |file_name, error_result| %>
           <% error_result.each do |error_type, error_hash| %>
-            <% message_title = error_type == 'Other Warnings' || error_type == 'CMS Warnings' ? 'Warning' : 'Error' %>
-            <% if error_type == "Reporting" %>
-              <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
-              <% pop_errors = population_data_errors(error_hash.execution_errors - report_sup_data_errors, 'population') %>
-              <% pop_sum_errors = population_data_errors(error_hash.execution_errors - pop_errors, 'population_sum') %>
-              <% non_pop_errors = error_hash.execution_errors - report_sup_data_errors - pop_errors - pop_sum_errors %>
-              <% errors = errors - report_sup_data_errors - pop_errors - pop_sum_errors - non_pop_errors %>
-              <%= render partial: 'test_executions/results/error_table', locals: { errors: non_pop_errors, message_title: message_title } %>
-              <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors + pop_errors + pop_sum_errors, pop_errors_hash: population_error_hash(pop_errors + pop_sum_errors, report_sup_data_errors) } %>
-            <% end %>
+            <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
+            <% pop_errors = population_data_errors(error_hash.execution_errors - report_sup_data_errors, 'population') %>
+            <% pop_sum_errors = population_data_errors(error_hash.execution_errors - pop_errors, 'population_sum') %>
+            <% non_pop_errors = error_hash.execution_errors - report_sup_data_errors - pop_errors - pop_sum_errors %>
+            <% errors = errors - report_sup_data_errors - pop_errors - pop_sum_errors - non_pop_errors %>
+            <%= render partial: 'test_executions/results/error_table', locals: { errors: non_pop_errors, message_title: error_type } %>
+            <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors + pop_errors + pop_sum_errors, pop_errors_hash: population_error_hash(pop_errors + pop_sum_errors, report_sup_data_errors) } %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -66,7 +66,7 @@
               <% total_errors = error_result.keys.map{ |s| error_result[s].execution_errors.count }.reduce(&:+) %>
               <% if total_errors.positive? %>
                 <div class="file-name">
-                  <% if error_result.keys.any? { |s| s != 'Other Warnings' && s != 'CMS Warnings' && error_result[s].execution_errors.count.positive?} %>
+                  <% if error_result.keys.any? { |s| s != 'Warnings' && error_result[s].execution_errors.count.positive?} %>
                     <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                   <% else %>
                     <%= icon('fas fa-fw text-warning', 'exclamation-triangle', :"aria-hidden" => true) %>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class = 'panel-body'>
       <dl class = 'dl-horizontal'>
-      <% get_error_counts(execution, task).each do |error_name, num_errors| %>
+      <% get_error_counts(execution).each do |error_name, num_errors| %>
         <dt><%= error_name %></dt>
         <dd class = 'text-nowrap'><%= num_errors || "--" %></dd>
       <% end %>

--- a/app/views/test_executions/results/_execution_results_for_file.html.erb
+++ b/app/views/test_executions/results/_execution_results_for_file.html.erb
@@ -44,21 +44,13 @@
   <% error_result.each do |error_type, error_hash| %>
     <div id=<%= "#{error_type.tr(' ', '_')}_#{identifier}" %>>
       <% if error_hash.execution_errors.count.positive? %>
-        <% message_title = error_type == 'Other Warnings' || error_type == 'CMS Warnings' ? 'Warning' : 'Error' %>
-
-        <% if error_type == "Reporting" %>
-          <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
-          <% pop_errors = population_data_errors(error_hash.execution_errors - report_sup_data_errors, 'population') %>
-          <% pop_sum_errors = population_data_errors(error_hash.execution_errors - pop_errors, 'population_sum') %>
-          <% non_pop_errors = error_hash.execution_errors - report_sup_data_errors - pop_errors - pop_sum_errors %>
-          <%= render partial: 'test_executions/results/error_table', locals: { errors: non_pop_errors, message_title: message_title } %>
-          <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors + pop_errors + pop_sum_errors, pop_errors_hash: population_error_hash(pop_errors + pop_sum_errors, report_sup_data_errors) } %>
-        <% else %>
-          <%= render partial: 'test_executions/results/error_table', locals: {
-            errors: error_hash.execution_errors,
-            message_title: message_title
-            } %>
-        <% end %>
+        <% message_title = error_type %>
+        <% report_sup_data_errors = population_data_errors(error_hash.execution_errors, 'supplemental_data') %>
+        <% pop_errors = population_data_errors(error_hash.execution_errors - report_sup_data_errors, 'population') %>
+        <% pop_sum_errors = population_data_errors(error_hash.execution_errors - pop_errors, 'population_sum') %>
+        <% non_pop_errors = error_hash.execution_errors - report_sup_data_errors - pop_errors - pop_sum_errors %>
+        <%= render partial: 'test_executions/results/error_table', locals: { errors: non_pop_errors, message_title: message_title } %>
+        <%= render partial: 'test_executions/results/supplemental_data_error_table', locals: { errors: report_sup_data_errors + pop_errors + pop_sum_errors, pop_errors_hash: population_error_hash(pop_errors + pop_sum_errors, report_sup_data_errors) } %>
 
         <% unless on_execution_show_page %>
           <div class="xml-view">

--- a/lib/cypress/error_collector.rb
+++ b/lib/cypress/error_collector.rb
@@ -47,17 +47,12 @@ module Cypress
 
     def create_file_error_hash(doc, all_errs, related_errs)
       file_error_hash = {}
-      submission_errors = all_errs.submission_errors
-      submission_errors += related_errs.only_errors if related_errs.count.positive?
-      file_error_hash['QRDA'] = error_hash(doc, all_errs.qrda_errors)
-      file_error_hash['Reporting'] = error_hash(doc, all_errs.reporting_errors)
-      file_error_hash['Submission'] = error_hash(doc, submission_errors)
-      cms_warn = all_errs.only_cms_warnings
-      cms_warn.concat(related_errs.only_cms_warnings) if related_errs.count.positive?
-      file_error_hash['CMS Warnings'] = error_hash(doc, cms_warn)
-      other_warn = all_errs.non_cms_warnings
-      other_warn.concat(related_errs.non_cms_warnings) if related_errs.count.positive?
-      file_error_hash['Other Warnings'] = error_hash(doc, other_warn)
+      errors = all_errs.only_errors
+      errors += related_errs.only_errors if related_errs.count.positive?
+      warnings = all_errs.only_warnings
+      warnings += related_errs.only_warnings if related_errs.count.positive?
+      file_error_hash['Errors'] = error_hash(doc, errors)
+      file_error_hash['Warnings'] = error_hash(doc, warnings)
       file_error_hash
     end
 

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -78,11 +78,10 @@ class TestExecutionHelper < ActiveSupport::TestCase
   def test_get_error_counts_no_execution
     setup_product_tests(true, false, true, true, filt1: 'val1')
 
-    errors_hash = get_error_counts(nil, @product_test.tasks.find_by(_type: 'C1Task'))
+    errors_hash = get_error_counts(nil)
 
-    assert_equal '--', errors_hash['QRDA Errors']
-    assert_equal '--', errors_hash['Reporting Errors']
-    assert_equal '--', errors_hash['Submission Errors']
+    assert_equal '--', errors_hash['Errors']
+    assert_equal '--', errors_hash['Warnings']
   end
 
   def test_get_error_counts
@@ -95,11 +94,9 @@ class TestExecutionHelper < ActiveSupport::TestCase
     execution.execution_errors.create(message: 'result error 2', msg_type: :error, validator_type: :result_validation)
     execution.state = :failed
 
-    errors_hash = get_error_counts(execution, c1_task)
+    errors_hash = get_error_counts(execution)
 
-    assert_equal 1, errors_hash['QRDA Errors']
-    assert_equal 2, errors_hash['Reporting Errors']
-    assert_nil errors_hash['Submission Errors']
+    assert_equal 3, errors_hash['Errors']
   end
 
   def test_get_select_history_message

--- a/test/helpers/xml_view_helper_test.rb
+++ b/test/helpers/xml_view_helper_test.rb
@@ -23,12 +23,12 @@ class XmlViewHelperTest < ActiveSupport::TestCase
     errs = collected_errors(@te)
     assert_equal 0, errs.nonfile.count
     assert_equal 1, errs.files.keys.count, 'should contain one file with errors'
-    assert_equal ['QRDA', 'Reporting', 'Submission', 'CMS Warnings', 'Other Warnings'], errs.files['0_Dental_Peds_A.xml'].keys, 'should contain right error keys for each file'
+    assert_equal %w[Errors Warnings], errs.files['0_Dental_Peds_A.xml'].keys, 'should contain right error keys for each file'
   end
 
   def test_popup_attributes_multiple_errors
     errs = collected_errors(@te)
-    error = errs.files['0_Dental_Peds_A.xml']['QRDA'].execution_errors
+    error = errs.files['0_Dental_Peds_A.xml']['Errors'].execution_errors
     title, button_text, _message = popup_attributes(error)
     assert_match 'Execution Errors (2)', title
     assert_match error.count.to_s, title
@@ -38,7 +38,7 @@ class XmlViewHelperTest < ActiveSupport::TestCase
 
   def test_popup_attributes_one_error
     errs = collected_errors(@te)
-    error = [errs.files['0_Dental_Peds_A.xml']['QRDA'].execution_errors.first] # get just one error
+    error = [errs.files['0_Dental_Peds_A.xml']['Errors'].execution_errors.first] # get just one error
     title, button_text, message = popup_attributes(error)
 
     assert_match 'Execution Error', title

--- a/test/models/test_execution_test.rb
+++ b/test/models/test_execution_test.rb
@@ -42,31 +42,6 @@ class TestExecutionTest < ActiveSupport::TestCase
     assert te.errored?, 'te.errored? not returning true when execution is errored'
   end
 
-  def test_qrda_reporting_and_submission_errors
-    qrda_errors = [
-      { validator: 'CDA SDTC Validator', msg_type: :error },
-      { validator: 'QRDA Cat 1 R3 Validator', msg_type: :error },
-      { validator: 'QRDA Cat 1 Validator', msg_type: :error },
-      { validator: 'QRDA Cat 3 Validator', msg_type: :error },
-      { validator_type: :xml_validation, msg_type: :error }
-    ]
-    reporting_errors = [
-      { validator: 'Cat 1 Measure ID Validator', msg_type: :error },
-      { validator: 'Cat 3 Measure ID Validator', msg_type: :error },
-      { validator_type: :result_validation, msg_type: :error }
-    ]
-    submission_errors = [
-      { validator_type: :submission_validation, msg_type: :error }
-    ]
-    execution_errors = qrda_errors + reporting_errors + submission_errors
-
-    te = TestExecution.new(execution_errors: execution_errors)
-
-    assert_equal te.execution_errors.qrda_errors.count, qrda_errors.count
-    assert_equal te.execution_errors.reporting_errors.count, reporting_errors.count
-    assert_equal te.execution_errors.submission_errors.count, submission_errors.count
-  end
-
   def test_validate_artifact_builds_execution_errors_for_incomplete_checked_criteria
     measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
     vendor = Vendor.new(name: "my vendor #{rand}")

--- a/test/unit/product_report_test.rb
+++ b/test/unit/product_report_test.rb
@@ -227,11 +227,8 @@ class ProductReportTest < ActionController::TestCase
     collected_errors = collected_errors(test_execution)
     error_count = collected_errors[:nonfile].size
     collected_errors[:files].each_value do |collected_error_values|
-      error_count += collected_error_values['QRDA'][:execution_errors].size
-      error_count += collected_error_values['Reporting'][:execution_errors].size
-      error_count += collected_error_values['Submission'][:execution_errors].size
-      error_count += collected_error_values['CMS Warnings'][:execution_errors].size
-      error_count += collected_error_values['Other Warnings'][:execution_errors].size
+      error_count += collected_error_values['Errors'][:execution_errors].size
+      error_count += collected_error_values['Warnings'][:execution_errors].size
     end
     assert_equal error_count, test_execution.execution_errors.size
   end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code