### PR TITLE
(5.4.0) Add HL7 only tasks to CVU+ test

### DIFF
--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -12,6 +12,7 @@ class CMSProgramTask < Task
     @validators.concat program_specific_validators
     # If the CMSProgramTask is for HL7 validation, only include QRDA validation
     @validators = hl7_validators if %w[HL7_Cat_I HL7_Cat_III].include? product_test.cms_program
+    @validators
   end
 
   # Each cms program may have program specific validations

--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -10,6 +10,8 @@ class CMSProgramTask < Task
                    MeasurePeriodValidator.new]
     # Each program may have program specific validations add them
     @validators.concat program_specific_validators
+    # If the CMSProgramTask is for HL7 validation, only include QRDA validation
+    @validators = hl7_validators if %w[HL7_Cat_I HL7_Cat_III].include? product_test.cms_program
   end
 
   # Each cms program may have program specific validations
@@ -24,6 +26,15 @@ class CMSProgramTask < Task
     return mips_virtual_group_validators if product_test.cms_program == 'MIPS_VIRTUALGROUP'
 
     []
+  end
+
+  def hl7_validators
+    if product_test.reporting_program_type == 'eh'
+      # ProgramCriteriaValidator is how the measure calculation is being called. Add it as well to Cat I files
+      [::Validators::QrdaCat1Validator.new(product_test.bundle, false, product_test.c3_test, true), ProgramCriteriaValidator.new(product_test)]
+    else
+      [::Validators::QrdaCat3Validator.new(nil, false, true, false, product_test.bundle)]
+    end
   end
 
   def hqr_pi_validators

--- a/app/models/cms_program_test.rb
+++ b/app/models/cms_program_test.rb
@@ -5,7 +5,7 @@ class CMSProgramTest < ProductTest
   accepts_nested_attributes_for :program_criteria, allow_destroy: true
 
   # List of cms programs
-  validates :cms_program, inclusion: %w[HQR_PI HQR_IQR HQR_PI_IQR HQR_IQR_VOL CPCPLUS MIPS_INDIV MIPS_GROUP MIPS_VIRTUALGROUP]
+  validates :cms_program, inclusion: %w[HQR_PI HQR_IQR HQR_PI_IQR HQR_IQR_VOL CPCPLUS MIPS_INDIV MIPS_GROUP MIPS_VIRTUALGROUP HL7_Cat_I HL7_Cat_III]
 
   after_create do |product_test|
     create_tasks

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -119,6 +119,7 @@ class Product
     update(params)
     add_multi_measure_tests(new_eh_ids, new_eh_ids != old_eh_ids, new_ep_ids, new_ep_ids != old_ep_ids)
     add_cms_program_tests(new_eh_ids, new_eh_ids != old_eh_ids, new_ep_ids, new_ep_ids != old_ep_ids)
+    add_hl7_tests(new_ids)
   end
 
   def add_measure_tests(params)
@@ -202,6 +203,17 @@ class Product
                               reporting_program_type: 'ep' }, CMSProgramTest)
       end
     end
+  end
+
+  def add_hl7_tests(measure_ids)
+    # Only create the hl7 tests if they don't already exist
+    return unless product_tests.cms_program_tests.where(cms_program: 'HL7_Cat_I').empty?
+
+    # The 'reporting_program_type' is used to restrict the upload type.  Use EH for Cat I, and EP for Cat III
+    product_tests.build({ name: 'HL7 Cat I Test', cms_program: 'HL7_Cat_I', measure_ids: measure_ids,
+                          reporting_program_type: 'eh' }, CMSProgramTest)
+    product_tests.build({ name: 'HL7 Cat III Test', cms_program: 'HL7_Cat_III', measure_ids: measure_ids,
+                          reporting_program_type: 'ep' }, CMSProgramTest)
   end
 
   def add_filtering_tests

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -95,6 +95,20 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
     end
   end
 
+  def test_qrda1_task_with_errors
+    setup_eh
+    pt = @product.product_tests.cms_program_tests.where(cms_program: 'HL7_Cat_I').first
+    task = pt.tasks.first
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_bad_schema.xml'))
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      assert_equal 1, te.execution_errors.size
+      # This is a schematron error
+      assert_equal 1, te.execution_errors.where(validator: 'CqmValidators::Cat1R51').size
+    end
+  end
+
   def test_eh_task_with_errors_quarter_reporting
     setup_eh
     pt = @product.product_tests.cms_program_tests.where(cms_program: 'HQR_PI').first


### PR DESCRIPTION
I believe this is probably the simplest way to address this user's concern 

https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2033

We currently don't run Cat I validations for any of the EP eCQMs.

<img width="948" alt="Screen Shot 2020-05-01 at 8 29 54 AM" src="https://user-images.githubusercontent.com/8173551/80805515-46ec6f00-8b86-11ea-8d63-31330e0e968f.png">


**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code