### PR TITLE
fix slow generation of measure table

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,7 @@ Metrics/AbcSize:
   # a Float.
   Max: 32
   Exclude:
+    - 'app/controllers/test_executions_controller.rb'
     - 'app/models/cms_program_task.rb'
     - 'lib/cypress/data_criteria_attribute_builder.rb'
     - 'lib/cypress/population_clone_job.rb'

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -21,6 +21,8 @@ class ProductsController < ApplicationController
     add_breadcrumb 'Vendor: ' + @product.vendor_name, vendor_path(@product.vendor_id)
     add_breadcrumb 'Product: ' + @product.name, vendor_product_path(@product.vendor_id, @product)
     @task = Task.find(params[:task_id]) if params[:task_id]
+    @has_eh_tests = @product.eh_tests?
+    @has_ep_tests = @product.ep_tests?
     respond_with(@product, &:js)
   end
 

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -20,6 +20,8 @@ class TestExecutionsController < ApplicationController
   def create
     authorize! :execute_task, @task.product_test.product.vendor
     @test_execution = @task.execute(results_params, current_user)
+    @has_eh_tests = @task.product_test.product.eh_tests?
+    @has_ep_tests = @task.product_test.product.ep_tests?
     @curr_task = Task.find(params[:task_id])
     respond_with(@test_execution) do |f|
       if @task.is_a? C1ChecklistTask

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -100,12 +100,12 @@ module ProductsHelper
     "wrapper-task-id-#{task.id}"
   end
 
-  def include_c3_column(task)
+  def include_c3_column(task, has_eh_tests, has_ep_tests)
     case task
     when C1Task
-      task.product_test.product.c3_test && task.product_test.product.eh_tests?
+      task.product_test.product.c3_test && has_eh_tests
     when C2Task
-      task.product_test.product.c3_test && task.product_test.product.ep_tests?
+      task.product_test.product.c3_test && has_ep_tests
     end
   end
 

--- a/app/views/products/_measure_tests_table.html.erb
+++ b/app/views/products/_measure_tests_table.html.erb
@@ -8,12 +8,14 @@
 %>
 <% # Convert get_c1_tasks into a boolean if it is a string. %>
 <% get_c1_tasks = get_c1_tasks.eql? "true" if get_c1_tasks.is_a? String %>
+<% has_eh_tests = product.eh_tests?
+   has_ep_tests = product.ep_tests? %>
 <% tasks = measure_test_tasks(product, get_c1_tasks) %>
 <% if !tasks.any? %>
   <p>There are no additional tests for this criteria.</p>
 <% else %>
   <% first_results_col_label = tasks.first.is_a?(C1Task) ? 'C1 Results' : 'C2 Results' %>
-  <% include_c3 = include_c3_column(tasks.first) %>
+  <% include_c3 = include_c3_column(tasks.first, has_eh_tests, has_ep_tests) %>
 
   <table class = 'table table-hover measure_tests_table'>
     <thead>
@@ -31,7 +33,7 @@
     <tbody>
       <% tasks.sort_by { |t| cms_int(t.product_test.cms_id) }.each do |task| %>
         <tr id = '<%= measure_tests_table_row_wrapper_id(task) %>'>
-          <%= render 'measure_tests_table_row', :task => task, :parent_reloading => true %>
+          <%= render 'measure_tests_table_row', :task => task, :parent_reloading => true, :has_eh_tests => has_eh_tests, :has_ep_tests => has_ep_tests %>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/products/_measure_tests_table_row.html.erb
+++ b/app/views/products/_measure_tests_table_row.html.erb
@@ -10,7 +10,7 @@
 <% parent_reloading = false unless (defined? parent_reloading) %>
 
 <% test = task.product_test %>
-<% include_c3 = include_c3_column(task) %>
+<% include_c3 = include_c3_column(task, has_eh_tests, has_ep_tests) %>
 
 <td data-sort="<%= cms_int(test.cms_id) %>"><%= test.cms_id %></td>
 <td><%= link_to test.name, new_task_test_execution_path(task) %></td>

--- a/app/views/products/_measure_tests_table_row.html.erb
+++ b/app/views/products/_measure_tests_table_row.html.erb
@@ -46,7 +46,7 @@
 <% if measure_test_running_for_row?(task) && !parent_reloading %>
   <script>
     $(document).ready(function() {
-      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= task.id.to_s %>" }});
+      $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= task.id.to_s %>", has_eh_tests: "<%= has_eh_tests%>", has_ep_tests: "<%= has_ep_tests%>" }});
     });
   </script>
 <% end %>

--- a/app/views/products/show.js.erb
+++ b/app/views/products/show.js.erb
@@ -29,6 +29,6 @@
 <% elsif params[:partial] == 'measure_tests_table_row' %>
   <% wrapper_id = measure_tests_table_row_wrapper_id(@task) %>
   setTimeout(function() {
-    $("#<%= wrapper_id %>").html("<%= escape_javascript render 'measure_tests_table_row', :task => @task %>");
+    $("#<%= wrapper_id %>").html("<%= escape_javascript render 'measure_tests_table_row', :task => @task, :has_eh_tests => @has_eh_tests, :has_ep_tests => @has_ep_tests%>");
   }, 2000);
 <% end %>

--- a/app/views/test_executions/create.js.erb
+++ b/app/views/test_executions/create.js.erb
@@ -9,7 +9,7 @@
 <% is_measure_test_execution = @curr_task.product_test.is_a? MeasureTest %>
 
 <% if is_measure_test_execution %>
-  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= params[:task_id] %>" }});
+  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'measure_tests_table_row', task_id: "<%= params[:task_id] %>", has_eh_tests: "<%= @has_eh_tests%>", has_ep_tests: "<%= @has_ep_tests%>" }});
 <% else # is filtering test execution %>
-  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_link', task_id: "<%= params[:task_id] %>" }});
+  $.ajax({url: "<%= request.env['PATH_INFO'] %>", type: "GET", dataType: 'script', data: { partial: 'filtering_test_link', task_id: "<%= params[:task_id] %>", has_eh_tests: "<%= @has_eh_tests%>", has_ep_tests: "<%= @has_ep_tests%>" }});
 <% end %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code