### PR TITLE
remove unit test for accessibility

### DIFF
--- a/.simplecov
+++ b/.simplecov
@@ -1,6 +1,19 @@
 SimpleCov.start 'rails' do
-  merge_timeout 3600
+  merge_timeout 7200
 end
 
-require 'codecov'
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
+class SimpleCov::Formatter::QualityFormatter
+  def format(result)
+    SimpleCov::Formatter::HTMLFormatter.new.format(result)
+    File.open("coverage/covered_percent", "w") do |f|
+      f.puts result.source_files.covered_percent.to_f
+    end
+  end
+end
+
+if ENV['CI'] == 'true'
+  require 'codecov'
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+else
+  SimpleCov.formatter = SimpleCov::Formatter::QualityFormatter
+end

--- a/features/checklist_tests/show.feature
+++ b/features/checklist_tests/show.feature
@@ -10,8 +10,6 @@ Scenario: Successful Revisit Checklist Test
   And the user views that product
   And the user views the record sample tab
   Then the user should see a button to revisit the checklist test
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Fill Out Checklist Incorrectly Produces Errors
   When the user creates a product that certifies c1 and visits the record sample page

--- a/features/measure_tests/records_list.feature
+++ b/features/measure_tests/records_list.feature
@@ -11,5 +11,3 @@ Scenario: Admin should be able to view calculation results
   And the user views task c1
   And the user views the task records
   Then the user should see calculation results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -10,8 +10,6 @@ Scenario: Successfully View a Measure Test
   And the user views task c1
   Then the user should see the upload functionality for that product test
   Then the user should see provider information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Only C1 Execution Page
   When the user creates a product with tasks c1
@@ -19,24 +17,18 @@ Scenario: View Only C1 Execution Page
   Then the user should only see the c1 execution page
   Then the user should see provider information
   And the user should be able to click eCQM Specification link
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Only C2 Execution Page
   When the user creates a product with tasks c2
   And the user views task c2
   Then the user should only see the c2 execution page
   Then the user should see provider information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View C1 And C2 Execution Pages
   When the user creates a product with tasks c1, c2
   And the user views task c1
   And the user switches to c2 certification
   Then the user should see the c2 execution page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View C1 and C2 With C3 Execution Pages
   When the user creates a product with tasks c1, c2, c3
@@ -45,8 +37,6 @@ Scenario: View C1 and C2 With C3 Execution Pages
   And the user switches to c2 and c3 certification
   And the user should be able to click eCQM Specification link
   Then the user should see the c1 only and c2 and c3 execution page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View C1 With C3 And C2 Execution Pages
   When the user creates a product with tasks c1, c2, c3
@@ -55,8 +45,6 @@ Scenario: View C1 With C3 And C2 Execution Pages
   And the user switches to c1 and c3 certification
   And the user should be able to click eCQM Specification link
   Then the user should see the c2 only and c1 and c3 execution page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Download CAT 1 Zip
   When the user creates a product with tasks c1
@@ -64,32 +52,24 @@ Scenario: Successful Download CAT 1 Zip
   And the user views task c1
   Then the user should be able to download a CAT 1 zip file
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot View Download CAT 1 Zip
   When the user creates a product with tasks c1
   And the product test state is not set to ready
   And the user views task c1
   Then the user should not be able to download a CAT 1 zip file
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Upload CAT 1 Zip
   When the user creates a product with tasks c1
   And the user views task c1
   And the user uploads a CAT 1 zip file
   Then the user should see test results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Upload CAT 3 XML
   When the user creates a product with records with tasks c2
   And the user views task c2
   And the user uploads a CAT 3 XML file with errors
   Then the user should see test results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   When the user creates a product with tasks c1
@@ -97,8 +77,6 @@ Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   And the user uploads an invalid file
   Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type
   When the user creates a product with tasks c2
@@ -106,8 +84,6 @@ Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type
   And the user uploads an invalid file
   Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful View Uploaded XML for Measure Test
   When the user creates a product with records with tasks c2
