### PR TITLE
increase test coverage

### DIFF
--- a/app/controllers/checklist_tests_controller.rb
+++ b/app/controllers/checklist_tests_controller.rb
@@ -4,14 +4,6 @@ class ChecklistTestsController < ProductTestsController
   before_action :check_bundle_deprecated, only: [:show]
   respond_to :js, only: [:show]
 
-  def create
-    @product_test = @product.product_tests.build({ name: 'c1 visual', measure_ids: @product.measure_ids }, ChecklistTest)
-    @product_test.save!
-    @product_test.create_checked_criteria
-    C1ChecklistTask.new(product_test: @product_test).save!
-    redirect_to vendor_product_path(@product.vendor_id, @product, anchor: 'ChecklistTest')
-  end
-
   def show
     @product = @product_test.product
     set_breadcrumbs
@@ -30,13 +22,6 @@ class ChecklistTestsController < ProductTestsController
     set_measures
     set_breadcrumbs
     render :show
-  end
-
-  def destroy
-    @product_test.destroy
-    respond_to do |format|
-      format.html { redirect_to vendor_product_path(@product.vendor_id, @product) }
-    end
   end
 
   def measure

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -51,6 +51,7 @@ class C1Task < Task
     return status if status == sibling.status
     return 'errored' if errored? || sibling.errored?
     return 'incomplete' if incomplete? || sibling.incomplete?
+    return 'pending' if pending? || sibling.pending?
 
     'failing'
   end

--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -58,6 +58,7 @@ class C2Task < Task
     return status if status == sibling.status
     return 'errored' if errored? || sibling.errored?
     return 'incomplete' if incomplete? || sibling.incomplete?
+    return 'pending' if pending? || sibling.pending?
 
     'failing'
   end

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -92,8 +92,8 @@ Scenario: Filtering properly hides irrelevant measures and tabs when one bundle 
 Scenario: Filtering properly hides irrelevant measures and tabs
   When the user navigates to the create product page
   And the user chooses the custom measure option
-  And the user types "CMS0v1" into the measure filter box
-  Then "CMS0v1" is active on the screen
+  And the user types "CMS3v1" into the measure filter box
+  Then "CMS3v1" is active on the screen
 
 Scenario: Options are appropriately enabled
   When the user navigates to the create product page

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -213,7 +213,6 @@ end
 
 And(/^the user types "([^"]*)" into the measure filter box$/) do |filter_text|
   page.find('#product_search_measures').native.send_keys(filter_text)
-  sleep(0.5)
 end
 
 # ^ ^ ^ Measure Selection ^ ^ ^
@@ -490,7 +489,6 @@ Then(/^all measures should still be selected$/) do
 end
 
 Then(/^"([^"]*)" is active on the screen$/) do |measure|
-  sleep(3)
   page.find('#measure_tabs').assert_text measure
 end
 

--- a/features/step_definitions/product.rb
+++ b/features/step_definitions/product.rb
@@ -212,7 +212,8 @@ And(/^the user manually selects all measures$/) do
 end
 
 And(/^the user types "([^"]*)" into the measure filter box$/) do |filter_text|
-  page.fill_in 'Type to filter by measure', with: filter_text
+  page.find('#product_search_measures').native.send_keys(filter_text)
+  sleep(0.5)
 end
 
 # ^ ^ ^ Measure Selection ^ ^ ^
@@ -489,6 +490,7 @@ Then(/^all measures should still be selected$/) do
 end
 
 Then(/^"([^"]*)" is active on the screen$/) do |measure|
+  sleep(3)
   page.find('#measure_tabs').assert_text measure
 end
 

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -127,7 +127,8 @@ module Cypress
 
     def self.get_random_payer_start_date(patient)
       start_times = patient.qdmPatient.dataElements.map { |de| de.try(:authorDatetime) }.compact
-      random_offset = rand(60 * 60 * 24 * 365)
+      # Offset is a random date within the same year
+      random_offset = rand(365)
       if !start_times.empty?
         [start_times.min - random_offset, patient.qdmPatient.birthDatetime].max
       else

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -24,5 +24,38 @@ module Admin
       assert_equal :admin, Settings.current.default_role
       assert_equal false, Settings.current.enable_debug_features
     end
