### PR TITLE
Support telehealth in cypress 6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: f5d7577a92a6c227d3af25242bcec04e9c90f590
+  revision: 3a15b249f3ace0dfc65875b6fe16caabefa92d75
   branch: master
   specs:
     cqm-reports (3.1.2)

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -214,6 +214,19 @@ result_measures:
   - hqmf_set_id : 'FA75DE85-A934-45D7-A2F7-C700A756078B'
     statement_name : 'Results'
 
+# These measures do not 
+telehealth_ineligible_measures:
+  # CMS22v9, CMS69v9, CMS142v9, CMS143v9, CMS771v2
+  # CMS75v9, CMS129v9 CMS133v8 are not included beacuse measures do not contain telehealth-eligible codes and do not require an encounter during the measurement period
+ [ '2C928085-7198-38EE-0171-996316C403A1',
+   '2C928085-7198-38EE-0171-9995E1F90412',
+   '2C928085-7198-38EE-0171-99A391370450',
+   '2C928085-7198-38EE-0171-9999E27A042B',
+   '2C928085-7198-38EE-0171-996032910386' ]
+
+telehealth_modifier_codes:
+  [ '95', 'GQ', 'GT' ]
+
 unit_matches:
   # relevant for CMS9v8+ GestationalAge.result >= 37 weeks, drc "Gestational age--at birth"
   - hqmf_set_id : '7D374C6A-3821-4333-A1BC-4531005D77B8'

--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -111,7 +111,7 @@ module Cypress
         has_telehealth_name = codes_modifier[:name]&.code == 'VR'
         next unless has_telehealth_value || has_telehealth_name
 
-        telehealth_encounter = patient.qdmPatient.encounters.where(_id: encounter_id.value)
+        telehealth_encounter = patient.qdmPatient.encounters.where(_id: encounter_id)
         qualifier_value = has_telehealth_value ? codes_modifier[:value]&.code : codes_modifier[:name]&.code
         ineligible_measures_ids = ineligible_measures.pluck('cms_id').join(', ')
         msg = "Telehealth encounter #{telehealth_encounter.first.codes.first.code} with modifier " \

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -37,18 +37,33 @@ module Validators
     end
 
     def calculate_patient(options)
-      patient, warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
-      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
+      patient, warnings, _codes, codes_modifiers = QRDA::Cat1::PatientImporter.instance.parse_cat1(@file)
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s)
       patient.save!
       post_processsor_check(patient, options)
