### PR TITLE
use the original patient id in clone patient for scoop and filter

### DIFF
--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -97,6 +97,7 @@
 
 
     <% sf_patient = @record.clone %>
+    <% sf_patient.id =  @record.id %>
     <% sf_measures = @record.bundle.measures %>
     <% sf_title = "All Measures" %>
     <% if @hqmf_id %>

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -133,6 +133,7 @@ Then(/^the user sees details$/) do
   sf_patient.qdmPatient.dataElements.each do |data_criteria|
     page.assert_text data_criteria['description']
   end
+  page.assert_text @patient.id.to_s
   @measures.each do |m|
     page.assert_text m.description
   end

--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -71,14 +71,10 @@ module Cypress
       Zip::ZipOutputStream.open(file.path) do |z|
         patients.each_with_index do |patient, i|
           sf_patient = patient.clone
+          sf_patient.id = patient.id
           patient_scoop_and_filter.scoop_and_filter(sf_patient)
           z.put_next_entry("#{next_entry_path(patient, i)}.#{FORMAT_EXTENSIONS[format.to_sym]}")
-          # TODO: R2P: make sure using correct exporter
-          z << if formatter == Cypress::HTMLExporter
-                 formatter.new.export(patient)
-               else
-                 formatter.export(sf_patient)
-               end
+          z << formatter.export(sf_patient)
         end
       end
     end

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -55,6 +55,7 @@ class PatientZipperTest < ActiveSupport::TestCase
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         assert_equal 1, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 1 negated code in the exported QRDA'
+        assert_equal 1, doc.xpath("//cda:patientRole/cda:id[@extension='#{patient.id}']").size, 'The id should match the original patient id'
         confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
         count += 1
       end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code