### PR TITLE
(6.x and 5.4.1) Allow selection of 2015 or Cures update

### DIFF
--- a/app/assets/javascripts/measure_selection.js
+++ b/app/assets/javascripts/measure_selection.js
@@ -320,6 +320,7 @@ ready_run_once = function() {
     }
       setElementHidden('#bundle_options', !cvuplus_checked);
       setElementHidden('#certification_options', cvuplus_checked);
+      setElementHidden('#certification_edition', cvuplus_checked);
   });
 
   // run this piece once too

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -130,7 +130,7 @@ class ProductsController < ApplicationController
 
   def product_params
     params[:product][:name]&.strip!
-    params.require(:product).permit(:name, :version, :description, :randomize_patients, :duplicate_patients, :shift_patients,
+    params.require(:product).permit(:name, :version, :description, :randomize_patients, :duplicate_patients, :shift_patients, :cures_update,
                                     :bundle_id, :measure_selection, :c1_test, :c2_test, :c3_test, :c4_test, :cvuplus, :vendor_patients,
                                     :bundle_patients, :supplemental_test_artifact, :remove_supplemental_test_artifact, measure_ids: [])
   end

--- a/app/models/c3_cat1_task.rb
+++ b/app/models/c3_cat1_task.rb
@@ -13,9 +13,11 @@ class C3Cat1Task < Task
   def cms_cat1_schematron_validator
     measure = product_test.measures[0]
     if measure.reporting_program_type == 'eh'
-      ::Validators::CMSQRDA1HQRSchematronValidator.new(product_test.bundle.version)
+      # If product is not for 21st Centutry Cures, then CMS errors are treated as warnings
+      ::Validators::CMSQRDA1HQRSchematronValidator.new(product_test.bundle.version, !product_test.cures_update)
     else
-      ::Validators::CMSQRDA1PQRSSchematronValidator.new(product_test.bundle.version)
+      # If product is not for 21st Centutry Cures, then CMS errors are treated as warnings
+      ::Validators::CMSQRDA1PQRSSchematronValidator.new(product_test.bundle.version, !product_test.cures_update)
     end
   end
 

--- a/app/models/c3_cat3_task.rb
+++ b/app/models/c3_cat3_task.rb
@@ -8,7 +8,10 @@ class C3Cat3Task < Task
 
   def cms_cat3_schematron_validator
     measure = product_test.measures[0]
-    @validators << ::Validators::CMSQRDA3SchematronValidator.new(product_test.bundle.version) if measure.reporting_program_type == 'ep'
+    if measure.reporting_program_type == 'ep'
+      # If product is not for 21st Centutry Cures, then CMS errors are treated as warnings
+      @validators << ::Validators::CMSQRDA3SchematronValidator.new(product_test.bundle.version, !product_test.cures_update)
+    end
   end
 
   def execute(file, user, sibling_execution_id)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -19,6 +19,7 @@ class Product
   # NOTE: more relationships must be defined
 
   field :cvuplus, type: Boolean, default: false
+  field :cures_update, type: Boolean
   field :vendor_patients, type: Boolean, default: false
   field :bundle_patients, type: Boolean, default: true
   field :name, type: String

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -40,6 +40,7 @@ class ProductTest
   mount_uploader :patient_archive, PatientArchiveUploader
   mount_uploader :html_archive, PatientArchiveUploader
 
+  delegate :cures_update, to: :product
   delegate :name, :version, to: :product, prefix: true
   delegate :effective_date, to: :product
   delegate :measure_period_start, to: :product

--- a/app/views/application/_certification_status_table.html.erb
+++ b/app/views/application/_certification_status_table.html.erb
@@ -25,7 +25,7 @@
             <%= link_to product.name, vendor_product_path(product.vendor_id, product) %>
           </th>
         <% else %>
-          <th class="status-heading" rowspan="2"><span class="sr-only">Status</span></th>
+          <th class="status-heading" rowspan="2"><%= @product.cures_update ? '2015 Edition Cures Update' : '2015 Edition' %></th>
         <% end %>
         <th scope="col" colspan="2" class="c1-heading">C1</th>
         <th scope="col" class="c2-heading">C2</th>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -17,6 +17,24 @@
             <% end %>
           </fieldset>
 
+          <fieldset id="certification_edition">
+            <legend class="control-label">Certification Edition</legend>
+            <div class="radio">
+              <%= f.form_group :cert_edition, help: "Select the certification edition." do %>
+                <%= f.radio_button :cures_update, "false",
+                                   label: "2015 Edition",
+                                   label_class: "btn btn-checkbox",
+                                   disabled: !@product.new_record?,
+                                   checked: !@product.cures_update %>
+                <%= f.radio_button :cures_update, "true",
+                                   label: "2015 Edition Cures Update",
+                                   label_class: "btn btn-checkbox",
+                                   disabled: !@product.new_record?,
+                                   checked: @product.cures_update %>
+              <% end # form_group %>
+            </div>
+          </fieldset>
+
           <fieldset id="certification_options">
             <legend class="control-label">Certification Types</legend>
             <div id="certifications_errors_container"></div>

--- a/app/views/products/report.html.erb
+++ b/app/views/products/report.html.erb
@@ -13,6 +13,8 @@
     <dd><%= @product.name %></dd>
     <dt>Bundle</dt>
     <dd><%= "#{@bundle.title} v#{@bundle.version}" %></dd>
+    <dt>Certification Edition</dt>
+    <dd><%= @product.cures_update ? '2015 Edition Cures Update' : '2015 Edition' %></dd>
     <dt>Cypress Version</dt>
     <dd><%= Cypress::Application::VERSION %></dd>
   </dl>


### PR DESCRIPTION
By default, all Tests created prior to this update will now be treated as 2015 only.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code