@@ -125,8 +101,6 @@ Scenario: Successfully View a Measure Test on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   Then the user should see the upload functionality for that product test
   Then the user should see provider information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Only C1 Execution Page on Deprecated Product
   When the user creates a product with tasks c1
@@ -135,8 +109,6 @@ Scenario: View Only C1 Execution Page on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   Then the user should only see the c1 execution page
   Then the user should see provider information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Only C2 Execution Page on Deprecated Product
   When the user creates a product with tasks c2
@@ -145,8 +117,6 @@ Scenario: View Only C2 Execution Page on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   Then the user should only see the c2 execution page
   Then the user should see provider information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View C1 And C2 Execution Pages on Deprecated Product
   When the user creates a product with tasks c1, c2
@@ -155,8 +125,6 @@ Scenario: View C1 And C2 Execution Pages on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   And the user switches to c2 certification
   Then the user should see the c2 execution page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View C1 And C2 With C3 Execution Pages on Deprecated Product
   When the user creates a product with tasks c1, c2, c3
@@ -166,8 +134,6 @@ Scenario: View C1 And C2 With C3 Execution Pages on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   And the user switches to c2 and c3 certification
   Then the user should see the c1 only and c2 and c3 execution page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Download CAT 1 Zip on Deprecated Product
   When the user creates a product with tasks c1
@@ -177,8 +143,6 @@ Scenario: Successful Download CAT 1 Zip on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   Then the user should be able to download a CAT 1 zip file
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot View Download CAT 1 Zip on Deprecated Product
   When the user creates a product with tasks c1
@@ -187,8 +151,6 @@ Scenario: Cannot View Download CAT 1 Zip on Deprecated Product
   And the user views task c1
   Then the user should see a notification saying the product was deprecated
   Then the user should not be able to download a CAT 1 zip file
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Upload CAT 1 Zip on Deprecated Product
   When the user creates a product with tasks c1
@@ -197,8 +159,6 @@ Scenario: Successful Upload CAT 1 Zip on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   And the user uploads a CAT 1 zip file
   Then the user should see test results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Upload CAT 3 XML on Deprecated Product
   When the user creates a product with tasks c2
@@ -207,8 +167,6 @@ Scenario: Successful Upload CAT 3 XML on Deprecated Product
   Then the user should see a notification saying the product was deprecated
   And the user uploads a CAT 3 XML file
   Then the user should see test results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type on Deprecated Product
   When the user creates a product with tasks c1
@@ -218,8 +176,6 @@ Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type on Deprecate
   And the user uploads an invalid file
   Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type on Deprecated Product
   When the user creates a product with tasks c2
@@ -229,8 +185,6 @@ Scenario: Unsuccessful Upload CAT 3 XML Because Incorrect File Type on Deprecate
   And the user uploads an invalid file
   Then the user should see an error message saying "Invalid file upload"
   And the user should see no execution results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful View Uploaded XML for Measure Test on Deprecated Product
   When the user creates a product with records with tasks c2

--- a/features/multi_measure_tests/records_list.feature
+++ b/features/multi_measure_tests/records_list.feature
@@ -10,8 +10,6 @@ Scenario: Admin should be able to view calculation results
   And the user views multi measure cat3 task
   And the user views the task records
   Then the user should see calculation results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Admin should be able to view list of measures
   When the user creates a cvu plus product with records
@@ -19,8 +17,6 @@ Scenario: Admin should be able to view list of measures
   And the user views multi measure cat3 task
   And the user views the task records
   Then the user should see the list of measures
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aaa
 
 Scenario: Admin should be able to filter patient data
   When the user creates a cvu plus product with records

--- a/features/multi_measure_tests/show.feature
+++ b/features/multi_measure_tests/show.feature
@@ -8,13 +8,9 @@ Scenario: Successfully View a Multi Measure Test
   When the user creates a cvu plus product
   And the user views multi measure cat3 task
   Then the user should see the download test deck link
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successfully View a Multi Measure Test with expected results
   When the user creates a cvu plus product with records
   And the user views multi measure cat3 task
   Then the user should see the list expected results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 

