### PR TITLE
Normalize relevant times

### DIFF
--- a/lib/ext/data_element.rb
+++ b/lib/ext/data_element.rb
@@ -3,6 +3,7 @@ module QDM
   class DataElement
     field :dataElementAttributes, type: Array, default: []
     field :encounter_id, type: BSON::ObjectId
+    field :denormalize_as_datetime, type: Boolean
   end
 
   class DataElementAttribute

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -138,6 +138,41 @@ module CQM
       end
     end
 
+    # Iterates through each data element to add
+    # 1. A Relevant DateTime if a Relevant Period is specified
+    # 2. A Relevant Period if a Relevant DateTime is specified
+    # This is used to normalize for eCQM calculations that may use one or the other
+    # The denormalize_as_datetime flag is used by the "denormalize_date_times" to return the record to the original state
+    def normalize_date_times
+      qdmPatient.dataElements.each do |de|
+        next unless de.respond_to?(:relevantDatetime) && de.respond_to?(:relevantPeriod)
+
+        if de.relevantDatetime
+          de.relevantPeriod = QDM::Interval.new(de.relevantDatetime, de.relevantDatetime).shift_dates(0)
+          de.denormalize_as_datetime = true
+        elsif de.relevantPeriod
+          # if low time exists, use it.  Otherwise high time
+          de.relevantDatetime = de.relevantPeriod.low || de.relevantPeriod.high
+          de.denormalize_as_datetime = false
+        end
+      end
+    end
+
+    # "normalize_date_times" add a flag "denormalize_as_datetime" to indicate if a dataElement originally used relevantDatetime
+    # using that flag, return record to the original state
+    def denormalize_date_times
+      qdmPatient.dataElements.each do |de|
+        next unless de.respond_to?(:relevantDatetime) && de.respond_to?(:relevantPeriod)
+
+        if de.denormalize_as_datetime
+          de.relevantPeriod = nil
+        else
+          de.relevantDatetime = nil
+        end
+      end
+      save
+    end
+
     # when laboratory_tests and physical_exams are reported for CMS529, they need to reference the
     # encounter they are related to.  The time range can include 24 hours before and after the encounter occurs.
     def add_encounter_ids_to_events

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -33,6 +33,7 @@ module Validators
       return false unless mrn
 
       record = parse_record(doc, options)
+      record.normalize_date_times
       return false unless record
 
       product_test = options['task'].product_test

--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -25,6 +25,7 @@ module Validators
         # if a criteria has already passed, no need to check again
         next if criteria.passed_qrda
 
+        patient.normalize_date_times
         if validate_criteria(criteria, patient.qdmPatient)
           criteria.passed_qrda = true
           criteria.save


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code