### PR TITLE
selectively add back 508 checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,8 @@ group :development, :test do
   gem 'rubocop', '~>0.66.0'
   gem 'rubocop-rspec'
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
-  gem 'axe-matchers'
+  gem 'axe-core-capybara'
+  gem 'axe-core-cucumber'
   gem 'byebug'
   gem 'capybara'
   gem 'capybara-accessible'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,9 +57,19 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.7.6)
       execjs
-    axe-matchers (2.6.1)
-      dumb_delegator (~> 0.8)
-      virtus (~> 1.0)
+    axe-core-api (4.1.0)
+      capybara
+      dumb_delegator
+      selenium-webdriver
+      virtus
+      watir
+    axe-core-capybara (4.1.0)
+      axe-core-api
+      dumb_delegator
+    axe-core-cucumber (4.1.0)
+      axe-core-api
+      dumb_delegator
+      virtus
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -203,7 +213,7 @@ GEM
     docile (1.3.2)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dumb_delegator (0.8.1)
+    dumb_delegator (1.0.0)
     equalizer (0.0.11)
     erubi (1.9.0)
     erubis (2.7.0)
@@ -481,6 +491,9 @@ GEM
     vmstat (2.3.1)
     warden (1.2.8)
       rack (>= 2.0.6)
+    watir (6.17.0)
+      regexp_parser (~> 1.2)
+      selenium-webdriver (~> 3.6)
     web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
@@ -502,7 +515,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  axe-matchers
+  axe-core-capybara
+  axe-core-cucumber
   bootsnap
   bootstrap-sass (~> 3.4.1)
   bootstrap_form (~> 2.7.0)

--- a/features/admin/show.feature
+++ b/features/admin/show.feature
@@ -7,6 +7,8 @@ Scenario: User is admin
   When the user is an admin
   And the user navigates to the admin page
   Then the user should be able to access the page
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: User is not an admin
   When the user is not an admin

--- a/features/admin/show.feature
+++ b/features/admin/show.feature
@@ -7,8 +7,8 @@ Scenario: User is admin
   When the user is an admin
   And the user navigates to the admin page
   Then the user should be able to access the page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: User is not an admin
   When the user is not an admin

--- a/features/admin/show.feature
+++ b/features/admin/show.feature
@@ -10,6 +10,22 @@ Scenario: User is admin
   Then the page should be axe clean according to: section508
   Then the page should be axe clean according to: wcag2aa
 
+Scenario: User can edit settings
+  When the user is an admin
+  And the user navigates to the admin page
+  And the user clicks edit application settings
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
+
+Scenario: User can upload bundle
+  When the user is an admin
+  And the user navigates to the admin page
+  And the user clicks bundles
+  And the user clicks import bundle
+  Then the user should be able to import bundle
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
+
 Scenario: User is not an admin
   When the user is not an admin
   And the user navigates to the admin page

--- a/features/checklist_tests/show.feature
+++ b/features/checklist_tests/show.feature
@@ -22,8 +22,8 @@ Scenario: Fill Out Checklist Correctly
   And the user fills out the record sample with good data
   Then the user should see checkmarks next to each complete data criteria
   And the user should be able to upload a Cat I file
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Successful Upload Cat I file After Completing Checklist
   When the user creates a product that certifies c1 and visits the record sample page

--- a/features/checklist_tests/show.feature
+++ b/features/checklist_tests/show.feature
@@ -22,6 +22,8 @@ Scenario: Fill Out Checklist Correctly
   And the user fills out the record sample with good data
   Then the user should see checkmarks next to each complete data criteria
   And the user should be able to upload a Cat I file
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Upload Cat I file After Completing Checklist
   When the user creates a product that certifies c1 and visits the record sample page

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -72,6 +72,10 @@ Scenario: Successful Upload CAT 3 XML
   Then the user should see failed results
   Then the page should be axe clean according to: section508
   Then the page should be axe clean according to: wcag2aa
+  And the user clicks user name
+  Then the user should see recently failed tests
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   When the user creates a product with tasks c1

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -69,7 +69,9 @@ Scenario: Successful Upload CAT 3 XML
   When the user creates a product with records with tasks c2
   And the user views task c2
   And the user uploads a CAT 3 XML file with errors
-  Then the user should see test results
+  Then the user should see failed results
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   When the user creates a product with tasks c1