--- a/features/products/edit.feature
+++ b/features/products/edit.feature
@@ -11,20 +11,14 @@ Scenario: Successful View Product Edit Page
 Scenario: Successful Edit Product
   When the user changes the name of the product
   Then the user should see a notification saying the product was edited
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful edit Product with Supplemental Test Artifact
   When the user uploads a correct supplemental test artifact to the product
   Then the user should see a notification saying the product was edited
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful edit Product with Supplemental Test Artifact
   When the user uploads a incorrect supplemental test artifact to the product
   Then the user should see an error message saying "You are not allowed to upload"
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot Download Supplemental Test Artifact when not an ATL
   Given the user is signed in as a non admin
@@ -48,23 +42,15 @@ Scenario: Can Remove a Supplemental Test Artifact
 Scenario: Successful Remove Product
   When the user removes the product
   Then the user should see a notification saying the product was removed
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Remove Product From Vendor Page
   When the user removes the product from the vendor page
   Then the user should see a notification saying the product was removed
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Cancel Remove Product
   When the user cancels removing the product
   Then the user should still see the product
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can View Product Information
   When the user views the product
   Then the user should see the product information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/products/edit_deprecated.feature
+++ b/features/products/edit_deprecated.feature
@@ -13,29 +13,19 @@ Scenario: Successful View Deprecated Product Edit Page
 Scenario: Successful Edit Deprecated Product
   When the user changes the name of the product
   Then the user should see a notification saying the product was edited
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Remove Deprecated Product
   When the user removes the product
   Then the user should see a notification saying the product was removed
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Remove Deprecated Product From Vendor Page
   When the user removes the product from the vendor page
   Then the user should see a notification saying the product was removed
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Cancel Remove Deprecated Product
   When the user cancels removing the product
   Then the user should still see the product
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can View Deprecated Product Information
   When the user views the product
   Then the user should see the product information
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -8,32 +8,22 @@ Scenario: View Create Product Page
   When the user navigates to the create product page
   Then the default bundle should be pre-selected
   Then the shift_records option should not be pre-selected
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successfully Create Product
   When the user creates a product using appropriate information
   Then the user should see a notification saying the product was created
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Product Because No Name
   When the user creates a product with no name
   Then the user should not be able to create a product
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Product Because Name Taken
   When the user creates two products with the same name
   Then the user should see an error message saying "name was already taken"
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Product Because No Task Type Selected
   When the user creates a product with no task type
   Then the user should not be able to create a product
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Create Product with debug mode off and C2 Type selected
   When debug mode is false
@@ -50,21 +40,15 @@ Scenario: Successful Create Product with debug mode off and C1 Type selected
 Scenario: Successful Create Product with Multiple Measures From Different Groups
   When the user creates a product with multiple measures from different groups
   Then the user should see a notification saying the product was created
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Create Product with Group of Measures
   When the user creates a product with selecting a group of measures
   Then the user should see a notification saying the product was created
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Measure Group Unchecked After Deselecting Measure In Group
   When the user fills out all product information but measures
   And the user selects a group of measures but deselects one
   Then the group of measures should no longer be selected
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Filtering does not clear selected measures
   When the user navigates to the create product page
@@ -115,8 +99,6 @@ Scenario: Checking CVU+ Product updates Bundle Options
   Then "Include bundle patients" checkbox should be checked
   Then "Include vendor patients" checkbox should be enabled
   Then "Include vendor patients" checkbox should be unchecked
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Checking Certification Product updates Bundle Options
   When the user navigates to the create product page
