### PR TITLE
display warnings in the report

### DIFF
--- a/app/views/products/report/_certification_report.html.erb
+++ b/app/views/products/report/_certification_report.html.erb
@@ -118,6 +118,10 @@
   <% c1_not_started_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c1_task? && test.tasks.c1_task.status == 'incomplete' }.compact %>
   <%= render partial: 'products/report/measure_tests_list', locals: { title: 'C1 Not Started Measure Tests', tasks: c1_not_started_tasks } %>
 
+  <% # C1 Passing Measure Tests with Warnings %>
+  <% c1_passing_tasks_with_warnings = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c1_task? && test.tasks.c1_task.passing? && test.tasks.c1_task.most_recent_execution.execution_errors.any? }.compact %>
+  <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C1 Passing Measure Tests with Warnings', tasks: c1_passing_tasks_with_warnings, c3: false } %>
+
   <% # C1 Failing Measure Tests %>
   <% c1_failing_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c1_task? && test.tasks.c1_task.failing? }.compact %>
   <%= render partial: 'products/report/failing_measure_tests', locals: { title: 'C1 Failing Measure Tests', tasks: c1_failing_tasks, c3: false } %>
@@ -132,6 +136,10 @@
   <% # C2 Not Started Measure Tests %>
   <% c2_not_started_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c2_task? && test.tasks.c2_task.status == 'incomplete' }.compact %>
   <%= render partial: 'products/report/measure_tests_list', locals: { title: 'C2 Not Started Measure Tests', tasks: c2_not_started_tasks } %>
+
+  <% # C2 Passing Measure Tests with Warnings %>
+  <% c2_passing_tasks_with_warnings = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c2_task? && test.tasks.c2_task.passing? && test.tasks.c2_task.most_recent_execution.execution_errors.any? }.compact %>
+  <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C2 Passing Measure Tests with Warnings', tasks: c2_passing_tasks_with_warnings, c3: false } %>
 
   <% # C2 Failing Measure Tests %>
   <% c2_failing_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c2_task? && test.tasks.c2_task.failing? }.compact %>
@@ -158,6 +166,10 @@
     <% c3_cat1_not_started_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c3_cat1_task? && test.tasks.c3_cat1_task.status == 'incomplete' }.compact %>
     <%= render partial: 'products/report/measure_tests_list', locals: { title: 'C3 QRDA Category I Not Started Measure Tests', tasks: c3_cat1_not_started_tasks, c3: true } %>
 
+    <% # C3 Cat 1 Passing Measure Tests with Warnings %>
+    <% c3_cat1_passing_tasks_with_warnings = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c3_cat1_task? && test.tasks.c3_cat1_task.passing? && test.tasks.c3_cat1_task.most_recent_execution.execution_errors.any? }.compact %>
+    <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C3 QRDA Category I Passing Measure Tests with Warnings', tasks: c3_cat1_passing_tasks_with_warnings, c3: true } %>
+
     <% # C3 Cat 1 Failing Measure Tests %>
     <% c3_cat1_failing_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c1_task if test.c3_cat1_task? && test.tasks.c3_cat1_task.status == 'failing' }.compact %>
     <%= render partial: 'products/report/failing_measure_tests', locals: { title: 'C3 QRDA Category I Failing Measure Tests', tasks: c3_cat1_failing_tasks, c3: true } %>
@@ -165,6 +177,10 @@
     <% # C3 Cat 3 Not Started Measure Tests %>
     <% c3_cat3_not_started_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c3_cat3_task? && test.tasks.c3_cat3_task.status == 'incomplete' }.compact %>
     <%= render partial: 'products/report/measure_tests_list', locals: { title: 'C3 QRDA Category III Not Started Measure Tests', tasks: c3_cat3_not_started_tasks, c3: true } %>
