### PR TITLE
(clean-up) method cached_value no longer used

### DIFF
--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -98,20 +98,6 @@ module Validators
       passed
     end
 
-    def cached_value(vs)
-      @loaded_valuesets ||= {}
-      return @loaded_valuesets[vs.oid] if @loaded_valuesets[vs.oid]
-
-      js = {}
-      vs.concepts.each do |con|
-        name = con.code_system_name
-        js[name] ||= []
-        js[name] << con.code.downcase unless js[name].index(con.code.downcase)
-      end
-      @loaded_valuesets[vs.oid] = js
-      js
-    end
-
     def validate(doc, options)
       @can_continue = true
       valid = validate_calculated_results(doc, options)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code