### PR TITLE
Bring back measure api evaluator test

### DIFF
--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -5,22 +5,21 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
   include ActiveJob::TestHelper
 
-  # TODO: Add this test back in.
-  # def test_complete_roundtrip_using_real_bundle
-  #   # Leverage using functions in the ApiMeasureEvaluator
-  #   @apime = Cypress::ApiMeasureEvaluator.new('test', 'test')
-  #   import_bundle_and_create_product(retrieve_bundle)
-  #   perform_filtering_tests
-  #   perform_measure_tests
-  #   failed_tests = TestExecution.where(state: 'failed')
-  #   assert failed_tests.empty?, "Test failed for #{failed_tests.first.task.product_test.cms_id} - #{failed_tests.collect { |ft| ft.execution_errors.collect(&:message) }}" unless failed_tests.empty?
-  # end
+  def test_complete_roundtrip_using_real_bundle
+    # Leverage using functions in the ApiMeasureEvaluator
+    @apime = Cypress::ApiMeasureEvaluator.new('test', 'test')
+    import_bundle_and_create_product(retrieve_bundle)
+    perform_filtering_tests
+    perform_measure_tests
+    failed_tests = TestExecution.where(state: 'failed')
+    assert failed_tests.empty?, "Test failed for #{failed_tests.first.task.product_test.cms_id} - #{failed_tests.collect { |ft| ft.execution_errors.collect(&:message) }}" unless failed_tests.empty?
+  end
 
   # Get bundle from the demo server.  Use VCR if available
   def retrieve_bundle
     VCR.use_cassette('bundle_download') do
       bundle_resource = RestClient::Request.execute(method: :get,
-                                                    url: 'https://cypress.healthit.gov/measure_bundles/2019-fixture-bundle.zip',
+                                                    url: 'https://cypress.healthit.gov/measure_bundles/fixture-bundle-2020.zip',
                                                     user: ENV['VSAC_USERNAME'],
                                                     password: ENV['VSAC_PASSWORD'],
                                                     raw_response: true,


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code