### PR TITLE
update API measure evaluator to be resilient for payer filters

### DIFF
--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -223,6 +223,8 @@ module Cypress
       return filter_providers(doc, filters) if filters.key?('provider')
       return filter_problems(doc, filters) if filters.key?('problem')
 
+      # Normalize payer to a string value.  Parsing from JSON directly may have the parameter as an integer
+      filters = Hash[filters.map { |k, v| [k, k == 'payer' ? v.to_s : v] }] if filters.key?('payer')
       filter_demographics(doc, filters, creation_time)
     end
 
@@ -285,7 +287,7 @@ module Cypress
       counter += 1 if filters.value?(doc.at_xpath(race_xpath).value)
       counter += 1 if filters.value?(doc.at_xpath(gender_xpath).value)
       counter += 1 if filters.value?(doc.at_xpath(ethnic_xpath).value)
-      counter += 1 if filters.value?(get_payer_name(payer_value))
+      counter += 1 if filters.value?(payer_value)
       filters['age'] = age_filter_holder if age_filter_holder
       return true if counter == 2
     end
@@ -301,17 +303,6 @@ module Cypress
         filter_time < patient_birth_time + age_shit + 31_556_952
       else
         filter_time > patient_birth_time + age_shit
-      end
-    end
-
-    def get_payer_name(payer_code)
-      case payer_code
-      when '1'
-        1
-      when '2'
-        2
-      when '349'
-        349
       end
     end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code