--- a/features/measure_tests/show.feature
+++ b/features/measure_tests/show.feature
@@ -70,8 +70,8 @@ Scenario: Successful Upload CAT 3 XML
   And the user views task c2
   And the user uploads a CAT 3 XML file with errors
   Then the user should see failed results
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Unsuccessful Upload CAT 1 Zip Because Incorrect File Type
   When the user creates a product with tasks c1
@@ -95,6 +95,8 @@ Scenario: Successful View Uploaded XML for Measure Test
   Then the user should see a link to view the the uploaded xml
   When the user views the uploaded xml
   Then the user should see the uploaded xml
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa; skipping: color-contrast
 
 Scenario: Successfully View a Measure Test on Deprecated Product
   When the user creates a product with tasks c1

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -49,6 +49,8 @@ Scenario: Measure Group Unchecked After Deselecting Measure In Group
   When the user fills out all product information but measures
   And the user selects a group of measures but deselects one
   Then the group of measures should no longer be selected
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Filtering does not clear selected measures
   When the user navigates to the create product page

--- a/features/products/new.feature
+++ b/features/products/new.feature
@@ -49,8 +49,8 @@ Scenario: Measure Group Unchecked After Deselecting Measure In Group
   When the user fills out all product information but measures
   And the user selects a group of measures but deselects one
   Then the group of measures should no longer be selected
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Filtering does not clear selected measures
   When the user navigates to the create product page

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -39,6 +39,8 @@ Scenario: Successful Select C1 and C2 and C4 and View Tabs
 Scenario: Successful Select C1 and C2 and C3 and C4 and View Tabs
   When a user creates a product with c1, c2, c3, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Successful Download All Patients
   When a user creates a product with c2 certifications and visits that product page

--- a/features/products/show.feature
+++ b/features/products/show.feature
@@ -39,8 +39,8 @@ Scenario: Successful Select C1 and C2 and C4 and View Tabs
 Scenario: Successful Select C1 and C2 and C3 and C4 and View Tabs
   When a user creates a product with c1, c2, c3, c4 certifications and visits that product page
   Then the user should see the the appropriate tabs
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Successful Download All Patients
   When a user creates a product with c2 certifications and visits that product page

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -19,8 +19,8 @@ Scenario: View Master Patient List Page, Single Bundle
   And there is only 1 bundle installed
   Then the user should see a list of patients
   And the user should see a way to filter patients
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Download MPL from Master Patient List Page
   When the user visits the records page
@@ -82,8 +82,8 @@ Scenario: View Vendor Patient Page
   Given a vendor patient has measure_calculations
   When the user visits the vendor patient link
   Then the user should see vendor patient details
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Scoop and Filter Vendor Patient Page
   Given a vendor patient has measure_calculations

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -19,6 +19,8 @@ Scenario: View Master Patient List Page, Single Bundle
   And there is only 1 bundle installed
   Then the user should see a list of patients
   And the user should see a way to filter patients
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Download MPL from Master Patient List Page
   When the user visits the records page
@@ -80,6 +82,8 @@ Scenario: View Vendor Patient Page
   Given a vendor patient has measure_calculations
   When the user visits the vendor patient link
   Then the user should see vendor patient details
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Scoop and Filter Vendor Patient Page
   Given a vendor patient has measure_calculations

--- a/features/records/index.feature
+++ b/features/records/index.feature
@@ -65,6 +65,8 @@ Scenario: View Vendor Patient List Analyize Page
   And the user should see a way to analyize patients
   And the user views patient analytics
   And the user should see patient analytics
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa; skipping: color-contrast
 
 Scenario: Successful switch bundles for vendor patients
   When the user visits the vendor records page

--- a/features/step_definitions/admin.rb
+++ b/features/step_definitions/admin.rb
@@ -15,6 +15,18 @@ When(/^the user navigates to the admin page$/) do
   visit '/admin'
 end
 
+And(/^the user clicks edit application settings$/) do
+  page.click_button 'Edit Application Settings'
+end
+
+And(/^the user clicks bundles$/) do
+  page.find("[href='#bundles']").click
+end
+
+And(/^the user clicks import bundle$/) do
+  page.click_button '+ Import Bundle'
+end
+
 # # # # # # # #
 #   T H E N   #
 # # # # # # # #