+
+    test 'should successfully update internal settings' do
+      for_each_logged_in_user([ADMIN]) do
+        patch :update, params: { banner_message: 'banner test', warning_message: 'banner warning test', mailer_address: 'smtp.example.com', mailer_port: 3000, mailer_domain: 'example.com', mailer_user_name: 'testuser', mailer_password: 'password123', mode: 'internal' }
+      end
+      assert_equal 'Internal', Settings.current.application_mode
+      assert_equal true, Settings.current.auto_approve
+      assert_equal true, Settings.current.ignore_roles
+      assert_equal :'', Settings.current.default_role
+      assert_equal true, Settings.current.enable_debug_features
+    end
+
+    test 'should successfully update demo settings' do
+      for_each_logged_in_user([ADMIN]) do
+        patch :update, params: { banner_message: 'banner test', warning_message: 'banner warning test', mailer_address: 'smtp.example.com', mailer_port: 3000, mailer_domain: 'example.com', mailer_user_name: 'testuser', mailer_password: 'password123', mode: 'demo' }
+      end
+      assert_equal 'Demo', Settings.current.application_mode
+      assert_equal true, Settings.current.auto_approve
+      assert_equal false, Settings.current.ignore_roles
+      assert_equal :user, Settings.current.default_role
+      assert_equal true, Settings.current.enable_debug_features
+    end
+
+    test 'should successfully update atl settings' do
+      for_each_logged_in_user([ADMIN]) do
+        patch :update, params: { banner_message: 'banner test', warning_message: 'banner warning test', mailer_address: 'smtp.example.com', mailer_port: 3000, mailer_domain: 'example.com', mailer_user_name: 'testuser', mailer_password: 'password123', mode: 'atl' }
+      end
+      assert_equal 'ATL', Settings.current.application_mode
+      assert_equal false, Settings.current.auto_approve
+      assert_equal false, Settings.current.ignore_roles
+      assert_equal :'', Settings.current.default_role
+      assert_equal false, Settings.current.enable_debug_features
+    end
   end
 end

--- a/test/controllers/admin/trackers_controller_test.rb
+++ b/test/controllers/admin/trackers_controller_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+module Admin
+  class TrackersControllerTest < ActionController::TestCase
+    setup do
+      FactoryBot.create(:admin_user)
+      @controller = Admin::TrackersController.new
+    end
+
+    test 'should successfully destroy tracker' do
+      tracker = Tracker.find_or_create_by(job_id: BSON::ObjectId.new)
+      for_each_logged_in_user([ADMIN]) do
+        delete :destroy, params: { id: tracker.id }
+      end
+    end
+  end
+end

--- a/test/controllers/admin/trackers_controller_test.rb
+++ b/test/controllers/admin/trackers_controller_test.rb
@@ -5,13 +5,19 @@ module Admin
     setup do
       FactoryBot.create(:admin_user)
       @controller = Admin::TrackersController.new
+      @vendor = FactoryBot.create(:vendor_with_points_of_contact)
     end
 
     test 'should successfully destroy tracker' do
-      tracker = Tracker.find_or_create_by(job_id: BSON::ObjectId.new)
+      tracker = Tracker.find_or_create_by(job_id: BSON::ObjectId.new,
+                                          job_class: 'PatientAnalysisJob',
+                                          status: :failed,
+                                          options: { vendor_id: @vendor.id })
       for_each_logged_in_user([ADMIN]) do
         delete :destroy, params: { id: tracker.id }
+        assert_response 302
       end
+      assert_equal 0, Tracker.all.size
     end
   end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -25,11 +25,7 @@ class TasksControllerTest < ActionController::TestCase
       testfile.close
       count = 0
       Zip::ZipFile.foreach(testfile.path) do |zip_entry|
-        if zip_entry.name.include?('.xml') && !zip_entry.name.include?('__MACOSX')
-          doc = Nokogiri::HTML(zip_entry.get_input_stream, &:strict)
-          doc.at_css('head title').to_s
-          count += 1
-        end
+        count += 1 if zip_entry.name.include?('.xml') && !zip_entry.name.include?('__MACOSX')
       end
       assert_equal @task.patients.count, count, 'Zip file has wrong number of records'
       assert_response 200, "#{@user.email} should have access "

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -10,10 +10,30 @@ class TasksControllerTest < ActionController::TestCase
     FactoryBot.create(:user_user)
     vendor_user = FactoryBot.create(:vendor_user)
     FactoryBot.create(:other_user)
