### PR TITLE
QRDA post processor should not fail for a negated valueset it doesn't…

### DIFF
--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -17,6 +17,8 @@ module Cypress
                  system: bundle.default_negation_codes[negated_vs]['codeSystem'] }
              else
                valueset = ValueSet.where(oid: negated_vs, bundle_id: bundle.id)
+               return if valueset.empty?
+
                { code: valueset.first.concepts.first['code'], system: valueset.first.concepts.first['code_system_oid'] }
              end
       data_element.dataElementCodes << code

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -101,17 +101,26 @@ class PatientZipperTest < ActiveSupport::TestCase
     imported_patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
     imported_patient.update(_type: CQM::VendorPatient)
     cloned_import = imported_patient.clone
+    cloned_import2 = imported_patient.clone
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert_equal false, codefound, 'code should not be found prior to replace_negated_codes'
+    # Should replace with a code from the valueset
     Cypress::QRDAPostProcessor.replace_negated_codes(imported_patient, patient.bundle)
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert codefound, 'replaced code should equal original code'
     assert imported_patient.save
-    APP_CONSTANTS['version_config']['~>2020.0.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
+    # Should not replace a code when valuesets do not exist
+    ValueSet.destroy_all
     Cypress::QRDAPostProcessor.replace_negated_codes(cloned_import, patient.bundle)
-    codefound = cloned_import.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
-    assert codefound, 'replaced code should equal default code'
+    codefound = cloned_import.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
+    assert_not codefound, 'Without valusets the code should not be replaced'
     assert cloned_import.save
+    # Should replace with the default code
+    APP_CONSTANTS['version_config']['~>2020.0.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
+    Cypress::QRDAPostProcessor.replace_negated_codes(cloned_import2, patient.bundle)
+    codefound = cloned_import2.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
+    assert codefound, 'replaced code should equal default code'
+    assert cloned_import2.save
   end
 
   test 'Should create valid qrda file' do


### PR DESCRIPTION
… know about

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-725
- [ ] Internal ticket links to this PR 
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code