### PR TITLE
TestExecutionPatient in db break description task. (#1444)

### DIFF
--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -43,7 +43,9 @@ module CQM
     def bundle
       if !self['bundleId'].nil?
         Bundle.find(self['bundleId'])
-      elsif !correlation_id.nil?
+      elsif self['_type'] == 'CQM::TestExecutionPatient'
+        TestExecution.find(correlation_id).task.bundle
+      elsif self['_type'] == 'CQM::ProductTestPatient'
         ProductTest.find(correlation_id).bundle
       end
     end

--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -69,7 +69,7 @@ namespace :cypress do
       description_hash = {}
 
       start = Time.new.in_time_zone
-      Patient.not_in(_type: CQM::ProductTestPatient).each do |p|
+      Patient.where(_type: { '$in': ['CQM::BundlePatient', 'CQM::VendorPatient'] }).each do |p|
         # pull out codes by exporting and re-importing
         if p.code_description_hash.empty?
           @options = { start_time: Date.new(2012, 1, 1), end_time: Date.new(2012, 12, 31) }

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -132,6 +132,7 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
       te = task.execute(file, @user)
       te.reload
       ir = CQM::IndividualResult.where(measure_id: measure.id, correlation_id: te.id, population_set_key: 'PopulationCriteria1')
+      assert_equal ir.first.patient.bundle.id, task.bundle.id
       assert_equal 1, ir.first['IPP']
     end
 

--- a/test/unit/lib/validators/expected_results_validator_test.rb
+++ b/test/unit/lib/validators/expected_results_validator_test.rb
@@ -90,6 +90,7 @@ class ExpectedResultsValidatorTest < ActiveSupport::TestCase
     @validator.validate(file, 'task' => @task)
     errors = @validator.errors
 
+    assert_equal @patient3.bundle.id, @task.product_test.bundle.id
     assert_empty errors, 'should be no errors when changing the gender count in accordance with the augmented patients'
   end
 


### PR DESCRIPTION
* TestExecutionPatient in db break description task.
Specifically look for BundlePatient and VendorPatient to update

* return bundle for TestExecutionPatient using correlation_id

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code