### PR TITLE
save after post_processsor_check

### DIFF
--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -41,8 +41,8 @@ module Validators
       persisible_codes_modifiers = {}
       codes_modifiers.each { |key, cm| persisible_codes_modifiers[key.to_s] = cm }
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: options.test_execution.id.to_s, codes_modifiers: persisible_codes_modifiers, file_name: options[:file_name])
-      patient.save!
       post_processsor_check(patient, options)
+      patient.save!
       warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
     end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code