### PR TITLE
Skip CMS demographic checks on stratifications Again

### DIFF
--- a/lib/validators/cms_population_count_validator.rb
+++ b/lib/validators/cms_population_count_validator.rb
@@ -36,6 +36,8 @@ module Validators
             add_error("Missing #{pop_key} for #{measure.cms_id}", file_name: options[:file_name]) if reported_result[pop_key].nil?
             # Skip demographic validators if population is missing
             next if reported_result[pop_key].nil?
+            # Skip if there is a stratification_id.  Stratifications do not report demographics
+            next if pop_set_hash[:stratification_id]
 
             # Skip demographic validators if a code is already found to be missing. Otherwise, validate that all demographic codes are present
             verify_all_codes_reported(reported_result, pop_key, 'PAYER', options) unless @missing_codes['PAYER']


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code