### PR TITLE
[Cypress v5] add validator_type to model to fix failing TestExecutionRepresenter

### DIFF
--- a/app/models/execution_error.rb
+++ b/app/models/execution_error.rb
@@ -8,6 +8,7 @@ class ExecutionError
   field :measure_id, type: String
   field :validation_type, type: String
   field :validator, type: String
+  field :validator_type, type: Symbol
   field :stratification, type: String
   field :location
   field :file_name, type: String


### PR DESCRIPTION
https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2175

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code