### PR TITLE
remove end time from all CQMExecution calculation requests

### DIFF
--- a/app/jobs/product_test_setup_job.rb
+++ b/app/jobs/product_test_setup_job.rb
@@ -29,10 +29,9 @@ class ProductTestSetupJob < ApplicationJob
   end
 
   def do_calculation(product_test, patients, correlation_id)
-    effective_date_end = Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number)
     effective_date = Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number)
     patient_ids = patients.map { |p| p.id.to_s }
-    options = { 'effectiveDateEnd': effective_date_end, 'effectiveDate': effective_date }
+    options = { 'effectiveDate': effective_date }
     results = product_test.measures.map do |measure|
       SingleMeasureCalculationJob.perform_now(patient_ids, measure.id.to_s, correlation_id, options)
     end.flatten

--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -93,8 +93,7 @@ class VendorPatientUploadJob < ApplicationJob
 
   def generate_calculations(patients, bundle, vendor_id)
     patient_ids = patients.map { |p| p.id.to_s }
-    options = { 'effectiveDateEnd' => Time.at(bundle.effective_date).in_time_zone.to_formatted_s(:number),
-                'effectiveDate' => Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number),
+    options = { 'effectiveDate' => Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number),
                 'includeClauseResults' => true }
     tracker_index = 0
     # cqm-execution-service (using includeClauseResults) can run out of memory when it is run with a lot of patients.

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -12,9 +12,8 @@ Given(/^a vendor patient has measure_calculations$/) do
   second_measure.hqmf_id = 'CE65090C-EB1F-11E7-8C3F-9A214CF093AE'
   second_measure.cms_id = 'CMS032v7'
   second_measure.save
-  effective_date_end = Time.at(@bundle.effective_date).in_time_zone.to_formatted_s(:number)
   effective_date = Time.at(@bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
-  options = { 'effectiveDateEnd' => effective_date_end, 'effectiveDate' => effective_date, 'includeClauseResults' => true }
+  options = { 'effectiveDate' => effective_date, 'includeClauseResults' => true }
   SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, @vendor.id.to_s, options)
   SingleMeasureCalculationJob.perform_now([@patient.id.to_s], second_measure.id.to_s, @vendor.id.to_s, options)
   second_measure.source_data_criteria = nil

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -487,7 +487,6 @@ module Cypress
     def do_calculation(product_test, patients, correlation_id)
       measures = product_test.measures
       calc_job = Cypress::CqmExecutionCalc.new(patients.map(&:qdmPatient), measures, correlation_id,
-                                               effectiveDateEnd: Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
                                                effectiveDate: Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
       calc_job.execute
     end

--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -179,9 +179,8 @@ module Cypress
 
     def self.calculate_results(bundle, tracker, include_highlighting = false)
       patient_ids = bundle.patients.map { |p| p.id.to_s }
-      effective_date_end = Time.at(bundle.effective_date).in_time_zone.to_formatted_s(:number)
       effective_date = Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
-      options = { 'effectiveDateEnd': effective_date_end, 'effectiveDate': effective_date, 'includeClauseResults': include_highlighting }
+      options = { 'effectiveDate': effective_date, 'includeClauseResults': include_highlighting }
       if include_highlighting
         calculate_results_with_highlighting(bundle, patient_ids, tracker, options)
       else

--- a/lib/tasks/bundle_eval.rake
+++ b/lib/tasks/bundle_eval.rake
@@ -33,9 +33,8 @@ namespace :bundle do
 
               calc_diffs = false
               # Set up ecm-execution
-              effective_date_end = Time.at(bundle.effective_date).in_time_zone.to_formatted_s(:number)
               effective_date = Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
-              options = { 'effectiveDateEnd': effective_date_end, 'effectiveDate': effective_date }
+              options = { 'effectiveDate': effective_date }
               # create a new patient to calculate with the individual data element code and compare with the existing patient results;
               # any differences in calculation are noted as a crosswalk issue
               cw_patient = patient.clone

--- a/lib/validators/calculating_augmented_records.rb
+++ b/lib/validators/calculating_augmented_records.rb
@@ -24,7 +24,6 @@ module Validators
       return false unless record
 
       calc_job = Cypress::CqmExecutionCalc.new([record.qdmPatient], product_test.measures, nil,
-                                               'effectiveDateEnd': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
       results = calc_job.execute(false)
       passed = compare_results(results, record, options)

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -42,7 +42,6 @@ module Validators
       calc_job = Cypress::CqmExecutionCalc.new([record.qdmPatient],
                                                product_test.measures,
                                                options.test_execution.id.to_s,
-                                               'effectiveDateEnd': Time.at(product_test.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(product_test.measure_period_start).in_time_zone.to_formatted_s(:number))
       results = calc_job.execute(false)
       passed = determine_passed(mrn, results, record, options)

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -54,7 +54,6 @@ module Validators
       calc_job = Cypress::CqmExecutionCalc.new([patient.qdmPatient],
                                                measures,
                                                options.test_execution.id.to_s,
-                                               'effectiveDateEnd': Time.at(options.task.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(options.task.measure_period_start).in_time_zone.to_formatted_s(:number),
                                                'file_name': options[:file_name])
       calc_job.execute(true)

--- a/test/jobs/measure_evaluation_job_test.rb
+++ b/test/jobs/measure_evaluation_job_test.rb
@@ -19,7 +19,6 @@ class MeasureEvaluationJobTest < ActiveJob::TestCase
 
       correlation_id = BSON::ObjectId.new.to_s
       calc_job = Cypress::CqmExecutionCalc.new(pt.patients.map!(&:qdmPatient), pt.measures, correlation_id,
-                                               'effectiveDateEnd': Time.at(pt.effective_date).in_time_zone.to_formatted_s(:number),
                                                'effectiveDate': Time.at(pt.measure_period_start).in_time_zone.to_formatted_s(:number))
       individual_results_from_sync_job = calc_job.execute(false)
 

--- a/test/unit/lib/cypress/highlighting_test.rb
+++ b/test/unit/lib/cypress/highlighting_test.rb
@@ -10,9 +10,8 @@ class HighlightingTest < ActiveJob::TestCase
 
   def test_highting_results
     measure = @bundle.measures.first
-    effective_date_end = Time.at(@bundle.effective_date).in_time_zone.to_formatted_s(:number)
     effective_date = Time.at(@bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
-    options = { 'effectiveDateEnd' => effective_date_end, 'effectiveDate' => effective_date, 'includeClauseResults' => true }
+    options = { 'effectiveDate' => effective_date, 'includeClauseResults' => true }
     perform_enqueued_jobs do
       SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, @vendor.id.to_s, options)
       ir = IndividualResult.where(correlation_id: @vendor.id.to_s, measure_id: measure.id, patient_id: @patient.id).first


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code