### PR TITLE
test_end_date_in_the_future needs date to be in the future, not 2020

### DIFF
--- a/test/unit/lib/validators/encounter_validator_test.rb
+++ b/test/unit/lib/validators/encounter_validator_test.rb
@@ -36,7 +36,7 @@ class EncounterValidatorTest < ActiveSupport::TestCase
   end
 
   def test_end_date_in_the_future
-    change_encounter_period(@document, '20160829140000', '20200829150000')
+    change_encounter_period(@document, '20160829140000', '20300829150000')
     @validator.validate(@document)
 
     assert_equal 1, @validator.errors.count, "Expected 1 error, got #{@validator.errors}"


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code