### PR TITLE
(clean-up) hqmf oids no longer needed to identify diagnosis data elements

### DIFF
--- a/lib/cypress/criteria_picker.rb
+++ b/lib/cypress/criteria_picker.rb
@@ -87,18 +87,5 @@ module Cypress
       end
       false # no record diagnosis matches a code in this valueset
     end
-
-    def self.hqmf_oids_for_problem(problem_oid, measures)
-      measure = measures.first
-      hqmf_oids = []
-      measure.source_data_criteria.each do |criteria|
-        next unless criteria.codeListId == problem_oid
-
-        hqmf_oid = HQMF::DataCriteria.template_id_for_definition(cr_hash['definition'], cr_hash['status'], cr_hash['negation'])
-        hqmf_oid ||= HQMF::DataCriteria.template_id_for_definition(cr_hash['definition'], cr_hash['status'], cr_hash['negation'], 'r2')
-        hqmf_oids << hqmf_oid
-      end
-      hqmf_oids.uniq
-    end
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code