+
+    <% # C3 Cat 3 Passing Measure Tests with Warnings %>
+    <% c3_cat3_passing_tasks_with_warnings = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c3_cat3_task? && test.tasks.c3_cat3_task.passing? && test.tasks.c3_cat3_task.most_recent_execution.execution_errors.any? }.compact %>
+    <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C3 QRDA Category III Passing Measure Tests with Warnings', tasks: c3_cat3_passing_tasks_with_warnings, c3: true } %>
 
     <% # C3 Cat 3 Failing Measure Tests %>
     <% c3_cat3_failing_tasks = @product.product_tests.measure_tests.collect { |test| test.tasks.c2_task if test.c3_cat3_task? && test.tasks.c3_cat3_task.status == 'failing' }.compact %>
@@ -181,6 +197,10 @@
   <% c4_cat1_not_started_tasks = @product.product_tests.filtering_tests.collect { |test| test.cat1_task if test.task_status('Cat1FilterTask') == 'incomplete' }.compact %>
   <%= render partial: 'products/report/filtering_tests_list', locals: { title: 'C4 QRDA Category I Not Started Measure Tests', tasks: c4_cat1_not_started_tasks } %>
 
+  <% # C4 Cat 1 Passing Measure Tests with Warnings %>
+  <% c4_cat1_passing_tasks_with_warnings = @product.product_tests.filtering_tests.collect { |test| test.cat1_task if test.task_status('Cat1FilterTask') == 'passing' && test.tasks.cat1_filter_task.most_recent_execution.execution_errors.any? }.compact %>
+  <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C4 QRDA Category I Passing Measure Tests with Warnings', tasks: c4_cat1_passing_tasks_with_warnings, c3: false, c4: true } %>
+
   <% # C4 Cat 1 Failing Measure Tests %>
   <% c4_cat1_failing_tasks = @product.product_tests.filtering_tests.collect { |test| test.cat1_task if test.task_status('Cat1FilterTask') == 'failing' }.compact %>
   <%= render partial: 'products/report/failing_measure_tests', locals: { title: 'C4 QRDA Category I Failing Measure Tests', tasks: c4_cat1_failing_tasks, c3: false, c4: true } %>
@@ -188,6 +208,10 @@
   <% # C4 Cat 3 Not Started Measure Tests %>
   <% c4_cat3_not_started_tasks = @product.product_tests.filtering_tests.collect { |test| test.cat3_task if test.task_status('Cat3FilterTask') == 'incomplete' }.compact %>
   <%= render partial: 'products/report/filtering_tests_list', locals: { title: 'C4 QRDA Category III Not Started Measure Tests', tasks: c4_cat3_not_started_tasks } %>
+
+  <% # C4 Cat 3 Passing Measure Tests with Warnings %>
+  <% c4_cat3_passing_tasks_with_warnings = @product.product_tests.filtering_tests.collect { |test| test.cat3_task if test.task_status('Cat3FilterTask') == 'passing' && test.tasks.cat3_filter_task.most_recent_execution.execution_errors.any? }.compact %>
+  <%= render partial: 'products/report/measure_tests_with_warnings', locals: { title: 'C4 QRDA Category III Passing Measure Tests with Warnings', tasks: c4_cat3_passing_tasks_with_warnings, c3: false, c4: true } %>
 
   <% # C4 Cat 3 Failing Measure Tests %>
   <% c4_cat3_failing_tasks = @product.product_tests.filtering_tests.collect { |test| test.cat3_task if test.task_status('Cat3FilterTask') == 'failing' }.compact %>

--- a/app/views/products/report/_failing_measure_tests.html.erb
+++ b/app/views/products/report/_failing_measure_tests.html.erb
@@ -47,11 +47,27 @@
           <% end %>
         <% end %>
       <% end %>
