### PR TITLE
Only choose problem filter criteria with snomed codes

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -228,7 +228,7 @@ class Product
     filter_tests.concat [build_filtering_test(measure, criteria[0, 2]), build_filtering_test(measure, criteria[2, 2])]
     filter_tests << build_filtering_test(measure, ['providers'], 'NPI, TIN & Provider Location')
     filter_tests << build_filtering_test(measure, ['providers'], 'NPI & TIN', false)
-    criteria = ApplicationController.helpers.measure_has_diagnosis_criteria?(measure) ? ['problems'] : criteria.values_at(4, (0..3).to_a.sample)
+    criteria = ApplicationController.helpers.measure_has_snomed_dx_criteria?(measure) ? ['problems'] : criteria.values_at(4, (0..3).to_a.sample)
     filter_tests << build_filtering_test(measure, criteria)
     ApplicationController.helpers.generate_filter_patients(filter_tests)
   end

--- a/lib/ext/value_set.rb
+++ b/lib/ext/value_set.rb
@@ -6,6 +6,10 @@ class ValueSet
   store_in collection: 'health_data_standards_svs_value_sets'
 
   belongs_to :bundle, class_name: 'Bundle', inverse_of: :value_sets
+
+  def snomed_codes?
+    concepts.any? { |concept| concept.code_system_oid == '2.16.840.1.113883.6.96' }
+  end
 end
 
 class Concept

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -168,6 +168,23 @@ class ProducTest < ActiveSupport::TestCase
     assert_equal 5, pt.product_tests.filtering_tests.count
   end
 
+  def test_add_filtering_test_without_snomed_dx
+    # Modify a measure to have a single Diagnosis data criteria without a snomed code
+    measure = Measure.find_by hqmf_id: '40280382-5FA6-FE85-0160-0918E74D2075'
+    vs = ValueSet.first
+    vs.concepts.first.code_system_oid = '2.16.840.1.113883.6.95' # Not SNOMED
+    vs.save
+    measure.source_data_criteria = [QDM::Diagnosis.new(codeListId: vs.oid)]
+    measure.save
+    pt = Product.new(vendor: @vendor, name: 'test_product', c2_test: true, c4_test: true, measure_ids: ['40280382-5FA6-FE85-0160-0918E74D2075'],
+                     bundle_id: @bundle.id)
+    pt.save!
+    pt.add_filtering_tests
+    filter_criteria = pt.product_tests.filtering_tests.collect(&:options).collect(&:filters).collect(&:keys).flatten
+    # The set of filter_criteria should not include a problem filter
+    assert_equal false, filter_criteria.include?('problems')
+  end
+
   # def test_add_checklist_test
   #   pt = Product.new(vendor: @vendor, name: 'my_product', c1_test: true, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
   #                    bundle_id: @bundle.id)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-678
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code