### PR TITLE
more gross stuff for extracting attribute valuesets nested in And/Or …

### DIFF
--- a/lib/cypress/data_criteria_attribute_builder.rb
+++ b/lib/cypress/data_criteria_attribute_builder.rb
@@ -100,6 +100,20 @@ module Cypress
             @cql_data_criteria << { 'attribute' => current_hash['path'],
                                     'data_criteria' => scope,
                                     'attribute_vs' => @vs_hash[grand_parent_hash['where']['valueset']['name']] }
+          elsif grand_parent_hash['where'] && grand_parent_hash['where']['type'] == 'And'
+            grand_parent_hash['where']['operand'].each do |and_hash|
+              if and_hash['type'] == 'InValueSet'
+                @cql_data_criteria << { 'attribute' => current_hash['path'],
+                                        'data_criteria' => scope,
+                                        'attribute_vs' => @vs_hash[and_hash['valueset']['name']] }
+              elsif and_hash['type'] == 'Or'
+                and_hash['operand'].each do |or_hash|
+                  @cql_data_criteria << { 'attribute' => current_hash['path'],
+                                          'data_criteria' => scope,
+                                          'attribute_vs' => @vs_hash[or_hash['valueset']['name']] }
+                end
+              end
+            end
           end
         elsif name == 'type' &&  values == 'Property' && grand_parent_hash['type'] == 'Equivalent'
           scope = find_data_criteria_for_property(library_id, expression_id, current_hash)

--- a/lib/tasks/bundle.rake
+++ b/lib/tasks/bundle.rake
@@ -36,4 +36,14 @@ namespace :bundle do
     patient_id_mapping.close
     bundle.destroy
   end
+
+  task :test_dcab, [:cms_id] => :setup do |_, args|
+    measure = Measure.where(cms_id: args.cms_id).first
+    measure.source_data_criteria.each do |sdc|
+      sdc.dataElementAttributes = []
+    end
+    measure.save
+    dcab = Cypress::DataCriteriaAttributeBuilder.new
+    dcab.build_data_criteria_for_measure(measure)
+  end
 end


### PR DESCRIPTION
…expressions

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code