### PR TITLE
(5.4.0) Fewer birthdates

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -120,15 +120,7 @@ module Cypress
 
     def self.randomize_birthdate(patient, random: Random.new)
       birth_datetime = patient.birthDatetime
-      while birth_datetime == patient.birthDatetime
-        patient.birthDatetime = patient.birthDatetime.change(
-          case random.rand(3)
-          when 0 then { day: 1, month: 1 }
-          when 1 then { day: random.rand(28) + 1 }
-          when 2 then { month: random.rand(12) + 1 }
-          end
-        )
-      end
+      patient.birthDatetime = patient.birthDatetime.change(day: random.rand(28) + 1) while birth_datetime == patient.birthDatetime
       if patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first
         patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first.birthDatetime = patient.birthDatetime
       end

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -70,14 +70,14 @@ module CQM
     end
 
     def randomize_patient_name_or_birth(patient, changed, augmented_patients, random: Random.new)
-      case random.rand(3) # random chooses which part of the patient is modified
-      when 0 # first name
+      case random.rand(21) # random chooses which part of the patient is modified. Limit birthdate to ~1/20
+      when 0..9 # first name
         patient = Cypress::NameRandomizer.randomize_patient_name_first(patient, augmented_patients, random: random)
         changed[:first] = [first_names, patient.first_names]
-      when 1 # last name
+      when 10..19 # last name
         patient = Cypress::NameRandomizer.randomize_patient_name_last(patient, augmented_patients, random: random)
         changed[:last] = [familyName, patient.familyName]
-      when 2 # birthdate
+      when 20 # birthdate
         Cypress::DemographicsRandomizer.randomize_birthdate(patient.qdmPatient, random: random)
         changed[:birthdate] = [qdmPatient.birthDatetime, patient.qdmPatient.birthDatetime]
       end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code