### PR TITLE
Update dropdown items to remove confusing date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'os'
 
 gem 'cqm-models', '~> 3.0.1'
 gem 'cqm-parsers', '~> 3.1.0'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'master'
+gem 'cqm-reports', '~> 3.1.0'
 gem 'cqm-validators', '~> 3.0.0'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,21 +1,4 @@
 GIT
-  remote: https://github.com/projecttacoma/cqm-reports
-  revision: 48fa1c2eaf44f201ed59c9f4e24990cc7cc4b04f
-  branch: master
-  specs:
-    cqm-reports (3.1.0)
-      cqm-models (~> 3.0.0)
-      cqm-validators (~> 3.0.0)
-      erubis (~> 2.7)
-      log4r (~> 1.1)
-      memoist (~> 0.9)
-      mongoid-tree (> 2.0)
-      mustache
-      nokogiri (~> 1.10)
-      uuid (~> 2.3)
-      zip-zip (~> 0.3)
-
-GIT
   remote: https://github.com/turbolinks/turbolinks-classic
   revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
   branch: master
@@ -156,6 +139,17 @@ GEM
       rubyzip (~> 1.3)
       typhoeus
       uuid (~> 2.3.7)
+      zip-zip (~> 0.3)
+    cqm-reports (3.1.0)
+      cqm-models (~> 3.0.0)
+      cqm-validators (~> 3.0.0)
+      erubis (~> 2.7)
+      log4r (~> 1.1)
+      memoist (~> 0.9)
+      mongoid-tree (> 2.0)
+      mustache
+      nokogiri (~> 1.10)
+      uuid (~> 2.3)
       zip-zip (~> 0.3)
     cqm-validators (3.0.0)
       nokogiri (~> 1.10)
@@ -527,7 +521,7 @@ DEPENDENCIES
   codecov
   cqm-models (~> 3.0.1)
   cqm-parsers (~> 3.1.0)
-  cqm-reports!
+  cqm-reports (~> 3.1.0)
   cqm-validators (~> 3.0.0)
   cucumber (~> 3.0.2)
   cucumber-rails

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -1,8 +1,7 @@
 module TestExecutionsResultsHelper
   include ActionView::Helpers::TextHelper
 
-  def get_select_history_message(execution, index)
-    total_test_executions = execution.task.test_executions.size
+  def get_select_history_message(execution, index, total_test_executions)
     execution_number = total_test_executions - index
     msg = ''
     msg << 'Most Recent - ' if index.zero?

--- a/app/helpers/test_executions_results_helper.rb
+++ b/app/helpers/test_executions_results_helper.rb
@@ -1,10 +1,12 @@
 module TestExecutionsResultsHelper
   include ActionView::Helpers::TextHelper
 
-  def get_select_history_message(execution, is_most_recent)
+  def get_select_history_message(execution, index)
+    total_test_executions = execution.task.test_executions.size
+    execution_number = total_test_executions - index
     msg = ''
-    msg << 'Most Recent - ' if is_most_recent
-    msg << execution.created_at.in_time_zone.strftime('%B %e, %Y %l:%M%P')
+    msg << 'Most Recent - ' if index.zero?
+    msg << "Upload #{execution_number} of #{total_test_executions}"
     case execution.status_with_sibling
     when 'passing' then msg << ' (passing)'
     when 'incomplete' then msg << ' (in progress)'

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -76,8 +76,9 @@
         Results
         <div class = 'pull-right'>
           <select id="select_execution" aria-label="View test execution">
+            <% total_test_executions = @task.test_executions.size %>
             <% @task.test_executions.sort_by { |obj| obj.created_at }.reverse.each_with_index do |execution, i| %>
-              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i) %></option>
+              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i, total_test_executions) %></option>
             <% end %>
           </select>
           <button id="view_execution" class="btn btn-xs btn-<%= execution_status_class(@test_execution) %>">Refresh View</button>

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -77,7 +77,7 @@
         <div class = 'pull-right'>
           <select id="select_execution" aria-label="View test execution">
             <% @task.test_executions.sort_by { |obj| obj.created_at }.reverse.each_with_index do |execution, i| %>
-              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i.zero?) %></option>
+              <option value = <%= task_test_execution_path(@task, execution) %> <%= 'selected="selected"' if execution.id == @test_execution.id %>><%= get_select_history_message(execution, i) %></option>
             <% end %>
           </select>
           <button id="view_execution" class="btn btn-xs btn-<%= execution_status_class(@test_execution) %>">Refresh View</button>

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -112,13 +112,13 @@ class TestExecutionHelper < ActiveSupport::TestCase
     execution.execution_errors.create(message: 'result error 2', msg_type: :error, validator_type: :result_validation)
 
     execution.state = :failed
-    msg = get_select_history_message(execution, true)
+    msg = get_select_history_message(execution, 0)
 
     assert_includes msg, 'Most Recent'
     assert_includes msg, '(3 errors)'
 
     execution.state = :passed
-    msg = get_select_history_message(execution, false)
+    msg = get_select_history_message(execution, 1)
 
     assert_not_includes msg, 'Most Recent'
     assert_includes msg, '(passing)'

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -112,13 +112,13 @@ class TestExecutionHelper < ActiveSupport::TestCase
     execution.execution_errors.create(message: 'result error 2', msg_type: :error, validator_type: :result_validation)
 
     execution.state = :failed
-    msg = get_select_history_message(execution, 0)
+    msg = get_select_history_message(execution, 0, 1)
 
     assert_includes msg, 'Most Recent'
     assert_includes msg, '(3 errors)'
 
     execution.state = :passed
-    msg = get_select_history_message(execution, 1)
+    msg = get_select_history_message(execution, 1, 1)
 
     assert_not_includes msg, 'Most Recent'
     assert_includes msg, '(passing)'


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code