### PR TITLE
(6.x and 5.4.1) Only show C3 when its appropriate for the eCQM

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -80,6 +80,7 @@ Metrics/ParameterLists:
 Metrics/PerceivedComplexity:
   Max: 10
   Exclude:
+    - 'app/helpers/products_helper.rb'
     - 'lib/cypress/data_criteria_attribute_builder.rb'
     - 'lib/validators/checklist_criteria_validator.rb'
     - 'test/unit/lib/validators/checklist_criteria_validator_test.rb'

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -157,7 +157,7 @@ module ProductsHelper
   def title_for(product, test_type, is_qrda_1_measure_test = true)
     case test_type
     when 'ChecklistTest'
-      product.c3_test ? 'C1 + C3 Sample' : 'C1 Sample'
+      product.c3_test && product.eh_tests? ? 'C1 + C3 Sample' : 'C1 Sample'
     when 'MeasureTest'
       measure_test_title(product, is_qrda_1_measure_test)
     when 'FilteringTest'

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -100,6 +100,15 @@ module ProductsHelper
     "wrapper-task-id-#{task.id}"
   end
 
+  def include_c3_column(task)
+    case task
+    when C1Task
+      task.product_test.product.c3_test && task.product_test.product.eh_tests?
+    when C2Task
+      task.product_test.product.c3_test && task.product_test.product.ep_tests?
+    end
+  end
+
   # returns array of tasks. includes a c3 task if it exists
   # input should be a c1 or c2 task
   def with_c3_task(task)
@@ -162,14 +171,14 @@ module ProductsHelper
 
   def measure_test_title(product, is_qrda_1_measure_test = true)
     if is_qrda_1_measure_test
-      if product.c1_test && product.c3_test
+      if product.c1_test && product.c3_test && product.eh_tests?
         'C1 + C3 (QRDA-I)'
       elsif product.c1_test
         'C1 (QRDA-I)'
       else
         'C3 (QRDA-I)'
       end
-    elsif product.c2_test && product.c3_test
+    elsif product.c2_test && product.c3_test && product.ep_tests?
       'C2 + C3 (QRDA-III)'
     elsif product.c2_test
       'C2 (QRDA-III)'
@@ -181,7 +190,7 @@ module ProductsHelper
   def description_for(product, test_type, is_qrda_1_measure_test = true)
     case test_type
     when 'ChecklistTest'
-      certifications = product.c3_test ? 'C1 and C3 certifications' : 'C1 certification'
+      certifications = product.c3_test && product.eh_tests? ? 'C1 and C3 certifications' : 'C1 certification'
       "Validate the EHR system for #{certifications} by entering specified patient data for the following measures."
     when 'MeasureTest'
       what_certifications_test_for = if is_qrda_1_measure_test
@@ -196,7 +205,7 @@ module ProductsHelper
   end
 
   def qrda_1_measure_test_description(product)
-    if product.c1_test && product.c3_test
+    if product.c1_test && product.c3_test && product.eh_tests?
       'record and export (C1) and submit (C3)'
     elsif product.c1_test
       'record and export (C1)'
@@ -206,7 +215,7 @@ module ProductsHelper
   end
 
   def qrda_3_measure_test_description(product)
-    if product.c2_test && product.c3_test
+    if product.c2_test && product.c3_test && product.ep_tests?
       'import and calculate (C2) and submit (C3)'
     elsif product.c2_test
       'import and calculate (C2)'

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -29,10 +29,15 @@ module TestExecutionsHelper
 
   # task_type is String and c3_task is boolean
   # returns an array of booleans [c1, c2, c3, c4]. true if page is testing these certification types
-  def current_certifications(task_type, c3_task)
+  def current_certifications(task_type, c3_task, eh_measures, ep_measures)
     return [false, false, false, true] if %w[Cat1FilterTask Cat3FilterTask].include?(task_type)
 
