### PR TITLE
Reintroduce slim test decks for C1 only tests

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -3,8 +3,6 @@ class Product
   include Mongoid::Attributes::Dynamic
   include Mongoid::Timestamps
 
-  TEST_DECK_MAX = 50
-
   before_save :enforce_duplicate_patient_settings
 
   mount_uploader :supplemental_test_artifact, SupplementUploader
@@ -240,6 +238,16 @@ class Product
 
   def eh_tests?
     product_tests.any?(&:eh_measures?)
+  end
+
+  def slim_test_deck?
+    !c2_test
+  end
+
+  def test_deck_max
+    return 5 if slim_test_deck?
+
+    50
   end
 
   # Here we validate that duplicate_patients is set if c2_test is set

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -45,6 +45,8 @@ class ProductTest
   delegate :effective_date, to: :product
   delegate :measure_period_start, to: :product
   delegate :bundle, to: :product
+  delegate :slim_test_deck?, to: :product
+  delegate :test_deck_max, to: :product
   delegate :c1_test, :c2_test, :c3_test, to: :product
 
   before_create :generate_random_seed
@@ -83,8 +85,7 @@ class ProductTest
   def generate_patients(job_id = nil)
     if product.randomize_patients
       # If we're using a "slim test deck", don't pass in any random IDs
-      # random_ids = bundle.patients.pluck(:_id)
-      random_ids = gather_patient_ids
+      random_ids = slim_test_deck? ? [] : gather_patient_ids
       Cypress::PopulationCloneJob.new('test_id' => id, 'patient_ids' => master_patient_ids, 'randomization_ids' => random_ids,
                                       'randomize_demographics' => true, 'generate_provider' => product.c4_test, 'job_id' => job_id).perform
     else
@@ -322,8 +323,8 @@ class ProductTest
     ipp_ids = (mpl_ids - denom_ids - msrpopl_ids)
 
     # Pick some IDs from the IPP. If we've already got a lot of patients, only pick a couple more, otherwise pick 1/2 or more
-    ipp_ids = if (mpl_ids.count + denom_ids.count + msrpopl_ids.count) > Product::TEST_DECK_MAX
-                ipp_ids.sample(Product::TEST_DECK_MAX / 2)
+    ipp_ids = if (mpl_ids.count + denom_ids.count + msrpopl_ids.count) > test_deck_max
+                ipp_ids.sample(test_deck_max / 2)
               else
                 ipp_ids.sample(prng.rand((ipp_ids.count / 2.0).ceil..(ipp_ids.count)))
               end
@@ -332,18 +333,18 @@ class ProductTest
 
   def pick_denom_ids
     # numer_id ensures we get at least one patient who is in the Numerator, no matter what
-    numer_id = patient_in_numerator
+    numer_id = patient_in_numerator.sample
     denom_ids = patients_in_denominator_and_greater
 
     # If there are a lot of patients in denom_ids (usually when the IPP and denominator are the same thing),
     # pull out the numerator/Denex/Denexcep patients as high value (this is numer_ids), then sample from the rest to get to TEST_DECK_MAX
     # NOTE: "a lot" is defined by the relation to "TEST_DECK_MAX" on the product,
-    if denom_ids.count > (Product::TEST_DECK_MAX - 1)
+    if denom_ids.count > (test_deck_max - 1)
       high_value_ids = patients_in_high_value_populations
-      high_value_ids = high_value_ids.sample(Product::TEST_DECK_MAX - 1)
-      denom_ids = high_value_ids + denom_ids.sample(Product::TEST_DECK_MAX - high_value_ids.count - 1)
+      high_value_ids = high_value_ids.sample(test_deck_max - 1)
+      denom_ids = high_value_ids + denom_ids.sample(test_deck_max - high_value_ids.count - 1)
     end
-    patients_in_denominator_and_greater.empty? ? numer_id.uniq : (denom_ids << numer_id).uniq
+    patients_in_denominator_and_greater.empty? ? [numer_id] : (denom_ids << numer_id).uniq
   end
 
   def pick_msrpopl_ids
@@ -351,10 +352,10 @@ class ProductTest
 
     # If there are a lot of patients in the MSRPOPL results above, (usually if there are a lot of MSRPOPLEX values)
     # pull out only those patients with more than one episode in the MSRPOPL
-    if msrpopl_ids.count > Product::TEST_DECK_MAX
+    if msrpopl_ids.count > test_deck_max
       numer_ids = BundlePatient.where("measure_relevance_hash.#{measures.pluck(:_id).first.to_s}.MSRPOPL": true).pluck(:_id)
-      numer_ids = numer_ids.sample(Product::TEST_DECK_MAX)
-      msrpopl_ids = numer_ids + msrpopl_ids.sample(Product::TEST_DECK_MAX - numer_ids.count)
+      numer_ids = numer_ids.sample(test_deck_max)
+      msrpopl_ids = numer_ids + msrpopl_ids.sample(test_deck_max - numer_ids.count)
     end
     msrpopl_ids
   end

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -79,6 +79,31 @@ class MeasureTestTest < ActiveJob::TestCase
     end
   end
 
+  def test_create_with_slim_records
+    perform_enqueued_jobs do
+      patient_to_copy = @bundle.patients.first
+      # Add a bunch of patients to the bundle to exagerate the number of patients
+      50.times do
+        patient_copy = patient_to_copy.clone
+        patient_copy.save
+      end
+      slim_product = @vendor.products.create(name: 'test_product_slim_random', c1_test: true, randomize_patients: true,
+                                             bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+      product = @vendor.products.create(name: 'test_product_random', c2_test: true, randomize_patients: true,
+                                        bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+      assert_enqueued_jobs 0
+      slim_pt = slim_product.product_tests.build({ name: 'slim_test_for_measure_1a', bundle_id: @bundle.id,
+                                                   measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
+      pt = product.product_tests.build({ name: 'test_for_measure_1a', bundle_id: @bundle.id,
+                                         measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
+      assert pt.save, 'should be able to save valid product test'
+      assert slim_pt.save, 'should be able to save valid product test'
+      assert slim_pt.patients.count < pt.patients.count, 'there should be fewer records in the slim test deck'
+      assert pt.patients.count > 20, 'there should be greater than 20 records in the regular test deck'
+      assert slim_pt.patients.count < 10, 'there should be fewer than 10 records in the slim test deck'
+    end
+  end
+
   def test_create_task_c2
     @product.c2_test = true
     pt = @product.product_tests.build({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -82,7 +82,7 @@ class MeasureTestTest < ActiveJob::TestCase
   def test_create_with_slim_records
     perform_enqueued_jobs do
       patient_to_copy = @bundle.patients.first
-      # Add a bunch of patients to the bundle to exagerate the number of patients
+      # Add a bunch of patients to the bundle to exaggerate the number of patients
       50.times do
         patient_copy = patient_to_copy.clone
         patient_copy.save


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-723
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code