+      eligible_measures, ineligible_measures = telehealth_eligible_and_ineligible_ecqms(options.task.product_test.measures)
+      calculate_patient_for_measures(patient, options, eligible_measures) unless eligible_measures.empty?
+      unless ineligible_measures.empty?
+        Cypress::QRDAPostProcessor.remove_telehealth_encounters(patient, codes_modifiers, warnings, ineligible_measures) if codes_modifiers
+        calculate_patient_for_measures(patient, options, ineligible_measures)
+      end
+      warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
+    end
+
+    def calculate_patient_for_measures(patient, options, measures)
       calc_job = Cypress::CqmExecutionCalc.new([patient.qdmPatient],
-                                               options.task.product_test.measures,
+                                               measures,
                                                options.test_execution.id.to_s,
                                                'effectiveDateEnd': Time.at(options.task.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(options.task.measure_period_start).in_time_zone.to_formatted_s(:number),
                                                'file_name': options[:file_name])
       calc_job.execute(true)
+    end
+
+    def telehealth_eligible_and_ineligible_ecqms(measures)
+      ineligible_measures = measures.where(:hqmf_id.in => APP_CONSTANTS['telehealth_ineligible_measures'])
+      eligible_measures = measures.where(:hqmf_id.nin => APP_CONSTANTS['telehealth_ineligible_measures'])
+      [eligible_measures, ineligible_measures]
     end
 
     def post_processsor_check(patient, options)

--- a/test/fixtures/qrda/cat_I/sample_patient_good_telehealth.xml
+++ b/test/fixtures/qrda/cat_I/sample_patient_good_telehealth.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-stylesheet type="text/xsl" href="cda.xsl"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:sdtc="urn:hl7-org:sdtc" xmlns:voc="urn:hl7-org:v3/voc" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!-- QRDA Header -->
+  <realmCode code="US"/>
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
+  <!-- US Realm Header Template Id -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2015-08-01" />
+  <!-- QRDA templateId -->
+  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2016-02-01" />
+  <!-- QDM-based QRDA templateId -->
+  <templateId root="2.16.840.1.113883.10.20.24.1.2" extension="2016-08-01"/>
+  <!-- CMS QRDA templateId -->
+  <templateId root="2.16.840.1.113883.10.20.24.1.3" extension="2017-07-01" />
+  <!-- This is the globally unique identifier for this QRDA document -->
+  <id root="5b010313-eff2-432c-9909-6193d8416fac"/>
+  <!-- QRDA document type code -->
+  <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
+  <title>QRDA Incidence Report</title>
+  <!-- This is the document creation time -->
+  <effectiveTime value="20130418191046"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="eng"/>
+  <!-- reported patient -->
+  <recordTarget>
+    <patientRole>
+      <!-- id root="Cypress" extension="51703a883054cf84390000d4"/ -->
+      <!-- Fake Medicare HIC number -->
+      <id extension="12345" root="2.16.840.1.113883.4.572"/>
+      <addr use="HP">
+        <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:+1-781-271-3000"/>
+      <patient>
+        <name>
+          <given>Dental_Peds</given>
+          <family>A</family>
+        </name>
+        <administrativeGenderCode code="M" codeSystem="2.16.840.1.113883.5.1" codeSystemName="HL7 AdministrativeGender"/>
+        <birthTime value="19400101083000"/>
+        <raceCode code="1002-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity" displayName="American Indian or Alaska Native"/>
+        <ethnicGroupCode code="2186-5" codeSystem="2.16.840.1.113883.6.238" codeSystemName="CDC Race and Ethnicity" displayName="Not Hispanic or Latino"/>
+        <languageCommunication>
+          <templateId assigningAuthorityName="HITSP/C83" root="2.16.840.1.113883.3.88.11.83.2"/>
+          <templateId assigningAuthorityName="IHE/PCC" root="1.3.6.1.4.1.19376.1.5.3.1.2.1"/>
+          <languageCode code="eng"/>
+        </languageCommunication>
+      </patient>
+    </patientRole>
+  </recordTarget>
+  <!-- Example of an author who is a device -->
+  <author>
+    <time value="20130418191046"/>
+    <assignedAuthor>
+      <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
+      <!-- NPI -->
+      <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
+      <addr>
+        <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      <assignedAuthoringDevice>
+        <manufacturerModelName>Cypress</manufacturerModelName>
+        <softwareName>Cypress</softwareName>
+      </assignedAuthoringDevice>
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>Cypress Test Deck</name>
+        <telecom use="WP" value="tel:(781)271-3000"/>
+        <addr>
+          <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+          <city>Bedford</city>
+          <state>MA</state>
+          <postalCode>01730</postalCode>
+          <country>US</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <informationRecipient>
+    <intendedRecipient>
+      <id extension="HQR_PI" root="2.16.840.1.113883.3.249.7"/>
+    </intendedRecipient>
+  </informationRecipient>
+  <legalAuthenticator>
+    <time value="20130418191046"/>
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+      <addr>
+        <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      <assignedPerson>
+        <name>
+          <given>Henry</given>
+          <family>Seven</family>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>Cypress</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <!-- TODO: This is where the provider information will go.
+       It is currently hard coded, but should be replaced with the providers
+       and the time over which they are performing. -->
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <!-- care provision -->
+      <effectiveTime>
+        <low value="20100601"/>
+        <high value="20100915"/>
+      </effectiveTime>
+      <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+      <performer typeCode="PRF">
+        <time>
+          <low value="20020716"/>
+          <high value="20070915"/>
+        </time>
+        <assignedEntity>
+          <!-- This is the provider NPI -->
+          <id extension="111111111" root="2.16.840.1.113883.4.6"/>
+          <representedOrganization>
+            <!-- This is the organization TIN -->
+            <id extension="1234567" root="2.16.840.1.113883.4.2"/>
+            <!-- This is the organization CCN -->
+            <id extension="54321" root="2.16.840.1.113883.4.336"/>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <component>
+    <structuredBody>
+      <component>
+        <section>
+          <!-- 
+            *****************************************************************
+            Measure Section
+            *****************************************************************
+          -->
+          <!-- This is the templateId for Measure Section -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+          <!-- This is the templateId for Measure Section QDM -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.3"/>
+          <!-- This is the LOINC code for "Measure document". This stays the same for all measure section required by QRDA standard -->
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Measure Section</title>
+          <text>
+            <table border="1" width="100%">
+              <thead>
+                <tr>
+                  <th>eMeasure Title</th>
+                  <th>Version neutral identifier</th>
+                  <th>eMeasure Version Number</th>
+                  <th>NQF eMeasure Number</th>
+                  <th>Version specific identifier</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents</td>
+                  <td>0B63F730-25D6-4248-B11F-8C09C66A04EB</td>
+                  <td>1</td>
+                  <td>50d3a284da5fe6e140000042</td>
+                  <td>8A4D92B2-397A-48D2-0139-7CC6B5B8011E</td>
+                  <td/>
+                </tr>
+              </tbody>
+            </table>
+          </text>
+          <!-- 1..* Organizers, each containing a reference to an eMeasure -->
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- This is the templateId for Measure Reference -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- This is the templateId for eMeasure Reference QDM -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.97"/>
+              <id extension="50d3a284da5fe6e140000042"/>
+              <statusCode code="completed"/>
+              <!-- Containing isBranch external references -->
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- SHALL: This is the version specific identifier for eMeasure: QualityMeasureDocument/id it is a GUID-->
+                  <id extension="BE65090C-EB1F-11E7-8C3F-9A214CF093AE" root="2.16.840.1.113883.4.738"/>
+                  <!-- SHOULD This is the title of the eMeasure -->
+                  <text>Weight Assessment and Counseling for Nutrition and Physical Activity for Children and Adolescents</text>
+                  <!-- SHOULD: setId is the eMeasure version neutral id  -->
+                  <setId root="C621C7B6-EB1F-11E7-8C3F-9A214CF093AE"/>
+                  <!-- This is the sequential eMeasure Version number -->
+                  <versionNumber value="1"/>
+                </externalDocument>
+              </reference>
+            </organizer>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <!-- This is the templateId for Reporting Parameters section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+          <templateId root="2.16.840.1.113883.10.20.17.2.1.1" extension="2016-03-01" />
+          <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Reporting Parameters</title>
+          <text>
+            <list>
+              <item>Reporting period: January 1st, 2017 00:00 - December 31st, 2017 00:00</item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameteres Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="2010-2011"/>
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101"/>
+                <high value="20171231"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <component>
+        <section>
+          <!-- This is the templateId for Patient Data section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
+          <!-- This is the templateId for Patient Data QDM section -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.1" extension="2016-08-01" />
+          <templateId root="2.16.840.1.113883.10.20.24.2.1.1" extension="2017-07-01"/>
+          <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Patient Data</title>
+          <text/>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!--Encounter performed Act -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.133" extension="2017-08-01"/>
+              <id extension="50d3a288da5fe6e1400001f1" root="1.3.6.1.4.1.115"/>
+              <code code="ENC" codeSystem="2.16.840.1.113883.5.6" displayName="Encounter" codeSystemName="ActClass"/>
+              <entryRelationship typeCode="SUBJ">
+                <encounter classCode="ENC" moodCode="EVN">
+                  <!--  Encounter activities template -->
+                  <templateId extension="2015-08-01" root="2.16.840.1.113883.10.20.22.4.49"/>
+                  <!-- Encounter performed template -->
+                  <templateId extension="2017-08-01" root="2.16.840.1.113883.10.20.24.3.23"/>
+                  <id extension="50d3a288da5fe6e1400001f1" root="1.3.6.1.4.1.115"/>
+                  <code code="720" codeSystem="2.16.840.1.113883.6.96" sdtc:valueSet="1.8.9.10">
+                    <originalText>Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)</originalText>
+                    <qualifier>
+                      <value code="GQ" displayName="Virtual" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+                    </qualifier>
+                  </code>
+                  <text>Encounter, Performed: Office Visit (Code List: 2.16.840.1.113883.3.464.1003.101.12.1001)</text>
+                  <statusCode code="completed"/>
+                  <effectiveTime>
+                    <!-- We try to look for the admit/discharge times on the encounter if they are
+               there. If not, we fall back to the typical start/end date. -->
+                    <low value="20170503000000"/>
+                    <high value="20170503000000"/>
+                  </effectiveTime>
+                </encounter>
+              </entryRelationship>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -122,6 +122,29 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
     end
   end
 
