### PR TITLE
[Wait on cqm-reports 3.1.0] Handling warnings from imports

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Metrics/AbcSize:
     - 'lib/cypress/data_criteria_attribute_builder.rb'
     - 'lib/cypress/population_clone_job.rb'
     - 'test/**/*.rb'
+    - 'lib/validators/program_criteria_validator.rb'
 Metrics/ModuleLength:
   Max: 120
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'os'
 
 gem 'cqm-models', '~> 3.0.1'
 gem 'cqm-parsers', '~> 3.1.0'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'import_exception_warnings'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'master'
 gem 'cqm-validators', '~> 3.0.0'
 
 # Use faker to generate addresses

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'os'
 
 gem 'cqm-models', '~> 3.0.1'
 gem 'cqm-parsers', '~> 3.1.0'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'qrda_5_2_errata'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'import_exception_warnings'
 gem 'cqm-validators', '~> 3.0.0'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: 3ad3196ff32370f146a32ded337f7a2882847098
-  branch: qrda_5_2_errata
+  revision: 1c3594e5758388e9390c53e85f47e4bc73f74f37
+  branch: import_exception_warnings
   specs:
     cqm-reports (3.0.0)
       cqm-models (~> 3.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: 7383ba2fab791b4c1d82465d4c52617c04d3bce2
+  revision: 48fa1c2eaf44f201ed59c9f4e24990cc7cc4b04f
   branch: master
   specs:
-    cqm-reports (3.0.1)
+    cqm-reports (3.1.0)
       cqm-models (~> 3.0.0)
       cqm-validators (~> 3.0.0)
       erubis (~> 2.7)
@@ -297,7 +297,7 @@ GEM
     mocha (1.11.2)
     mongo (2.11.4)
       bson (>= 4.4.2, < 5.0.0)
-    mongoid (6.4.4)
+    mongoid (6.4.5)
       activemodel (>= 5.1, < 6.0.0)
       mongo (>= 2.5.1, < 3.0.0)
     mongoid-compatibility (0.5.1)
@@ -316,7 +316,7 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (6.10.0.364)
     nio4r (2.5.2)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
     os (1.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GIT
   specs:
     cqm-reports (3.0.1)
       cqm-models (~> 3.0.0)
+      cqm-validators (~> 3.0.0)
       erubis (~> 2.7)
       log4r (~> 1.1)
       memoist (~> 0.9)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: 1c3594e5758388e9390c53e85f47e4bc73f74f37
-  branch: import_exception_warnings
+  revision: 7383ba2fab791b4c1d82465d4c52617c04d3bce2
+  branch: master
   specs:
-    cqm-reports (3.0.0)
+    cqm-reports (3.0.1)
       cqm-models (~> 3.0.0)
       erubis (~> 2.7)
       log4r (~> 1.1)

--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -70,7 +70,7 @@ class VendorPatientUploadJob < ApplicationJob
 
     # import
     begin
-      patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+      patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
 
       # shift date
       utc_start = DateTime.parse(doc_start).to_time.utc

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -509,7 +509,7 @@ module Cypress
     end
 
     def import_cat1_file(doc, patient_ids, bundle_id)
-      patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+      patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, Bundle.find(bundle_id))
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval')
       patient.save!

--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -161,7 +161,7 @@ module Cypress
         doc = Nokogiri::XML::Document.parse(qrda)
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
-        patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+        patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
         patient['bundleId'] = bundle.id
         patient.update(_type: CQM::BundlePatient, correlation_id: bundle.id)
         Cypress::QRDAPostProcessor.replace_negated_codes(patient, bundle)

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -19,7 +19,7 @@ module Validators
         errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
       end
       unit_errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
-      warnings.each { |e| add_warning e, file_name: options[:file_name] }
+      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
 
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
       patient

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -7,7 +7,7 @@ module Validators
     end
 
     def parse_record(doc, options)
-      patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+      patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
 
       # check for single code negation errors
       product_test = ProductTest.find(@test_id)
@@ -19,6 +19,7 @@ module Validators
         errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
       end
       unit_errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
+      warnings.each { |e| add_warning e, file_name: options[:file_name] }
 
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
       patient

--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -19,7 +19,7 @@ module Validators
     def validate(file, _options = {})
       @file = file
       # parse the cat 1 file into the patient model
-      patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
+      patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
       # iterate through each criteria to see if it is contained in the patient
       @criteria_list.each do |criteria|
         # if a criteria has already passed, no need to check again

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -38,7 +38,7 @@ module Validators
 
     def calculate_patient(options)
       patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
-      warnings.each { |w| add_warning w, file_name: options[:file_name] }
+      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s)
       patient.save!
       post_processsor_check(patient, options)

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -37,7 +37,8 @@ module Validators
     end
 
     def calculate_patient(options)