-    [%w[C1Task C1ChecklistTask].include?(task_type), task_type == 'C2Task', c3_task, false]
+    # matched_reporting_types are the following
+    # C2 Tasks (QRDA Cat III) with ep measures
+    # C1 Tasks (QRDA Cat I) with eh measures
+    qrda_cat_1_task = %w[C1Task C1ChecklistTask].include?(task_type)
+    matched_reporting_types = (task_type == 'C2Task' && ep_measures) || (qrda_cat_1_task && eh_measures)
+    [qrda_cat_1_task, task_type == 'C2Task', matched_reporting_types && c3_task, false]
   end
 
   # returns the number of each type of error

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -8,17 +8,17 @@ module TestExecutionsHelper
       (task.is_a?(CMSProgramTask) && task.product_test.reporting_program_type == 'eh')
   end
 
-  def task_type_to_title(task_type, c3)
+  def task_type_to_title(task_type)
     case task_type
     when 'C1Task'
       if @product_test.c1_test
-        c3 ? 'C1 and C3' : 'C1'
+        @product_test.c3_cat1_task? ? 'C1 and C3' : 'C1'
       else
         'C3 (QRDA-I)'
       end
     when 'C2Task'
       if @product_test.c2_test
-        c3 ? 'C2 and C3' : 'C2'
+        @product_test.c3_cat3_task? ? 'C2 and C3' : 'C2'
       else
         'C3 (QRDA-III)'
       end
@@ -57,7 +57,7 @@ module TestExecutionsHelper
   def get_title_message(test, task)
     msg = ''
     if test.is_a? MeasureTest
-      msg << task_type_to_title(task._type, task.product_test.product.c3_test)
+      msg << task_type_to_title(task._type)
       msg << ' certification'
       msg << 's' if test.product.c3_test
     else

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -233,6 +233,14 @@ class Product
     ApplicationController.helpers.generate_filter_patients(filter_tests)
   end
 
+  def ep_tests?
+    product_tests.any?(&:ep_measures?)
+  end
+
+  def eh_tests?
+    product_tests.any?(&:eh_measures?)
+  end
+
   # Here we validate that duplicate_patients is set if c2_test is set
   def enforce_duplicate_patient_settings
     self.duplicate_patients = c2_test if duplicate_patients.nil?

--- a/app/views/application/_checklist_execution_results.html.erb
+++ b/app/views/application/_checklist_execution_results.html.erb
@@ -10,7 +10,7 @@
 <% status_with_sibling = execution ? execution.status_with_sibling : nil %>
 <% c3_execution = execution ? execution.sibling_execution : nil %>
 <% should_include_c1 = task.product_test.product.c1_test %>
-<% should_include_c3 = task.product_test.product.c3_test %>
+<% should_include_c3 = task.product_test.product.c3_test && task.product_test.product.eh_tests? %>
 
 <table class = 'table table-hover table-condensed'>
   <thead>

--- a/app/views/checklist_tests/show.html.erb
+++ b/app/views/checklist_tests/show.html.erb
@@ -1,7 +1,7 @@
 <% product = @product %>
 <% has_many_measures = @product_test.measures.count > CAT1_CONFIG['number_of_checklist_measures'] %>
 
-<%= render 'application/certification_bar', :product => product, :active_certs => [true, false, product.c3_test, false] %>
+<%= render 'application/certification_bar', :product => product, :active_certs => [true, false, product.c3_test && @product_test.eh_measures?, false] %>
 
 <div class="panel-actions pull-right">
   <%= button_to print_criteria_product_checklist_test_path(@product, @product_test), :method => :get, :class => "btn btn-default" do %>

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -13,7 +13,7 @@
   <p>There are no additional tests for this criteria.</p>
 <% else %>
   <% first_results_col_label = tasks.first.is_a?(C1Task) ? 'C1 Results' : 'C2 Results' %>
-  <% include_c3 = product.c3_test %>
+  <% include_c3 = include_c3_column(tasks.first) %>
 
   <table class = 'table table-hover measure_tests_table'>
     <thead>

--- a/app/views/products/_measure_tests_table_row.html.erb
+++ b/app/views/products/_measure_tests_table_row.html.erb
@@ -10,7 +10,7 @@
 <% parent_reloading = false unless (defined? parent_reloading) %>
 
 <% test = task.product_test %>
-<% include_c3 = test.product.c3_test %>
+<% include_c3 = include_c3_column(task) %>
 
 <td data-sort="<%= cms_int(test.cms_id) %>"><%= test.cms_id %></td>
 <td><%= link_to test.name, new_task_test_execution_path(task) %></td>

