### PR TITLE
account for duplicate entries when remove_telehealth_encounters

### DIFF
--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -112,6 +112,9 @@ module Cypress
         next unless has_telehealth_value || has_telehealth_name
 
         telehealth_encounter = patient.qdmPatient.encounters.where(_id: encounter_id)
+        # The telehealth_encounter may have already been removed if there is a duplicate entry in the QRDA file
+        next if telehealth_encounter.empty?
+
         qualifier_value = has_telehealth_value ? codes_modifier[:value]&.code : codes_modifier[:name]&.code
         ineligible_measures_ids = ineligible_measures.pluck('cms_id').join(', ')
         msg = "Telehealth encounter #{telehealth_encounter.first.codes.first.code} with modifier " \


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-798
- [x] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code