@@ -25,4 +37,8 @@ end
 
 Then(/^the user should not be able to access the page$/) do
   page.assert_text 'not authorized'
+end
+
+Then(/^the user should be able to import bundle$/) do
+  page.assert_text 'Import Bundle'
 end

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -140,6 +140,10 @@ And(/^the user changes the selected bundle$/) do
   end
 end
 
+And(/^the user clicks user name$/) do
+  page.find("[href='/users/edit']").click
+end
+
 # # # # # # # #
 #   T H E N   #
 # # # # # # # #
@@ -208,4 +212,8 @@ end
 
 Then(/^the user should see the uploaded xml$/) do
   page.assert_text '<?xml versio'
+end
+
+Then(/^the user should see recently failed tests$/) do
+  assert_text 'Failed'
 end

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -197,6 +197,11 @@ Then(/^the user should see test results$/) do
   assert_text 'Results'
 end
 
+Then(/^the user should see failed results$/) do
+  page.refresh
+  assert_text 'Failed'
+end
+
 Then(/^the user should see a link to view the the uploaded xml$/) do
   page.find(:xpath, "//input[@value='View Uploaded XML with Errors']")
 end

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -80,7 +80,7 @@ And(/^the user views patient analytics$/) do
 end
 
 And(/^the user should see patient analytics$/) do
-  page.assert_text 'Analysis of patients'
+  page.assert_text 'Analysis of Patients'
 end
 
 And(/^the user searches for a measure$/) do
@@ -166,6 +166,8 @@ When(/^the user visits the vendor records page$/) do
   @vendor = Vendor.create!(name: 'test_vendor_name')
   @measure = @bundle.measures.find_by(hqmf_id: 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE') unless @bundle.measures.count.eql? 0
   @patient = FactoryBot.create(:vendor_test_patient, bundleId: @bundle._id, correlation_id: @vendor.id)
+  PatientAnalysisJob.perform_now(@bundle.id.to_s, @vendor.id.to_s)
+  wait_for_all_delayed_jobs_to_run
   visit "/records?vendor_id=#{@vendor.id}&bundle_id=#{@bundle.id}"
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,7 +14,7 @@ require 'capybara/cucumber'
 require 'capybara/poltergeist'
 require 'capybara/accessible'
 
-require 'axe/cucumber/step_definitions'
+require 'axe-cucumber-steps'
 
 Mongoid.logger.level = Logger::INFO
 Mongo::Logger.logger.level = Logger::INFO

--- a/features/users/login.feature
+++ b/features/users/login.feature
@@ -14,6 +14,8 @@ Scenario: Successful login
 Scenario: Not Logged In
   When the user navigates to the home page
   Then the user should be redirected to the sign in page
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful umls login
   When the user tries to log in with invalid umls information

--- a/features/users/login.feature
+++ b/features/users/login.feature
@@ -14,8 +14,8 @@ Scenario: Successful login
 Scenario: Not Logged In
   When the user navigates to the home page
   Then the user should be redirected to the sign in page
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Unsuccessful umls login
   When the user tries to log in with invalid umls information

--- a/features/vendors/edit.feature
+++ b/features/vendors/edit.feature
@@ -21,6 +21,8 @@ Scenario: Can View Vendor Information
 Scenario: Can View Vendor Preference
   When the user views the vendor preferences
   Then the user should see choose code system preferences
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Can Save Vendor Preference
   When the user views the vendor preferences

--- a/features/vendors/new.feature
+++ b/features/vendors/new.feature
@@ -7,6 +7,8 @@ Background:
 Scenario: Successful Create Vendor
   When the user creates a vendor with appropriate information
   Then the user should see the vendor name
+  Then the page should be accessible according to: section508
+  Then the page should be accessible according to: wcag2aa
 
 Scenario: Unsuccessful Create Vendor Because No Name
   When the user creates a vendor with no name

--- a/features/vendors/new.feature
+++ b/features/vendors/new.feature
@@ -7,8 +7,8 @@ Background:
 Scenario: Successful Create Vendor
   When the user creates a vendor with appropriate information
   Then the user should see the vendor name
-  Then the page should be accessible according to: section508
-  Then the page should be accessible according to: wcag2aa
+  Then the page should be axe clean according to: section508
+  Then the page should be axe clean according to: wcag2aa
 
 Scenario: Unsuccessful Create Vendor Because No Name
   When the user creates a vendor with no name


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code