### PR TITLE
Random payer date

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -110,6 +110,7 @@ module Cypress
 
     def self.randomize_payer(patient, prng)
       payer_element = patient.qdmPatient.get_data_elements('patient_characteristic', 'payer')
+      payer_element.first.relevantPeriod = QDM::Interval.new(get_random_payer_start_date(patient), nil)
       payer_hash = sample_payer(patient, prng)
       if payer_element&.any? && payer_element.first.dataElementCodes &&
          payer_element.first.dataElementCodes.any?

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -110,7 +110,6 @@ module Cypress
 
     def self.randomize_payer(patient, prng)
       payer_element = patient.qdmPatient.get_data_elements('patient_characteristic', 'payer')
-      payer_element.first.relevantPeriod = QDM::Interval.new(get_random_payer_start_date(patient), nil)
       payer_hash = sample_payer(patient, prng)
       if payer_element&.any? && payer_element.first.dataElementCodes &&
          payer_element.first.dataElementCodes.any?
@@ -121,15 +120,16 @@ module Cypress
         new_payer['descriptor'] = payer_hash ['name']
         payer_element.first.dataElementCodes << new_payer
         payer_element.first.dataElementCodes.shift # get rid of existing dataElementCode
+        payer_element.first.relevantPeriod = QDM::Interval.new(get_random_payer_start_date(patient, prng), nil)
       else
         raise 'Cannot find payer element'
       end
     end
 
-    def self.get_random_payer_start_date(patient)
+    def self.get_random_payer_start_date(patient, prng)
       start_times = patient.qdmPatient.dataElements.map { |de| de.try(:authorDatetime) }.compact
       # Offset is a random date within the same year
-      random_offset = rand(365)
+      random_offset = prng.rand(365)
       if !start_times.empty?
         [start_times.min - random_offset, patient.qdmPatient.birthDatetime].max
       else

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -79,12 +79,12 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     QDM::Patient.create!(cqmPatient: @record, birthDatetime: DateTime.new(1981, 6, 8, 4, 0, 0).utc)
     @record.bundleId = @bundle.id
     @prng = Random.new(Random.new_seed)
-    payer_date = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record)
+    payer_date = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, @prng)
     # If a patient only has a birthdate, the payer start time should be the birthdate
     assert_equal payer_date, @record.qdmPatient.birthDatetime
     assessment_performed = QDM::AssessmentPerformed.new(id: 'assessment', authorDatetime: DateTime.new(2011, 3, 24, 20, 53, 20).utc)
     @record.qdmPatient.dataElements.push assessment_performed
-    payer_date_with_author_times = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record)
+    payer_date_with_author_times = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, @prng)
     # If a patient has a birthdate and an element with an authordate, the payer start time should be between the birthdate and authorDatetime
     assert payer_date_with_author_times > @record.qdmPatient.birthDatetime
     assert payer_date_with_author_times < assessment_performed.authorDatetime


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code