### PR TITLE
[Cypress 5] Skip CMS demographic checks on stratifications

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,10 +110,9 @@ GEM
     cliver (0.3.2)
     code_analyzer (0.4.8)
       sexp_processor
-    codecov (0.1.14)
+    codecov (0.2.11)
       json
       simplecov
-      url
     coderay (1.1.2)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -203,7 +202,7 @@ GEM
       devise (>= 4.6)
     diff-lcs (1.3)
     diffy (3.3.0)
-    docile (1.3.1)
+    docile (1.3.2)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     dumb_delegator (0.8.0)
@@ -251,7 +250,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
-    json (2.3.0)
+    json (2.3.1)
     kaminari-core (1.1.1)
     kaminari-mongoid (1.0.1)
       kaminari-core (~> 1.0)
@@ -444,11 +443,10 @@ GEM
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
     sexp_processor (4.12.0)
-    simplecov (0.16.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.3)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -480,7 +478,6 @@ GEM
     unicorn-rails (2.2.1)
       rack
       unicorn
-    url (0.3.2)
     uuid (2.3.9)
       macaddr (~> 1.0)
     vcr (5.0.0)

--- a/lib/validators/cms_population_count_validator.rb
+++ b/lib/validators/cms_population_count_validator.rb
@@ -36,6 +36,8 @@ module Validators
             add_error("Missing #{pop_key} for #{measure.cms_id}", file_name: options[:file_name]) if reported_result[pop_key].nil?
             # Skip demographic validators if population is missing
             next if reported_result[pop_key].nil?
+            # Skip if there is a stratification_id.  Stratifications do not report demographics
+            next if pop_set_hash[:stratification_id]
 
             # Skip demographic validators if a code is already found to be missing. Otherwise, validate that all demographic codes are present
             verify_all_codes_reported(reported_result, pop_key, 'PAYER', options) unless @missing_codes['PAYER']


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code