@@ -125,8 +107,6 @@ Scenario: Checking Certification Product updates Bundle Options
   Then "Include bundle patients" input should be disabled
   Then "Include vendor patients" input should be invisible
   Then "Include vendor patients" input should be disabled
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
   Scenario: Checking Certification Product updates Bundle Options after Enabling CVU+
   When the user creates a cvu+ product then selects certification product
@@ -137,5 +117,3 @@ Scenario: Checking Certification Product updates Bundle Options
 Scenario: Successful Cancel Create Product
   When the user cancels creating a product
   Then the user should not see the product
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -45,16 +45,12 @@ Scenario: Successful Download All Patients
   And all product tests have a state of ready
   And the user visits the product page
   Then the user should be able to download all patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Cannot View Download All Patients
   When a user creates a product with c2 certifications and visits that product page
   And all product tests do not have a state of ready
   And the user visits the product page
   Then the user should not be able to download all patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can Download Report
   When a user creates a product with c2 certifications and visits that product page

--- a/features/program_tests/edit.feature
+++ b/features/program_tests/edit.feature
@@ -9,8 +9,6 @@ Scenario: Successfully Enter Data for a Program Test
   And the user views CPCPLUS program task
   And the user fills out the program test with good data
   Then the program test should have a program_criteria with the entered value
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successfully Upload QRDA III for a Program Test and Views Results
   When the user creates a cvu plus product
@@ -19,8 +17,6 @@ Scenario: Successfully Upload QRDA III for a Program Test and Views Results
   And the user uploads a Cat III file and waits for results
   And the user should be able to click view results
   Then the user should see errors and warnings
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successfully Upload QRDA III for a Program Test and Views Product
   When the user creates a cvu plus product
@@ -29,8 +25,6 @@ Scenario: Successfully Upload QRDA III for a Program Test and Views Product
   And the user uploads a Cat III file and waits for results
   And the user visits the product page
   Then the user should see cms program tests
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successfully Upload QRDA I for a Program Test and Views Results
   When the user creates a cvu plus product
@@ -40,5 +34,3 @@ Scenario: Successfully Upload QRDA I for a Program Test and Views Results
   And the user should be able to click view results
   Then the user should see errors and warnings
   Then the user should see measure calculations
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/program_tests/show.feature
+++ b/features/program_tests/show.feature
@@ -8,5 +8,3 @@ Scenario: Successfully View a Program Test
   When the user creates a cvu plus product
   And the user views CPCPLUS program task
   Then the user should see instructions
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -8,8 +8,6 @@ Scenario: View Master Patient List Page
   Then the user should see a list of patients
   And the user should see a way to switch bundles
   And the user should see a way to filter patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Master Patient List Page, Deprecated Bundle
   When the user visits the records page
@@ -21,8 +19,6 @@ Scenario: View Master Patient List Page, Single Bundle
   And there is only 1 bundle installed
   Then the user should see a list of patients
   And the user should see a way to filter patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Download MPL from Master Patient List Page
   When the user visits the records page
@@ -47,16 +43,12 @@ Scenario: Successful switch bundles
   When the user visits the records page
   And the user selects a bundle
   Then the user should see records for that bundle
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful filter records
   When the user visits the records page
   And the user searches for a measure
   And the user selects a measure from the dropdown
   Then the user should see results for that measure
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Vendor Patient List Page
   When the user visits the vendor records page
@@ -64,8 +56,6 @@ Scenario: View Vendor Patient List Page
   And the user should see a way to switch bundles
   And the user should see a way to filter patients
   And the user should see a way to select all patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Vendor Patient List Analyize Page
   When the user visits the vendor records page
@@ -73,15 +63,11 @@ Scenario: View Vendor Patient List Analyize Page
   And the user should see a way to analyize patients
   And the user views patient analytics
   And the user should see patient analytics
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful switch bundles for vendor patients
   When the user visits the vendor records page
   And the user selects a bundle
   Then the user should see records for that bundle
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful filter records for vendor patient
   When the user visits the vendor records page