-      <% errors.each do |err| %>
-        <li>
-          <%= err.message.encode('ASCII', invalid: :replace, undef: :replace) %>
-          <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>
-        </li>
+      <% unless errors.empty? || errors.only_errors.empty? %>
+        <li>Errors</li>
+        <ul>
+        <% errors.only_errors.each do |err| %>
+          <li>
+            <%= err.message.encode('ASCII', invalid: :replace, undef: :replace) %>
+            <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>
+          </li>
+        <% end %>
+      </ul>
+      <% end %>
+      <% unless errors.empty? || errors.only_warnings.empty? %>
+        <li>Warnings</li>
+        <ul>
+        <% errors.only_warnings.each do |err| %>
+          <li>
+            <%= err.message.encode('ASCII', invalid: :replace, undef: :replace) %>
+            <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>
+          </li>
+        <% end %>
+      </ul>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/products/report/_measure_tests_with_warnings.html.erb
+++ b/app/views/products/report/_measure_tests_with_warnings.html.erb
@@ -1,0 +1,48 @@
+<%
+
+# local variables:
+#
+#   title   (String)
+#   tasks   (Array of tasks) all tasks should be failing
+#   c3      (boolean) true if errors for the c3 task should be displayed [optional]
+#   c4      (boolean) true if errors for the c4 task should be displayed [optional]
+
+%>
+
+<% return unless tasks && tasks.any? %>
+
+<% c3 ||= false %>
+<% c4 ||= false %>
+
+<h2><%= title %></h2>
+
+<% if tasks %>
+  <% tasks.each do |task| %>
+    <% test = task.product_test %>
+    <strong>
+      <% if c4 %>
+        <% task.product_test.options.filters.each_with_index do |(key, _val), index| %>
+          <%= ' / ' unless index.zero? %>
+          <%= key.titleize %>
+        <% end %>
+        <%= ': ' %>
+      <% end %>
+      <%= "#{test.cms_id} #{test.name}" unless task.product_test.is_a?(ChecklistTest) %>
+    </strong>
+    <ul>
+      <% execution = c3 ? task.most_recent_execution.sibling_execution : task.most_recent_execution %>
+      <% errors = execution.execution_errors %>
+      <% unless errors.empty? || errors.only_warnings.empty? %>
+        <li>Warnings</li>
+        <ul>
+        <% errors.only_warnings.each do |err| %>
+          <li>
+            <%= err.message.encode('ASCII', invalid: :replace, undef: :replace) %>
+            <%= " (#{err.file_name})" if err.has_attribute?('file_name') && err.file_name != '' %>
+          </li>
+        <% end %>
+      </ul>
+      <% end %>
+    </ul>
+  <% end %>
+<% end %>

--- a/app/views/test_executions/results/_error_table.html.erb
+++ b/app/views/test_executions/results/_error_table.html.erb
@@ -13,6 +13,8 @@
 <table class = 'table table-hover table-condensed'>
   <thead>
     <tr>
+      <% message_title = 'Error' if message_title == 'Errors'
+         message_title = 'Warning' if message_title == 'Warnings' %>
       <th scope="col"><%= "#{message_title} message" %></th>
       <th scope="col" class = 'col-sm-2'>Go To in XML</th>
     </tr>

--- a/test/factories/execution_error.rb
+++ b/test/factories/execution_error.rb
@@ -16,7 +16,13 @@ FactoryBot.define do
         message { 'Calculated value (0) for IPP (78A9F833-07AA-448F-B94F-B2C4D8BF4F3F) does not match expected value (1)' }
       end
 
+      trait :qrda_import_warning do
+        msg_type { 'warning' }
+        message { 'Interval with nullFlavor low time and nullFlavor high time' }
+      end
+
       factory :calculating_smoking_gun_validator_compare_results, traits: [:compare_results]
+      factory :calculating_smoking_gun_validator_qrda_import_warning, traits: [:qrda_import_warning]
     end
 
     factory :cat3_population_validator do

--- a/test/unit/product_report_test.rb
+++ b/test/unit/product_report_test.rb
@@ -29,6 +29,10 @@ class ProductReportTest < ActionController::TestCase
       {
         'report_text' => 'does not match expected value',
         'factory_name' => :calculating_smoking_gun_validator_compare_results
+      },
+      {
+        'report_text' => 'Interval with nullFlavor low time and nullFlavor high time',
+        'factory_name' => :calculating_smoking_gun_validator_qrda_import_warning
       }
     ],
     'Cat3PopulationValidator' => [


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code