### PR TITLE
Don't show CVU calculations for uploads with greater than 500 files.

### DIFF
--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -115,24 +115,32 @@ end %>
       <% if (@task.is_a? CMSProgramTask) && @task.product_test.reporting_program_type == 'eh'
         continuous_measures = @task.measures.where(measure_scoring: 'CONTINUOUS_VARIABLE').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
         proportion_measures = @task.measures.where(measure_scoring: 'PROPORTION').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
+        display_calculations = file_name_id_hash.size < APP_CONSTANTS['max_cvu_calculations_displayed'] ? true : false
         file_name_id_hash.each do |file_name, patient|
           if files_with_errors.include?(file_name) %>
             <div id=<%= "#{execution.id}_#{file_name.gsub(/[\W]/,'_')}" %>>
-              <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: execution, file_name: file_name, error_result: collected_errors.files[file_name], is_passing: passing, on_execution_show_page: true, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: false } %>
+              <% unless display_calculations %>
+                <p><strong>Please use Product Report to view eCQM calculations for uploads with greater than <%= APP_CONSTANTS['max_cvu_calculations_displayed'] %> files.</strong></p>
+              <% end %> 
+              <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: execution, file_name: file_name, error_result: collected_errors.files[file_name], is_passing: passing, on_execution_show_page: true, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: false, display_calculations: display_calculations } %>
             </div>
           <% else %>
             <div id=<%= "#{execution.id}_#{file_name.gsub(/[\W]/,'_')}" %>>
               <p class="lead">
                 <%= "#{file_name}" %>
               </p>
-              <%= render partial: 'test_executions/results/calculation_results_for_file', locals: { execution: execution, file_name: file_name, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: false } %>
+              <% if display_calculations %>
+                <%= render partial: 'test_executions/results/calculation_results_for_file', locals: { execution: execution, file_name: file_name, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: false } %>
+              <% else %>
+                <p><strong>Please use Product Report to view eCQM calculations for uploads with greater than <%= APP_CONSTANTS['max_cvu_calculations_displayed'] %> files.</strong></p>
+              <% end %>
             </div>
           <% end %>
         <% end %>
       <% else %>
         <% collected_errors.files.each do |file_name, error_result| %>
           <div id=<%= "#{execution.id}_#{file_name.gsub(/[\W]/,'_')}" %>>
-            <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: execution, file_name: file_name, error_result: error_result, is_passing: passing, on_execution_show_page: true, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: nil, export: false} %>
+            <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: execution, file_name: file_name, error_result: error_result, is_passing: passing, on_execution_show_page: true, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: nil, export: false, display_calculations: false } %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/test_executions/file_result.html.erb
+++ b/app/views/test_executions/file_result.html.erb
@@ -17,6 +17,6 @@
     <h1 class='panel-title'>Results</h1>
   </div>
   <div class = 'panel-body' id = 'display_execution_results' >
-    <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: @test_execution, file_name: @file_name, error_result: @error_result, is_passing: is_passing, on_execution_show_page: false, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: @patient, export: false } %>
+    <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: @test_execution, file_name: @file_name, error_result: @error_result, is_passing: is_passing, on_execution_show_page: false, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: @patient, export: false, display_calculations: true } %>
   </div>
 </div>

--- a/app/views/test_executions/results/_execution_results_for_file.html.erb
+++ b/app/views/test_executions/results/_execution_results_for_file.html.erb
@@ -22,7 +22,9 @@
 </p>
 
 <% if (@task.is_a? CMSProgramTask) && @task.product_test.reporting_program_type == 'eh' %>
-  <%= render partial: 'test_executions/results/calculation_results_for_file', locals: { execution: execution, file_name: file_name, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: export } %>
+  <% if display_calculations %>
+    <%= render partial: 'test_executions/results/calculation_results_for_file', locals: { execution: execution, file_name: file_name, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: patient, export: export } %>
+  <% end %>
 <% end %>
 
 <% if on_execution_show_page && !export %>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -208,6 +208,8 @@ CPC_measures:
 '40280382-6258-7581-0162-92877E281530', '40280382-6258-7581-0162-92CDAF46165E', '40280382-610B-E7A4-0161-9A6155603811',
 '40280382-6258-7581-0162-92106B67138D']
 
+max_cvu_calculations_displayed: 500
+
 # These eCQMs store a list of "Results" within the statement_results of an Individual Result
 result_measures:
   # CMS529


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code