### PR TITLE
always display_calculations in report

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -147,7 +147,8 @@ class ProductsController < ApplicationController
                      continuous_measures: continuous_measures,
                      proportion_measures: proportion_measures,
                      patient: patient,
-                     export: true
+                     export: true,
+                     display_calculations: true
                    }
 
                  else
@@ -160,7 +161,8 @@ class ProductsController < ApplicationController
                      continuous_measures: continuous_measures,
                      proportion_measures: proportion_measures,
                      patient: patient,
-                     export: true
+                     export: true,
+                     display_calculations: true
                    }
                  end
           # note assumes 1 task per CMPSProgramTest producttest


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code