--- a/app/views/products/report/_certification_report.html.erb
+++ b/app/views/products/report/_certification_report.html.erb
@@ -10,8 +10,8 @@
         <th scope="col">Submeasures</th>
         <%= @product.c1_test ? "<th scope='col' class = 'text-center'>C1 QRDA Category I</th>".html_safe : "<td></td>".html_safe %>
         <%= @product.c2_test ? "<th scope='col' class = 'text-center'>C2 QRDA Category III</th>".html_safe : "<td></td>".html_safe %>
-        <%= @product.c3_test ? "<th scope='col' class = 'text-center'>C3 QRDA Category I</th>".html_safe : "<td></td>".html_safe %>
-        <%= @product.c3_test ? "<th scope='col' class = 'text-center'>C3 QRDA Category III</th>".html_safe : "<td></td>".html_safe %>
+        <%= @product.c3_test && @product.eh_tests? ? "<th scope='col' class = 'text-center'>C3 QRDA Category I</th>".html_safe : "<td></td>".html_safe %>
+        <%= @product.c3_test && @product.ep_tests? ? "<th scope='col' class = 'text-center'>C3 QRDA Category III</th>".html_safe : "<td></td>".html_safe %>
       </tr>
     </thead>
     <tbody>

--- a/app/views/test_executions/_task_status.html.erb
+++ b/app/views/test_executions/_task_status.html.erb
@@ -16,7 +16,7 @@
 <div class = 'col-sm-4'>
   <div class = 'panel <%= panel_class %> task-panel'>
     <div class = 'panel-heading'>
-      <h1 class = 'panel-title text-center'><%= task_type_to_title(task._type, c3) %></h1>
+      <h1 class = 'panel-title text-center'><%= task_type_to_title(task._type) %></h1>
     </div>
     <div class = 'panel-body'>
       <dl class = 'dl-horizontal'>

--- a/app/views/test_executions/file_result.html.erb
+++ b/app/views/test_executions/file_result.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'application/certification_bar', locals: { product: @task.product_test.product, active_certs: current_certifications(@task._type, @task.product_test.product.c3_test) } %>
+<%= render partial: 'application/certification_bar', locals: { product: @task.product_test.product, active_certs: current_certifications(@task._type, @task.product_test.product.c3_test, @task.product_test.eh_measures?, @task.product_test.ep_measures?) } %>
 
 <% is_passing = @test_execution.status_with_sibling == 'passing' %>
 

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -9,7 +9,7 @@
   <% cat1_task = @task.product_test.tasks.cat1_filter_task %>
   <% cat3_task = @task.product_test.tasks.cat3_filter_task %>
 <% end %>
-<%= render partial: 'application/certification_bar', locals: { product: @product_test.product, active_certs: current_certifications(@task._type, @product_test.c3_test) } %>
+<%= render partial: 'application/certification_bar', locals: { product: @product_test.product, active_certs: current_certifications(@task._type, @product_test.c3_test, @product_test.eh_measures?, @product_test.ep_measures?) } %>
 <% unless @task.is_a?(C1ChecklistTask) || @task.is_a?(C3ChecklistTask) %>
   <div class="panel clearfix">
     <%= button_to new_task_test_execution_path(iterate_task(@task, 'prev').id), :method => :get, :class => "btn btn-default pull-left" do %>

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -38,7 +38,7 @@ Scenario: View C1 And C2 Execution Pages
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 with C2 and C3 Execution Pages
+Scenario: View C1 and C2 With C3 Execution Pages
   When the user creates a product with tasks c1, c2, c3
   And the product has an ep measure
   And the user views task c1
@@ -48,7 +48,7 @@ Scenario: View C1 with C2 and C3 Execution Pages
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 with C3 And C2 Execution Pages
+Scenario: View C1 With C3 And C2 Execution Pages
   When the user creates a product with tasks c1, c2, c3
   And the product has an eh measure
   And the user views task c2
@@ -158,13 +158,14 @@ Scenario: View C1 And C2 Execution Pages on Deprecated Product
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 With C3 And C2 With C3 Execution Pages on Deprecated Product
+Scenario: View C1 And C2 With C3 Execution Pages on Deprecated Product
   When the user creates a product with tasks c1, c2, c3
