### PR TITLE
when finding a preferred code, don't select a negated valueset

### DIFF
--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -113,7 +113,7 @@ module Cypress
         vendor_preference = @test.product.vendor.preferred_code_systems[entry.qdmCategory]
         # if the vendor does not have a preference, pick the first code
         if vendor_preference.blank?
-          entry.dataElementCodes = [entry.dataElementCodes[0]]
+          entry.dataElementCodes = first_data_element_code(entry.dataElementCodes)
         else
           # if the vendor has a preference, loop through in order
           vendor_preference.each do |vp|
@@ -129,8 +129,13 @@ module Cypress
           end
         end
         # if there are still multiple codes, use the first
-        entry.dataElementCodes = [entry.dataElementCodes[0]] if entry.dataElementCodes.size > 1
+        entry.dataElementCodes = first_data_element_code(entry.dataElementCodes) if entry.dataElementCodes.size > 1
       end
+    end
+
+    # Find the first code that isn't a negated valueset
+    def first_data_element_code(data_element_codes)
+      [data_element_codes.reject { |dec| dec['system'] == '1.2.3.4.5.6.7.8.9.10' }.first]
     end
 
     def randomize_entry_ids(cloned_patient)

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -113,7 +113,7 @@ module Cypress
         vendor_preference = @test.product.vendor.preferred_code_systems[entry.qdmCategory]
         # if the vendor does not have a preference, pick the first code
         if vendor_preference.blank?
-          entry.dataElementCodes = first_data_element_code(entry.dataElementCodes)
+          entry.dataElementCodes = [first_data_element_code(entry.dataElementCodes)]
         else
           # if the vendor has a preference, loop through in order
           vendor_preference.each do |vp|
@@ -129,13 +129,13 @@ module Cypress
           end
         end
         # if there are still multiple codes, use the first
-        entry.dataElementCodes = first_data_element_code(entry.dataElementCodes) if entry.dataElementCodes.size > 1
+        entry.dataElementCodes = [first_data_element_code(entry.dataElementCodes)] if entry.dataElementCodes.size > 1
       end
     end
 
     # Find the first code that isn't a negated valueset
     def first_data_element_code(data_element_codes)
-      [data_element_codes.reject { |dec| dec['system'] == '1.2.3.4.5.6.7.8.9.10' }.first]
+      data_element_codes.reject { |dec| dec['system'] == '1.2.3.4.5.6.7.8.9.10' }.first
     end
 
     def randomize_entry_ids(cloned_patient)

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -250,11 +250,11 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
 
     data_element_codes = [negated_vs_code, standard_code1]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert_equal first_code, standard_code1, "First code should be code 1"
+    assert_equal first_code, standard_code1, 'First code should be code 1'
 
     data_element_codes = [standard_code1, standard_code2]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert_equal first_code, standard_code1, "First code should be code 1"
+    assert_equal first_code, standard_code1, 'First code should be code 1'
   end
 
   def clone_records(product_test, options = {})

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -242,6 +242,21 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
     assert found_random, 'Did not find any evidence that race was randomized.'
   end
 
+  def test_first_data_element_code
+    negated_vs_code = { 'code' => '2.16.840.1.113883.3.117.1.7.1.230', 'system' => '1.2.3.4.5.6.7.8.9.10' }
+    standard_code1 = { 'code' => '1', 'system' => '2.16.840.1.113883.6.96' }
+    standard_code2 = { 'code' => '2', 'system' => '2.16.840.1.113883.6.96' }
+    pcj = Cypress::PopulationCloneJob.new({})
+
+    data_element_codes = [negated_vs_code, standard_code1]
+    first_code = pcj.first_data_element_code(data_element_codes)
+    assert first_code, standard_code1
+
+    data_element_codes = [standard_code1, standard_code2]
+    first_code = pcj.first_data_element_code(data_element_codes)
+    assert first_code, standard_code2
+  end
+
   def clone_records(product_test, options = {})
     options['test_id'] = product_test.id unless options['test_id']
     options['subset_id'] = 'all'

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -250,11 +250,11 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
 
     data_element_codes = [negated_vs_code, standard_code1]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert first_code, standard_code1
+    assert_equal first_code, [standard_code1], "First code should be code 1"
 
     data_element_codes = [standard_code1, standard_code2]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert first_code, standard_code2
+    assert_equal first_code, [standard_code1], "First code should be code 1"
   end
 
   def clone_records(product_test, options = {})

--- a/test/unit/lib/population_clone_job_test.rb
+++ b/test/unit/lib/population_clone_job_test.rb
@@ -250,11 +250,11 @@ class PopulationCloneJobTest < ActiveSupport::TestCase
 
     data_element_codes = [negated_vs_code, standard_code1]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert_equal first_code, [standard_code1], "First code should be code 1"
+    assert_equal first_code, standard_code1, "First code should be code 1"
 
     data_element_codes = [standard_code1, standard_code2]
     first_code = pcj.first_data_element_code(data_element_codes)
-    assert_equal first_code, [standard_code1], "First code should be code 1"
+    assert_equal first_code, standard_code1, "First code should be code 1"
   end
 
   def clone_records(product_test, options = {})


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-767
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code