### PR TITLE
(5.4.0) Fewer birthdates 

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -120,7 +120,8 @@ module Cypress
 
     def self.randomize_birthdate(patient, random: Random.new)
       birth_datetime = patient.birthDatetime
-      patient.birthDatetime = patient.birthDatetime.change(day: random.rand(28) + 1) while birth_datetime == patient.birthDatetime
+      days_in_month = Time.days_in_month(patient.birthDatetime.month, patient.birthDatetime.year)
+      patient.birthDatetime = patient.birthDatetime.change(day: random.rand(days_in_month) + 1) while birth_datetime == patient.birthDatetime
       if patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first
         patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first.birthDatetime = patient.birthDatetime
       end

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -120,15 +120,7 @@ module Cypress
 
     def self.randomize_birthdate(patient, random: Random.new)
       birth_datetime = patient.birthDatetime
-      while birth_datetime == patient.birthDatetime
-        patient.birthDatetime = patient.birthDatetime.change(
-          case random.rand(3)
-          when 0 then { day: 1, month: 1 }
-          when 1 then { day: random.rand(28) + 1 }
-          when 2 then { month: random.rand(12) + 1 }
-          end
-        )
-      end
+      patient.birthDatetime = patient.birthDatetime.change(day: random.rand(28) + 1) while birth_datetime == patient.birthDatetime
       if patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first
         patient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first.birthDatetime = patient.birthDatetime
       end

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -70,14 +70,14 @@ module CQM
     end
 
     def randomize_patient_name_or_birth(patient, changed, augmented_patients, random: Random.new)
-      case random.rand(3) # random chooses which part of the patient is modified
-      when 0 # first name
+      case random.rand(21) # random chooses which part of the patient is modified. Limit birthdate to ~1/20
+      when 0..9 # first name
         patient = Cypress::NameRandomizer.randomize_patient_name_first(patient, augmented_patients, random: random)
         changed[:first] = [first_names, patient.first_names]
-      when 1 # last name
+      when 10..19 # last name
         patient = Cypress::NameRandomizer.randomize_patient_name_last(patient, augmented_patients, random: random)
         changed[:last] = [familyName, patient.familyName]
-      when 2 # birthdate
+      when 20 # birthdate
         Cypress::DemographicsRandomizer.randomize_birthdate(patient.qdmPatient, random: random)
         changed[:birthdate] = [qdmPatient.birthDatetime, patient.qdmPatient.birthDatetime]
       end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -96,7 +96,7 @@ class PatientTest < ActiveSupport::TestCase
     # at least one birthdate should be changed
     assert birthdate_count.positive?
     # fewer than 10 birthdates should be changed (there should be ~5)
-    # Padding in assert to account for randomness
+    # Padding in assert to account for randomness (count will be 13+ on ~0.15% of runs)
     assert birthdate_count < 13
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -97,6 +97,6 @@ class PatientTest < ActiveSupport::TestCase
     assert birthdate_count.positive?
     # fewer than 10 birthdates should be changed (there should be ~5)
     # Padding in assert to account for randomness
-    assert birthdate_count < 10
+    assert birthdate_count < 13
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -59,4 +59,44 @@ class PatientTest < ActiveSupport::TestCase
       assert(record_birthyear_equal?(r1, r1copy_set[0]), 'The two records should always have the same birthyear')
     end
   end
+
+  def test_randomize_patient_name_or_birth_counts
+    first_count = 0
+    last_count = 0
+    birthdate_count = 0
+    100.times do
+      random = Random.new_seed
+      prng1 = Random.new(random)
+
+      r1 = Patient.new(familyName: 'Robert', givenNames: ['Johnson'])
+      r1.qdmPatient.birthDatetime = DateTime.new(1985, 2, 18).utc
+      r1.qdmPatient.dataElements << QDM::PatientCharacteristicRace.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['races'].sample(random: prng1)['code'], 'code_system' => 'cdcrec' }])
+      r1.qdmPatient.dataElements << QDM::PatientCharacteristicEthnicity.new(dataElementCodes: [{ 'code' => APP_CONSTANTS['randomization']['ethnicities'].sample(random: prng1)['code'], 'code_system' => 'cdcrec' }])
+      r1.qdmPatient.dataElements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M', 'code_system' => 'AdministrativeGender' }])
+
+      clone_patient = r1.clone
+      _patient, changed = r1.randomize_patient_name_or_birth(clone_patient, {}, [], random: prng1)
+
+      first_count += 1 unless changed[:first].nil?
+      last_count += 1 unless changed[:last].nil?
+      next unless changed[:birthdate]
+
+      birthdate_count += 1
+      # Year should always remain unchanged
+      assert(changed[:birthdate][0].year, changed[:birthdate][1].year)
+      # Month should always remain unchanged
+      assert(changed[:birthdate][0].month, changed[:birthdate][1].month)
+      # Day should always be changed
+      assert_not_equal(changed[:birthdate][0].day, changed[:birthdate][1].day)
+    end
+    # at least one first name should be changed
+    assert first_count.positive?
+    # at least one last name should be changed
+    assert last_count.positive?
+    # at least one birthdate should be changed
+    assert birthdate_count.positive?
+    # fewer than 10 birthdates should be changed (there should be ~5)
+    # Padding in assert to account for randomness
+    assert birthdate_count < 10
+  end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code