-      patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
+      patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
+      warnings.each { |w| add_warning w, file_name: options[:file_name] }
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s)
       patient.save!
       post_processsor_check(patient, options)

--- a/test/fixtures/qrda/cat_I/import_warnings.xml
+++ b/test/fixtures/qrda/cat_I/import_warnings.xml
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="urn:hl7-org:v3" xmlns:voc="urn:hl7-org:v3/voc" xmlns:sdtc="urn:hl7-org:sdtc">
+
+<!-- QRDA Header -->
+<realmCode code="US"/>
+<typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+<!-- US Realm Header Template Id -->
+<templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01"/>
+<!-- QRDA templateId -->
+<templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2017-08-01"/>
+<!-- QDM-based QRDA templateId -->
+<templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2019-12-01"/>
+<!-- CMS QRDA templateId -->
+<templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2020-02-01"/>
+<!-- This is the globally unique identifier for this QRDA document -->
+<id root="88e44af0-9bcd-0138-3a2d-784f43709e4a"/>
+<!-- QRDA document type code -->
+<code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
+<title>QRDA Incidence Report</title>
+<!-- This is the document creation time -->
+<effectiveTime value="20200629002936"/>
+<confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+<languageCode code="en"/>
+<!-- reported patient -->
+<recordTarget>
+  <patientRole>
+    <id extension="5ef9343f66105ebb26e0c234" root="1.3.6.1.4.1.115" />
+      <addr use="HP">
+          <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="HP" value="tel:555-555-2003"/>
+    <patient>
+        <name>
+          <given>Import</given>
+          <family>Warnings</family>
+        </name>
+          <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="AdministrativeGender"/>
+        <birthTime value='20070202150000'/>
+          <raceCode code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDCREC"/>
+          <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDCREC"/>
+      <languageCommunication>
+        <templateId root="2.16.840.1.113883.3.88.11.83.2" assigningAuthorityName="HITSP/C83"/>
+        <templateId root="1.3.6.1.4.1.19376.1.5.3.1.2.1" assigningAuthorityName="IHE/PCC"/>
+        <languageCode code="eng"/>
+      </languageCommunication>
+    </patient>
+  </patientRole>
+</recordTarget>
+<author>
+  <time value="20200629002936"/>
+  <assignedAuthor>
+    <!-- NPI -->
+      <id extension="1348559463" root="2.16.840.1.113883.4.6"/>
+    <addr>
+      <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+      <city>Bedford</city>
+      <state>MA</state>
+      <postalCode>01730</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:(781)271-3000"/>
+    <assignedAuthoringDevice>
+      <manufacturerModelName>Cypress</manufacturerModelName>
+      <softwareName>Cypress</softwareName>
+    </assignedAuthoringDevice>
+  </assignedAuthor>
+</author><custodian>
+  <assignedCustodian>
+    <representedCustodianOrganization>
+        <id extension="522932" root="2.16.840.1.113883.4.336"/>
+      <name>Cypress Test Deck</name>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      <addr use="HP">
+        <streetAddressLine>885 Jeramy Valleys Burg</streetAddressLine>
+        <city>Port Ansel</city>
+        <state>NJ</state>
+        <postalCode>07618</postalCode>
+        <country>US</country>
+      </addr>
+    </representedCustodianOrganization>
+  </assignedCustodian>
+</custodian>
+<legalAuthenticator>
+  <time value="20200629002936"/>
+  <signatureCode code="S"/>
+  <assignedEntity>
+    <id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+    <addr>
+      <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+      <city>Bedford</city>
+      <state>MA</state>
+      <postalCode>01730</postalCode>
+      <country>US</country>
+    </addr>
+    <telecom use="WP" value="tel:(781)271-3000"/>
+    <assignedPerson>
+      <name>
+        <given>Henry</given>
+        <family>Seven</family>
+      </name>
+    </assignedPerson>
+    <representedOrganization>
+      <id root="2.16.840.1.113883.19.5"/>
+      <name>Cypress</name>
+    </representedOrganization>
+  </assignedEntity>
+</legalAuthenticator><participant typeCode="DEV">
+  <associatedEntity classCode="RGPR">
+    <!-- CMS EHR Certification Number (formerly known as Office of the 
+        National Coordinator Certification Number) -->
+    <id extension="123456789" root="2.16.840.1.113883.3.2074.1"/>
+  </associatedEntity>
+</participant><documentationOf typeCode="DOC">
+  <serviceEvent classCode="PCPR">
+    <!-- care provision -->
+    <effectiveTime>
+      <low nullFlavor="UNK"/>
+      <high nullFlavor="UNK"/>
+    </effectiveTime>
+    <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+    <performer typeCode="PRF">
+      <time>
+        <low nullFlavor="UNK"/>
+        <high nullFlavor="UNK"/>
+      </time>
+      <assignedEntity>
+          <id extension="1348559463" root="2.16.840.1.113883.4.6"/>
+          <id extension="522932" root="2.16.840.1.113883.4.336"/>
+        <code code="207Q00000X" codeSystem="2.16.840.1.113883.6.101" codeSystemName="Healthcare Provider Taxonomy (HIPAA)"/>
+        <addr use="HP">
+          <streetAddressLine>885 Jeramy Valleys Burg</streetAddressLine>
+          <city>Port Ansel</city>
+          <state>NJ</state>
+          <postalCode>07618</postalCode>
+          <country>US</country>
+        </addr>
+        <assignedPerson>
+          <name>
+            <given>Vera</given>
+            <family>Elliott</family>
+          </name>
+        </assignedPerson>
+        <representedOrganization>
+          <id extension="656445725" root="2.16.840.1.113883.4.2"/>
+          <addr use="HP">
+            <streetAddressLine>885 Jeramy Valleys Burg</streetAddressLine>
+            <city>Port Ansel</city>
+            <state>NJ</state>
+            <postalCode>07618</postalCode>
+            <country>US</country>
+          </addr>
+        </representedOrganization>
+      </assignedEntity>
+    </performer>
+  </serviceEvent>
+</documentationOf>
+<component>
+  <structuredBody>
+    <component>
+      <section>
+        <!-- 
+          *****************************************************************
+          Measure Section
+          *****************************************************************
+        -->
+        <!-- This is the templateId for Measure Section -->
+        <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+        <!-- This is the templateId for Measure Section QDM -->
+        <templateId root="2.16.840.1.113883.10.20.24.2.3"/>
+        <!-- This is the LOINC code for "Measure document". This stays the same for all measure section required by QRDA standard -->
+        <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+        <title>Measure Section</title>
+        <text>
+          <table border="1" width="100%">
+            <thead>
+              <tr>
+                <th>eMeasure Title</th>
+                <th>Version specific identifier</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.
+
+ - Percentage of patients with height, weight, and body mass index (BMI) percentile documentation
+ - Percentage of patients with counseling for nutrition
+ - Percentage of patients with counseling for physical activity</td>
+                <td>2C928085-7198-38EE-0171-9DA0C2CD078A</td>
+                <td/>
+              </tr>
+            </tbody>
+          </table>
+        </text>
+        <!-- 1..* Organizers, each containing a reference to an eMeasure -->
+        <entry>
+          <organizer classCode="CLUSTER" moodCode="EVN">
+            <!-- This is the templateId for Measure Reference -->
+            <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+            <!-- This is the templateId for eMeasure Reference QDM -->
+            <templateId root="2.16.840.1.113883.10.20.24.3.97"/>
+            <id extension="88e9b0e0-9bcd-0138-3a2d-784f43709e4a" root="1.3.6.1.4.1.115"/>
+            <statusCode code="completed"/>
+            <!-- Containing isBranch external references -->
+            <reference typeCode="REFR">
+              <externalDocument classCode="DOC" moodCode="EVN">
+                <!-- SHALL: This is the version specific identifier for eMeasure: QualityMeasureDocument/id it is a GUID-->
+                <id extension="2C928085-7198-38EE-0171-9DA0C2CD078A" root="2.16.840.1.113883.4.738"/>
+                <!-- SHOULD This is the title of the eMeasure -->
+                <text>Percentage of patients 3-17 years of age who had an outpatient visit with a Primary Care Physician (PCP) or Obstetrician/Gynecologist (OB/GYN) and who had evidence of the following during the measurement period. Three rates are reported.
+
+ - Percentage of patients with height, weight, and body mass index (BMI) percentile documentation
+ - Percentage of patients with counseling for nutrition
+ - Percentage of patients with counseling for physical activity</text>
+                <!-- SHOULD: setId is the eMeasure version neutral id  -->
+                <setId root="0B63F730-25D6-4248-B11F-8C09C66A04EB"/>
+              </externalDocument>
+            </reference>
+          </organizer>
+        </entry>
+      </section>
+    </component>    <component>
+      <section>
+        <!-- This is the templateId for Reporting Parameters section -->
+        <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+        <templateId extension="2016-03-01" root="2.16.840.1.113883.10.20.17.2.1.1"/>
+        <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+        <title>Reporting Parameters</title>
+        <text></text>
+        <entry typeCode="DRIV">
+          <act classCode="ACT" moodCode="EVN">
+            <!-- This is the templateId for Reporting Parameteres Act -->
+            <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+            <templateId extension="2016-03-01" root="2.16.840.1.113883.10.20.17.3.8.1"/>
+            <id extension="88e9d080-9bcd-0138-3a2d-784f43709e4a" root="1.3.6.1.4.1.115"/>
+            <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+            <effectiveTime>
+              <low value="20180101000000"/>
+              <high value="20181231235959"/>
+            </effectiveTime>
+          </act>
+        </entry>
+      </section>
+    </component>    <component>
+        <section>
+          <!-- This is the templateId for Patient Data section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
+          <!-- This is the templateId for Patient Data QDM section -->
+          <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.2.1"/>
+          <templateId extension="2020-02-01" root="2.16.840.1.113883.10.20.24.2.1.1"/>
+          <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Patient Data</title>
+          <text/>
+
+
+            <entry>
+              <act classCode="ACT" moodCode="EVN" >
+                <!--Encounter performed Act -->
+                <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.3.133"/>
+                <code code="ENC" codeSystem="2.16.840.1.113883.5.6" codeSystemName="ActClass" displayName="Encounter"/>
+                <entryRelationship typeCode="SUBJ">
+                  <encounter classCode="ENC" moodCode="EVN">
+                    <!--  Encounter activities template -->
+                    <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49"/>
+                    <!-- Encounter performed template -->
+                    <templateId extension="2019-12-01" root="2.16.840.1.113883.10.20.24.3.23"/>
+                    <id extension="5ebee1b066105e684b013cf1" root="1.3.6.1.4.1.115"/>
+                    <!-- QDM Attribute: Code -->
+                      <code code="99392" codeSystem="2.16.840.1.113883.6.12" codeSystemName="CPT"/>
+                    <text>Preventive Care, Established Office Visit, 0 to 17</text>
+                    <statusCode code="completed"/>
+                      <!-- QDM Attribute: Relevant Period -->
+                      <!-- low after high warning -->
+                      <effectiveTime><low value='20201006080000'/><high value='20181006083000'/></effectiveTime>
+                  </encounter>
+                </entryRelationship>
+              </act>
+            </entry>
+
+
+            <entry>
+              <observation classCode="OBS" moodCode="EVN" negationInd="true">
+                <!-- Assessment Performed -->
+                <templateId root="2.16.840.1.113883.10.20.24.3.144" extension="2019-12-01" />
+                <id root="1.3.6.1.4.1.115" extension="5ebee1ac66105e684b013812"/>
+                  <code code="73831-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                <text>Adolescent depression screening assessment</text>
+                <statusCode code="completed"/>
+                  <!-- QDM Attribute: Relevant dateTime -->
+                  <effectiveTime value='20180302170000'/>
+                  <!-- QDM Attribute: Author dateTime -->
+                  <author>
+                    <templateId root="2.16.840.1.113883.10.20.24.3.155" extension="2019-12-01"/>
+                    <time value='20180302170000'/>
+                    <assignedAuthor>
+                          <id nullFlavor="NA"/>
+                    </assignedAuthor>
+                  </author>                  <!-- QDM Attribute: Negation Rationale -->
+                  <entryRelationship typeCode="RSON">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.24.3.88" extension="2017-08-01"/>
+                      <id root="1.3.6.1.4.1.115" extension="c2fdd7a0-992a-0138-3a19-784f43709e4a" />
+                      <code code="77301-0" codeSystem="2.16.840.1.113883.6.1" displayName="reason" codeSystemName="LOINC"/>
+                      <statusCode code="completed"/>
+                      <!-- nullFlavored code element (without a valueset) warning -->
+                      <value nullFlavor="NA" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" xsi:type="CD"/>
+                    </observation>
+                  </entryRelationship>              </observation>
+            </entry>
+
+
+
+
+
+            <entry>
+              <observation classCode="OBS" moodCode="EVN" >
+                <!-- Procedure Activity Procedure (Consolidation) template -->
+                <templateId root="2.16.840.1.113883.10.20.22.4.13" extension="2014-06-09"/>
+                <!-- Physical Exam, Performed template -->
+                <templateId root="2.16.840.1.113883.10.20.24.3.59" extension="2019-12-01"/>
+                <id root="1.3.6.1.4.1.115" extension="5ebee1b066105e684b013cf5"/>
+                <!-- QDM Attribute: Code -->
+                  <code code="59574-4" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                <text>BMI percentile</text>
+                <statusCode code="completed"/>
+                  <!-- QDM Attribute: Relevant dateTime -->
+                  <effectiveTime value='20181006081500'/>
+                <!-- QDM Attribute: Result -->
+                <!-- string value warning -->
+                <value xsi:type="ST">Good</value>
+              </observation>
+            </entry>
+
+
+            <entry>
+              <!-- Patient Characteristic Payer -->
+              <observation classCode="OBS" moodCode="EVN">
+                <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
+                <id root="88ed68d0-9bcd-0138-3a2d-784f43709e4a"/> 
+                <code code="48768-6" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" displayName="Payment source"/> 
+                <statusCode code="completed"/>
+                  <!-- QDM Attribute: Relevant Period -->
+                  <!-- low and high both null warning -->
+                  <effectiveTime><low nullFlavor='UNK'/><high nullFlavor='UNK'/></effectiveTime>
+                  <value xsi:type="CD" code="1" codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology"/>
+              </observation>            
+            </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/fixtures/qrda/cat_I/import_warnings.xml
+++ b/test/fixtures/qrda/cat_I/import_warnings.xml
@@ -110,7 +110,7 @@
   </assignedEntity>
 </legalAuthenticator><participant typeCode="DEV">
   <associatedEntity classCode="RGPR">
