### PR TITLE
Create a slim test deck if the product does not have a C2 test, and t…

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -240,8 +240,9 @@ class Product
     product_tests.any?(&:eh_measures?)
   end
 
+  # Create a slim test deck if the product does not have a C2 test, and the product is not a CVU+ test
   def slim_test_deck?
-    !c2_test
+    !c2_test && !cvuplus
   end
 
   def test_deck_max

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -292,6 +292,24 @@ class ProducTest < ActiveSupport::TestCase
   #   product.product_tests.each(&:destroy)
   # end
 
+  def test_cvu_plus_not_slim
+    cvu_product = @vendor.products.create(name: 'test_product_cvu_random', cvuplus: true, randomize_patients: true,
+                                          bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+    assert_not cvu_product.slim_test_deck?
+  end
+
+  def test_c1_slim
+    cvu_product = @vendor.products.create(name: 'test_product_c1_random', c1_test: true, randomize_patients: true,
+                                          bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+    assert cvu_product.slim_test_deck?
+  end
+
+  def test_c1_c2_not_slim
+    cvu_product = @vendor.products.create(name: 'test_product_c1_random', c1_test: true, c2_test: true, randomize_patients: true,
+                                          bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+    assert_not cvu_product.slim_test_deck?
+  end
+
   # # # # # # # # # # # # # # # #
   #   S T A T U S   T E S T S   #
   # # # # # # # # # # # # # # # #

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -299,15 +299,15 @@ class ProducTest < ActiveSupport::TestCase
   end
 
   def test_c1_slim
-    cvu_product = @vendor.products.create(name: 'test_product_c1_random', c1_test: true, randomize_patients: true,
-                                          bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
-    assert cvu_product.slim_test_deck?
+    c1_product = @vendor.products.create(name: 'test_product_c1_random', c1_test: true, randomize_patients: true,
+                                         bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+    assert c1_product.slim_test_deck?
   end
 
   def test_c1_c2_not_slim
-    cvu_product = @vendor.products.create(name: 'test_product_c1_random', c1_test: true, c2_test: true, randomize_patients: true,
-                                          bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
-    assert_not cvu_product.slim_test_deck?
+    c1_c2_product = @vendor.products.create(name: 'test_product_c1_c2_random', c1_test: true, c2_test: true, randomize_patients: true,
+                                            bundle_id: @bundle.id, measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'])
+    assert_not c1_c2_product.slim_test_deck?
   end
 
   # # # # # # # # # # # # # # # #


### PR DESCRIPTION
…he product is not a CVU+ test

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-740
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code