### PR TITLE
treat each filter type as a string

### DIFF
--- a/app/representers/product_test_representer.rb
+++ b/app/representers/product_test_representer.rb
@@ -46,7 +46,7 @@ module ProductTestRepresenter
        if: ->(_) { _type == 'FilteringTest' && options.filters.key?('problems') && state == :ready },
        wrap: :filters, as: :filters
 
-  hash :other_filters, getter: ->(_) { options.filters.map { |filter_type, filter_val| [filter_type.to_s.singularize, filter_val.first] }.to_h },
+  hash :other_filters, getter: ->(_) { options.filters.map { |filter_type, filter_val| [filter_type.to_s.singularize, filter_val.first.to_s] }.to_h },
                        if: ->(_) { _type == 'FilteringTest' && !options.filters['providers'] && !options.filters['problems'] && state == :ready },
                        wrap: :filters, as: :filters
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code