-    <!-- CMS EHR Certification Number (formerly known as Office of the 
+    <!-- CMS EHR Certification Number (formerly known as Office of the
         National Coordinator Certification Number) -->
     <id extension="123456789" root="2.16.840.1.113883.3.2074.1"/>
   </associatedEntity>
@@ -162,7 +162,7 @@
   <structuredBody>
     <component>
       <section>
-        <!-- 
+        <!--
           *****************************************************************
           Measure Section
           *****************************************************************
@@ -286,7 +286,8 @@
                 <!-- Assessment Performed -->
                 <templateId root="2.16.840.1.113883.10.20.24.3.144" extension="2019-12-01" />
                 <id root="1.3.6.1.4.1.115" extension="5ebee1ac66105e684b013812"/>
-                  <code code="73831-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
+                  <!-- nullFlavored code element (without a valueset) warning -->
+                  <code nullFlavor="NA" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC"/>
                 <text>Adolescent depression screening assessment</text>
                 <statusCode code="completed"/>
                   <!-- QDM Attribute: Relevant dateTime -->
@@ -305,7 +306,7 @@
                       <id root="1.3.6.1.4.1.115" extension="c2fdd7a0-992a-0138-3a19-784f43709e4a" />
                       <code code="77301-0" codeSystem="2.16.840.1.113883.6.1" displayName="reason" codeSystemName="LOINC"/>
                       <statusCode code="completed"/>
-                      <!-- nullFlavored code element (without a valueset) warning -->
+                      <!-- nullFlavored code element that isn't the negated code, shouldn't throw a warning -->
                       <value nullFlavor="NA" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMEDCT" xsi:type="CD"/>
                     </observation>
                   </entryRelationship>              </observation>
@@ -339,14 +340,14 @@
               <!-- Patient Characteristic Payer -->
               <observation classCode="OBS" moodCode="EVN">
                 <templateId root="2.16.840.1.113883.10.20.24.3.55"/>
-                <id root="88ed68d0-9bcd-0138-3a2d-784f43709e4a"/> 
-                <code code="48768-6" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" displayName="Payment source"/> 
+                <id root="88ed68d0-9bcd-0138-3a2d-784f43709e4a"/>
+                <code code="48768-6" codeSystemName="LOINC" codeSystem="2.16.840.1.113883.6.1" displayName="Payment source"/>
                 <statusCode code="completed"/>
                   <!-- QDM Attribute: Relevant Period -->
                   <!-- low and high both null warning -->
                   <effectiveTime><low nullFlavor='UNK'/><high nullFlavor='UNK'/></effectiveTime>
                   <value xsi:type="CD" code="1" codeSystem="2.16.840.1.113883.3.221.5" codeSystemName="Source of Payment Typology"/>
-              </observation>            
+              </observation>
             </entry>
         </section>
       </component>

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -184,7 +184,7 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
 
   # Import and save Cat I file
   def import_cat1_file(doc)
-    patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+    patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
     Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
     patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval')
     patient.save!

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -98,7 +98,7 @@ class PatientZipperTest < ActiveSupport::TestCase
 
   def confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
     negated_oid = ValueSet.where('concepts.code': original_code).first.oid
-    imported_patient = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
+    imported_patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
     imported_patient.update(_type: CQM::VendorPatient)
     cloned_import = imported_patient.clone
     cloned_import2 = imported_patient.clone

--- a/test/unit/lib/validators/qrda_cat1_validator_test.rb
+++ b/test/unit/lib/validators/qrda_cat1_validator_test.rb
@@ -124,8 +124,8 @@ class QrdaCat1ValidatorTest < ActiveSupport::TestCase
     assert_not_empty errors
 
     # should contain one of each import error type
-    messages = errors.map(&:message)
-    assert messages.include?('Code element contains nullFlavor code and no valueset')
+    messages = errors.map(&:message).join
+    assert messages.include?('Negated code element contains nullFlavor code but no valueset')
     assert messages.include?('Interval with low time after high time')
     assert messages.include?('Interval with nullFlavor low time and nullFlavor high time')
     assert messages.include?("Value with string type found. When possible, it's best practice to use a coded value or scalar.")


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code