### PR TITLE
Cherrypick product test recalculate rake task from cypress 5

### DIFF
--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -24,7 +24,7 @@ namespace :cypress do
 
     task all: %i[environment database temp_files]
   end
-
+  # Usage: bundle exec rake cypress:recalculate:product_tests[5ed687f566105e4e3b9737a0] 
   namespace :recalculate do
     task setup: :environment
 

--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -24,7 +24,7 @@ namespace :cypress do
 
     task all: %i[environment database temp_files]
   end
-  # Usage: bundle exec rake cypress:recalculate:product_tests[5ed687f566105e4e3b9737a0] 
+  # Usage: bundle exec rake cypress:recalculate:product_tests[5ed687f566105e4e3b9737a0]
   namespace :recalculate do
     task setup: :environment
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-750
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code