### PR TITLE
[Cypress 6] update task execution controller delete to match process in product_test

### DIFF
--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -50,7 +50,11 @@ class TestExecutionsController < ApplicationController
 
   def destroy
     authorize! :delete, @test_execution.task.product_test.product.vendor
-    @test_execution.destroy!
+    task_ids = [@test_execution.task.id]
+    test_executions = TestExecution.where(:task_id.in => task_ids)
+    test_execution_ids = test_executions.pluck(:_id)
+    test_executions.delete
+    Artifact.where(:test_execution_id.in => test_execution_ids).destroy
     render body: nil, status: :no_content
   end
 

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -50,8 +50,7 @@ class TestExecutionsController < ApplicationController
 
   def destroy
     authorize! :delete, @test_execution.task.product_test.product.vendor
-    task_ids = [@test_execution.task.id]
-    test_executions = TestExecution.where(:task_id.in => task_ids)
+    test_executions = TestExecution.where(task_id: @test_execution.task.id)
     test_execution_ids = test_executions.pluck(:_id)
     test_executions.delete
     Artifact.where(:test_execution_id.in => test_execution_ids).destroy

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -90,7 +90,7 @@ class TestExecutionsControllerTest < ActionController::TestCase
     # access users
     for_each_logged_in_user([ADMIN, ATL, OWNER]) do
       @first_c2_task.test_executions.destroy
-      te = @first_c2_task.test_executions.build
+      te, _file_name = create_execution_with_task_type(@first_c2_task._type)
       @user.test_executions << te
       te.save!
       delete :destroy, params: { id: te.id }


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code