+  def test_telehealth_calcuations
+    setup_eh
+    measure = Measure.find_by(cms_id: 'CMS32v7')
+    pt = @product.product_tests.cms_program_tests.where(cms_program: 'HL7_Cat_I').first
+    task = pt.tasks.first
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good_telehealth.xml'))
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      ir = CQM::IndividualResult.where(measure_id: measure.id, correlation_id: te.id, population_set_key: 'PopulationCriteria1')
+      assert_equal 1, ir.first['IPP']
+    end
+
+    APP_CONSTANTS['telehealth_ineligible_measures'] = pt.measure_ids
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      ir = CQM::IndividualResult.where(measure_id: measure.id, correlation_id: te.id, population_set_key: 'PopulationCriteria1')
+      assert_equal 0, ir.first['IPP']
+      assert_equal 1, te.execution_errors.where(message: 'Telehealth encounter 720 with modifier GQ not used in calculation for eCQMs (CMS32v7, CMS134v6) that are not eligible for telehealth.').size
+    end
+  end
+
   def test_eh_task_with_errors_quarter_reporting
     setup_eh
     pt = @product.product_tests.cms_program_tests.where(cms_program: 'HQR_PI').first


### PR DESCRIPTION
* initial telehealth support in CVU+

* update git reference

* address test failures

* use gem

* add warnings even if there aren't telehealth measures

* update gemfile.lock

* update rails

* version 5.4.2

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code