+  And the product has an ep measure
   And the default bundle has been deprecated
   And the user views task c1
   Then the user should see a notification saying the product was deprecated
   And the user switches to c2 and c3 certification
-  Then the user should see the c2 and c3 execution page
+  Then the user should see the c1 only and c2 and c3 execution page
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -38,7 +38,7 @@ Scenario: View C1 And C2 Execution Pages
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 And C2 and C3 Execution Pages
+Scenario: View C1 with C2 and C3 Execution Pages
   When the user creates a product with tasks c1, c2, c3
   And the product has an ep measure
   And the user views task c1
@@ -48,7 +48,7 @@ Scenario: View C1 And C2 and C3 Execution Pages
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 and C3 And C2 Execution Pages
+Scenario: View C1 with C3 And C2 Execution Pages
   When the user creates a product with tasks c1, c2, c3
   And the product has an eh measure
   And the user views task c2

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -38,12 +38,23 @@ Scenario: View C1 And C2 Execution Pages
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 and C3 And C2 and C3 Execution Pages
+Scenario: View C1 And C2 and C3 Execution Pages
   When the user creates a product with tasks c1, c2, c3
+  And the product has an ep measure
   And the user views task c1
   And the user switches to c2 and c3 certification
   And the user should be able to click eCQM Specification link
-  Then the user should see the c2 and c3 execution page
+  Then the user should see the c1 only and c2 and c3 execution page
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
+
+Scenario: View C1 and C3 And C2 Execution Pages
+  When the user creates a product with tasks c1, c2, c3
+  And the product has an eh measure
+  And the user views task c2
+  And the user switches to c1 and c3 certification
+  And the user should be able to click eCQM Specification link
+  Then the user should see the c2 only and c1 and c3 execution page
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -158,7 +158,7 @@ Scenario: View C1 And C2 Execution Pages on Deprecated Product
   Then the page should be accessible according to: section508
   Then the page should be accessible according to: wcag2aa
 
-Scenario: View C1 and C3 And C2 and C3 Execution Pages on Deprecated Product
+Scenario: View C1 With C3 And C2 With C3 Execution Pages on Deprecated Product
   When the user creates a product with tasks c1, c2, c3
   And the default bundle has been deprecated
   And the user views task c1

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -61,12 +61,24 @@ And(/^the user views task (.*)$/) do |task_names|
   visit new_task_test_execution_path(task)
 end
 
+# the product has an ep measure
+And(/^the product has an (.*) measure$/) do |reporting_program|
+  measure = @product_test.measures.first
+  measure.reporting_program_type = reporting_program
+  measure.save
+  @product_test.reload
+end
+
 And(/^the user switches to c2 certification$/) do
   find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c2_task.id}/test_executions/new']").trigger('click')
 end
 
 And(/^the user switches to c2 and c3 certification$/) do
   find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c2_task.id}/test_executions/new']").trigger('click')
+end
+
+And(/^the user switches to c1 and c3 certification$/) do
+  find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c1_task.id}/test_executions/new']").trigger('click')
 end
 
 And(/^the product test state is set to ready$/) do
@@ -158,11 +170,18 @@ Then(/^the user should see the c2 execution page$/) do
   find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c1_task.id}/test_executions/new']").assert_text 'C1'
 end
 
-Then(/^the user should see the c2 and c3 execution page$/) do
+Then(/^the user should see the c1 only and c2 and c3 execution page$/) do
   find('#task_status_display').assert_text 'C2'
   find('#task_status_display').assert_text 'C3'
   find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c1_task.id}/test_executions/new']").assert_text 'C1'
-  find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c1_task.id}/test_executions/new']").assert_text 'C3'
+  find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c1_task.id}/test_executions/new']").assert_no_text 'C3'
+end
+
+Then(/^the user should see the c2 only and c1 and c3 execution page$/) do
+  find('#task_status_display').assert_text 'C1'
+  find('#task_status_display').assert_text 'C3'
+  find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c2_task.id}/test_executions/new']").assert_text 'C2'
+  find(:xpath, "//a[@href='/tasks/#{@product_test.tasks.c2_task.id}/test_executions/new']").assert_no_text 'C3'
 end
 
 Then(/^the user should be able to download a CAT 1 zip file$/) do

