### PR TITLE
(5.4.0) Update Record Sample to allow for string attribute values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,8 @@ gem 'os'
 
 gem 'cqm-models', '~> 2.0.0'
 gem 'cqm-parsers', '~> 2.0.0'
-gem 'cqm-reports', '~> 2.0.7'
+# gem 'cqm-reports', '~> 2.0.7'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'allow_string'
 gem 'cqm-validators', '~> 2.0.1'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,20 @@
 GIT
+  remote: https://github.com/projecttacoma/cqm-reports
+  revision: 9ac26781e9b2988fb1047cc7d6310e809d01cdb8
+  branch: allow_string
+  specs:
+    cqm-reports (2.0.8)
+      cqm-models (~> 2.0.0)
+      erubis (~> 2.7)
+      log4r (~> 1.1)
+      memoist (~> 0.9)
+      mongoid-tree (~> 2.1)
+      mustache
+      nokogiri (~> 1.10)
+      uuid (~> 2.3)
+      zip-zip (~> 0.3)
+
+GIT
   remote: https://github.com/turbolinks/turbolinks-classic
   revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
   branch: master
@@ -140,16 +156,6 @@ GEM
       protected_attributes_continued (~> 1.4)
       rubyzip (~> 1.2)
       typhoeus (~> 1.3)
-      uuid (~> 2.3)
-      zip-zip (~> 0.3)
-    cqm-reports (2.0.7)
-      cqm-models (~> 2.0.0)
-      erubis (~> 2.7)
-      log4r (~> 1.1)
-      memoist (~> 0.9)
-      mongoid-tree (~> 2.1)
-      mustache
-      nokogiri (~> 1.10)
       uuid (~> 2.3)
       zip-zip (~> 0.3)
     cqm-validators (2.0.1)
@@ -529,7 +535,7 @@ DEPENDENCIES
   codecov
   cqm-models (~> 2.0.0)
   cqm-parsers (~> 2.0.0)
-  cqm-reports (~> 2.0.7)
+  cqm-reports!
   cqm-validators (~> 2.0.1)
   cucumber (~> 3.0.2)
   cucumber-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
       jquery-rails
       railties (>= 3.1)
       sass-rails
-    jquery-rails (4.3.3)
+    jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)

--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -61,6 +61,7 @@ module Validators
       return true if attribute.is_a? DateTime
       return true if attribute.is_a? Integer
       return true if attribute.is_a? Float
+      return true if attribute.is_a? String
       # If the attribute is an Array, loop through the array
       return attribute.any? { |at| attribute_has_data(at, checked_criteria) } if attribute.is_a? Array
 

--- a/test/unit/lib/validators/checklist_criteria_validator_test.rb
+++ b/test/unit/lib/validators/checklist_criteria_validator_test.rb
@@ -347,6 +347,41 @@ class ChecklistCriteriaValidator < ActiveSupport::TestCase
     end
   end
 
+  def test_validate_result_with_string
+    validator = CqmValidators::Cat1R5.instance
+    cda_validator = CqmValidators::CDA.instance
+
+    dt = QDM::PatientGeneration.generate_loaded_datatype('QDM::LaboratoryTestPerformed')
+    dt.result = 'Positive'
+    setup_sdc(dt.clone, 'result', false, 'Positive', nil)
+
+    test_specific_qdm_patient = @qdm_patient.clone
+    test_specific_qdm_patient.dataElements << dt
+    @cqm_patient.qdmPatient = test_specific_qdm_patient
+
+    patient_xml = Qrda1R5.new(@cqm_patient, Measure.where(hqmf_id: 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'), @options).render
+
+    doc = Nokogiri::XML::Document.parse(patient_xml)
+    doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+    @validator.validate(doc)
+
+    begin
+      exported_qrda = doc
+      errors = validator.validate(exported_qrda)
+      cda_errors = cda_validator.validate(exported_qrda)
+      errors.each do |error|
+        puts "\e[31mSchema Error In test_validate_result_with_string: #{error.message}\e[0m"
+      end
+      cda_errors.each do |error|
+        puts "\e[31mSchema Error In test_validate_result_with_string: #{error.message}\e[0m"
+      end
+    rescue StandardError => e
+      puts "\e[31mException validating test_validate_result_with_string: #{e.message}\e[0m"
+    end
+    assert @checklist_test.checked_criteria.first[:passed_qrda]
+  end
+
   def test_validate_bad_files
     TEST_ARRAY.each do |ta|
       restricted_dt = QDM::PatientGeneration.generate_loaded_datatype(ta[6])


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code