### PR TITLE
Handle warning location

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -60,6 +60,7 @@ Metrics/AbcSize:
     - 'lib/cypress/data_criteria_attribute_builder.rb'
     - 'lib/cypress/population_clone_job.rb'
     - 'test/**/*.rb'
+    - 'lib/validators/program_criteria_validator.rb'
 Metrics/ModuleLength:
   Max: 120
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'os'
 
 gem 'cqm-models', '~> 3.0.1'
 gem 'cqm-parsers', '~> 3.1.0'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'import_exception_warnings'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'now_with_path'
 gem 'cqm-validators', '~> 3.0.0'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: 1c3594e5758388e9390c53e85f47e4bc73f74f37
-  branch: import_exception_warnings
+  revision: 78596d3093c31f847453f42db73a87f59dbf70d2
+  branch: now_with_path
   specs:
     cqm-reports (3.0.0)
       cqm-models (~> 3.0.0)
+      cqm-validators (~> 3.0.0)
       erubis (~> 2.7)
       log4r (~> 1.1)
       memoist (~> 0.9)

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -19,7 +19,7 @@ module Validators
         errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
       end
       unit_errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
-      warnings.each { |e| add_warning e, file_name: options[:file_name] }
+      warnings.each { |e| add_warning e.message, {file_name: options[:file_name], location: e.location} }
 
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
       patient

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -19,7 +19,7 @@ module Validators
         errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
       end
       unit_errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
-      warnings.each { |e| add_warning e.message, {file_name: options[:file_name], location: e.location} }
+      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
 
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
       patient

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -38,7 +38,7 @@ module Validators
 
     def calculate_patient(options)
       patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
-      warnings.each { |e| add_warning e.message, {file_name: options[:file_name], location: e.location} }
+      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s)
       patient.save!
       post_processsor_check(patient, options)

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -38,7 +38,7 @@ module Validators
 
     def calculate_patient(options)
       patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
-      warnings.each { |w| add_warning w, file_name: options[:file_name] }
+      warnings.each { |e| add_warning e.message, {file_name: options[:file_name], location: e.location} }
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s)
       patient.save!
       post_processsor_check(patient, options)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code