### PR TITLE
make cures update the default certification type

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -17,7 +17,7 @@ class Product
   # NOTE: more relationships must be defined
 
   field :cvuplus, type: Boolean, default: false
-  field :cures_update, type: Boolean
+  field :cures_update, type: Boolean, default: true
   field :vendor_patients, type: Boolean, default: false
   field :bundle_patients, type: Boolean, default: true
   field :name, type: String


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code