### PR TITLE
remove redundant 508 check

### DIFF
--- a/features/multi_measure_tests/records_list.feature
+++ b/features/multi_measure_tests/records_list.feature
@@ -20,7 +20,7 @@ Scenario: Admin should be able to view list of measures
   And the user views the task records
   Then the user should see the list of measures
   Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be accessible according to: wcag2aaa
 
 Scenario: Admin should be able to filter patient data
   When the user creates a cvu plus product with records
@@ -36,5 +36,3 @@ Scenario: Admin should be able to filter patient data
   When the user filters on All Measures
   Then the user should see text Value Set Name 8
   Then the user should see text Value Set Name 5
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aaa


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code