### PR TITLE
simplify ExamplePatientFinder using measure_relevance_hash

### DIFF
--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -85,6 +85,9 @@ module Cypress
       formatter = formatter_for_patients(example_patients.values, 'html')
       Zip::ZipOutputStream.open(file.path) do |z|
         example_patients.each do |measure_id, patient|
+          # skip if an example patient can't be found
+          next unless patient
+
           # TODO: R2P: format patients for export
           add_file_to_zip(z, "sample patient for #{measure_id}.html", formatter.export(patient))
         end

--- a/lib/cypress/example_patient_finder.rb
+++ b/lib/cypress/example_patient_finder.rb
@@ -3,23 +3,12 @@ module Cypress
     # TODO: R2P: get sample patients (for checklist test) with new model
 
     def self.find_example_patient(measure)
-      populations = measure.measure_scoring == 'CONTINUOUS_VARIABLE' ? %w[IPP MSRPOPL MSRPOPLEX OBSERV] : %w[IPP DENOM NUMER DENEX DENEXCEP]
-      example_patient = example_patient_by_pop(measure, populations, populations[1])
-      example_patient = !example_patient.nil? ? example_patient : example_patient_by_pop(measure, populations, 'IPP')
-      # if you still don't have a patient, find one from sub population a
-      !example_patient.nil? ? example_patient : example_patient_by_pop((Measure.find_by description: measure.description), populations, 'IPP')
-    end
-
-    def self.example_patient_by_pop(measure, _populations, pop)
       simplest = 100
       example_patient = nil
       # patient_ids for patients with IndividualResult for the measure specified
       patient_ids = IndividualResult.where(correlation_id: measure.bundle_id, measure_id: measure.id).pluck(:patient_id)
       CQM::Patient.find(patient_ids).each do |record|
-        # result_value is limited to including the population values, no need to include all of the highlighting information
-        result_value = record.calculation_results.where(measure_id: measure.id).only(:IPP, :DENOM, :NUMER, :NUMEX, :DENEX,
-                                                                                     :DENEXCEP, :MSRPOPL, :OBSERV, :MSRPOPLEX)
-        next unless get_result_value(result_value, pop)
+        result_value = record.measure_relevance_hash[measure.id.to_s]
 
         count = population_matches_for_patient(result_value, measure)
         return record if [1, 2].include?(count)
@@ -32,16 +21,11 @@ module Cypress
       example_patient
     end
 
-    def self.get_result_value(result_value, population)
-      result_value.first[population] if result_value.first
-    end
-
     def self.population_matches_for_patient(result_value, measure)
       sum = 0
       populations = measure.measure_scoring == 'CONTINUOUS_VARIABLE' ? %w[IPP MSRPOPL MSRPOPLEX OBSERV] : %w[IPP DENOM NUMER DENEX DENEXCEP]
       populations.each do |pop|
-        value = get_result_value(result_value, pop)
-        sum += 1 if value
+        sum += 1 if result_value[pop]
       end
       sum
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code