@@ -89,15 +75,11 @@ Scenario: Successful filter records for vendor patient
   And the user searches for a measure
   And the user selects a measure from the dropdown
   Then the user should see results for that measure
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: View Vendor Patient Page
   Given a vendor patient has measure_calculations
   When the user visits the vendor patient link
   Then the user should see vendor patient details
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Scoop and Filter Vendor Patient Page
   Given a vendor patient has measure_calculations
@@ -109,5 +91,3 @@ Scenario: Scoop and Filter Vendor Patient Page
   Then the user should see text PatientCharacteristicBirthdate
   When the user filters on All Measures
   Then the user should see text EncounterPerformed
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/records/show.feature
+++ b/features/records/show.feature
@@ -6,8 +6,6 @@ Background:
 Scenario: Successful view record
   When the user visits a record
   Then the user sees details
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful filter record
   When the user visits a record

--- a/features/users/account.feature
+++ b/features/users/account.feature
@@ -6,17 +6,12 @@ Background:
 Scenario: User wants to edit account information
   When the user clicks an account link
   Then the user should see an edit account page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Logout
   When the user logs out
   Then the user should be signed out
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: User can edit account information
   When the user clicks an account link
   And the user changes their email
   And the user submits the edit user page
-  Then the user should be on the page with Dashboard on it

--- a/features/users/login.feature
+++ b/features/users/login.feature
@@ -6,23 +6,15 @@ Background:
 Scenario: Unsuccessful login
   When the user tries to log in with invalid information
   Then the user should see an log in error message
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful login
   When the user logs in
   Then the user should see a sign out link
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Not Logged In
   When the user navigates to the home page
   Then the user should be redirected to the sign in page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful umls login
   When the user tries to log in with invalid umls information
   Then the user should see an umls error message
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/users/login_no_bundle.feature
+++ b/features/users/login_no_bundle.feature
@@ -7,17 +7,11 @@ Background:
 Scenario: Unsuccessful login
   When the user tries to log in with invalid information
   Then the user should see an log in error message
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful login
   When the user logs in
   Then the user should see a sign out link
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Not Logged In
   When the user navigates to the home page
   Then the user should be redirected to the sign in page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/users/register.feature
+++ b/features/users/register.feature
@@ -10,12 +10,8 @@ Scenario: Create an account
   When I fill in the form with correct information
   And I click Sign up
   Then I should have a new account
-  And the page should be accessible according to: section508
-  And the page should be accessible according to: wcag2aa
 
 Scenario: Create an account with no terms and conditions
   Given the user is on the sign up page
   When I fill in the form without accepting the T&C
   Then I should not be able to submit the form
-  And the page should be accessible according to: section508
-  And the page should be accessible according to: wcag2aa

--- a/features/vendors/edit.feature
+++ b/features/vendors/edit.feature
@@ -6,35 +6,23 @@ Background:
 
 Scenario: Successful Edit Vendor
   When the user edits the vendor
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Remove Vendor
   When the user removes the vendor
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Cancel Remove Vendor
   When the user cancels removing a vendor
   Then the user should still see the vendor
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can View Vendor Information
   When the user views the vendor information
   Then the user should see the vendor name
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can View Vendor Preference
   When the user views the vendor preferences
   Then the user should see choose code system preferences
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Can Save Vendor Preference
   When the user views the vendor preferences
   Then the user should see choose code system preferences
   Then the user should see save code system preferences
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa

--- a/features/vendors/new.feature
+++ b/features/vendors/new.feature
@@ -7,23 +7,15 @@ Background:
 Scenario: Successful Create Vendor
   When the user creates a vendor with appropriate information
   Then the user should see the vendor name
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Vendor Because No Name
   When the user creates a vendor with no name
   Then the user should not be able to create a vendor
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Vendor Because Name Taken
   When the user creates two vendors with the same name
   Then the user should see an error message saying the vendor name has been taken
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Cancel Create Vendor
   When the user cancels creating a vendor
   Then the user should not see the vendor
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code