--- a/lib/cypress/product_status_values.rb
+++ b/lib/cypress/product_status_values.rb
@@ -50,6 +50,7 @@ module Cypress
       if h['Checklist']['total'].zero?
         default_number = CAT1_CONFIG['number_of_checklist_measures']
         h['Checklist']['not_started'] = product.measure_ids.size < default_number ? product.measure_ids.size : default_number
+        h['Checklist']['not_started'] = 0 unless product.eh_tests?
       end
       cat1_status_values = product_test_statuses(product.product_tests.measure_tests.filter(&:eh_measures?), 'C3Cat1Task')
       cat3_status_values = product_test_statuses(product.product_tests.measure_tests.filter(&:ep_measures?), 'C3Cat3Task')
@@ -68,6 +69,7 @@ module Cypress
     # returns zero for all values if test is false
     def checklist_status_vals(test, cert_type)
       return [0, 0, 0, 0, 0] unless test
+      return [0, 0, 0, 0, 0] if cert_type == 'C3' && !test.eh_measures?
 
       passing = test.num_measures_complete
       total = test.measures.count
@@ -78,6 +80,8 @@ module Cypress
 
     # returns the number of tasks with most recent test executions [passing, failing, errored, not_started, total]
     def checklist_status_vals_for_execution(test, cert_type)
+      return [0, 0, 0, 0, 0] if cert_type == 'C3'
+
       task = cert_type == 'C3' ? test.tasks.c3_checklist_task : test.tasks.c1_checklist_task
       return [0, 0, 0, 0, 0] unless task&.most_recent_execution
 

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -179,19 +179,19 @@ class TestExecutionHelper < ActiveSupport::TestCase
 
   def test_current_certifications
     # c1 and c2 measure tests
-    assert_equal [true, false, false, false], current_certifications('C1Task', false)
-    assert_equal [false, true, false, false], current_certifications('C2Task', false)
-    assert_equal [true, false, true, false], current_certifications('C1Task', true)
-    assert_equal [false, true, true, false], current_certifications('C2Task', true)
+    assert_equal [true, false, false, false], current_certifications('C1Task', false, true, false)
+    assert_equal [false, true, false, false], current_certifications('C2Task', false, true, false)
+    assert_equal [true, false, true, false], current_certifications('C1Task', true, true, false)
+    assert_equal [false, true, true, false], current_certifications('C2Task', true, false, true)
 
     # filtering tests
-    assert_equal [false, false, false, true], current_certifications('Cat1FilterTask', false)
-    assert_equal [false, false, false, true], current_certifications('Cat1FilterTask', true)
-    assert_equal [false, false, false, true], current_certifications('Cat3FilterTask', false)
-    assert_equal [false, false, false, true], current_certifications('Cat3FilterTask', true)
+    assert_equal [false, false, false, true], current_certifications('Cat1FilterTask', false, true, false)
+    assert_equal [false, false, false, true], current_certifications('Cat1FilterTask', true, true, false)
+    assert_equal [false, false, false, true], current_certifications('Cat3FilterTask', false, true, false)
+    assert_equal [false, false, false, true], current_certifications('Cat3FilterTask', true, true, false)
 
     # checklist tests
-    assert_equal [true, false, false, false], current_certifications('C1ChecklistTask', false)
-    assert_equal [true, false, true, false], current_certifications('C1ChecklistTask', true)
+    assert_equal [true, false, false, false], current_certifications('C1ChecklistTask', false, false, true)
+    assert_equal [true, false, true, false], current_certifications('C1ChecklistTask', true, true, false)
   end
 end

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -59,6 +59,10 @@ class TestExecutionHelper < ActiveSupport::TestCase
 
   def test_get_title_message_cat1_plural
     setup_product_tests(true, false, true, true, filt1: 'val1', filt2: 'val2')
+    measure = @product_test.measures.first
+    measure.reporting_program_type = 'eh'
+    measure.save
+    @product_test.reload
     assert_equal get_title_message(@product_test, @product_test.tasks.find_by(_type: 'C1Task')), 'C1 and C3 certifications for TEST_CMSID test_measure_test_name'
     assert_equal get_title_message(@f_test, @f_test.tasks.find_by(_type: 'Cat1FilterTask')), 'CQM Filters Filt1/Filt2 for TEST_CMSID test_filtering_test_name'
   end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code