-    @test = FactoryBot.create(:product_test_static_result)
+    @test = FactoryBot.create(:cv_product_test_static_result)
     @product = @test.product
-    @task = @test.tasks.first
+    @task = @test.tasks.create({}, C1Task)
     add_user_to_vendor(vendor_user, @product.vendor)
+  end
+
+  # download good test deck as admin
+  test 'should be able to get good result' do
+    for_each_logged_in_user([ADMIN]) do
+      get :good_results, params: { id: @task.id }
+      testfile = Tempfile.new(['good_results_debug_file', '.zip'])
+      testfile.write response.body
+      testfile.close
+      count = 0
+      Zip::ZipFile.foreach(testfile.path) do |zip_entry|
+        if zip_entry.name.include?('.xml') && !zip_entry.name.include?('__MACOSX')
+          doc = Nokogiri::HTML(zip_entry.get_input_stream, &:strict)
+          doc.at_css('head title').to_s
+          count += 1
+        end
+      end
+      assert_equal @task.patients.count, count, 'Zip file has wrong number of records'
+      assert_response 200, "#{@user.email} should have access "
+    end
   end
 
   # need negative tests for user that does not have owner or vendor access

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -41,6 +41,55 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     @prng = Random.new(Random.new_seed)
   end
 
+  def test_null_demographics
+    @record = Patient.new(
+      givenNames: @given_names,
+      familyName: @family_name,
+      addresses: [@patient_address],
+      telecoms: [@patient_telecom]
+    )
+    QDM::Patient.create!(cqmPatient: @record, birthDatetime: DateTime.new(1981, 6, 8, 4, 0, 0).utc)
+    @record.bundleId = @bundle.id
+    @prng = Random.new(Random.new_seed)
+    gender_exception = assert_raises(RuntimeError) do
+      Cypress::DemographicsRandomizer.randomize_gender(@record, @prng)
+    end
+    race_exception = assert_raises(RuntimeError) do
+      Cypress::DemographicsRandomizer.randomize_race(@record, @prng)
+    end
+    ethnicity_exception = assert_raises(RuntimeError) do
+      Cypress::DemographicsRandomizer.randomize_ethnicity(@record, @prng)
+    end
+    payer_exception = assert_raises(RuntimeError) do
+      Cypress::DemographicsRandomizer.randomize_payer(@record, @prng)
+    end
+    assert_equal('Cannot find gender element', gender_exception.message)
+    assert_equal('Cannot find race element', race_exception.message)
+    assert_equal('Cannot find ethnicity element', ethnicity_exception.message)
+    assert_equal('Cannot find payer element', payer_exception.message)
+  end
+
+  def test_random_payer
+    @record = Patient.new(
+      givenNames: @given_names,
+      familyName: @family_name,
+      addresses: [@patient_address],
+      telecoms: [@patient_telecom]
+    )
+    QDM::Patient.create!(cqmPatient: @record, birthDatetime: DateTime.new(1981, 6, 8, 4, 0, 0).utc)
+    @record.bundleId = @bundle.id
+    @prng = Random.new(Random.new_seed)
+    payer_date = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record)
+    # If a patient only has a birthdate, the payer start time should be the birthdate
+    assert_equal payer_date, @record.qdmPatient.birthDatetime
+    assessment_performed = QDM::AssessmentPerformed.new(id: 'assessment', authorDatetime: DateTime.new(2011, 3, 24, 20, 53, 20).utc)
+    @record.qdmPatient.dataElements.push assessment_performed
+    payer_date_with_author_times = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record)
+    # If a patient has a birthdate and an element with an authordate, the payer start time should be between the birthdate and authorDatetime
+    assert payer_date_with_author_times > @record.qdmPatient.birthDatetime
+    assert payer_date_with_author_times < assessment_performed.authorDatetime
+  end
+
   def test_randomize_name
     Cypress::DemographicsRandomizer.randomize_name(@record, @prng)
     assert_not_equal @given_names, @record.givenNames


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code