### PR TITLE
(clean-up) Remove unused method zip_patients_all_measures

### DIFF
--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -83,23 +83,6 @@ module Cypress
       patients.sort_by { |p| p.givenNames.join('_') + '_' + p.familyName }
     end
 
-    def self.zip_patients_all_measures(file, measure_tests)
-      # TODO: R2P: check exporter
-      Zip::ZipOutputStream.open(file.path) do |zip|
-        measure_tests.each do |measure_test|
-          patients = measure_test.patients.to_a
-          measures, start_date, end_date = measure_start_end(patients)
-          formatter = Cypress::QRDAExporter.new(measures, start_date, end_date)
-          measure_folder = "patients_#{measure_test.cms_id}"
-
-          patients.each_with_index do |patient, i|
-            zip.put_next_entry("#{measure_folder}/#{next_entry_path(patient, i)}.xml")
-            zip << formatter.export(patient)
-          end
-        end
-      end
-    end
-
     def self.measure_start_end(patients)
       return unless patients.first
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code