### PR TITLE
Bring back api eval

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -199,3 +199,36 @@ jobs:
       run: |
         RUBYOPT="-W0"
         bundle exec rake test:controllers test:helpers test:jobs;
+  integration-test:
+    strategy:
+      fail-fast: false
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@21351ecc0a7c196081abca5dc55b08f085efe09a
+      with:
+        ruby-version: 2.6.3
+    - name: Install dependencies
+      run: |
+        . $HOME/.nvm/nvm.sh
+        nvm install 10.12
+        nvm use stable
+        bundle install
+        git clone -b cypress_v6 https://github.com/projecttacoma/cqm-execution-service.git /tmp/cqm-execution-service
+        yarn --cwd /tmp/cqm-execution-service install --only=production
+        yarn --cwd /tmp/cqm-execution-service start &
+        wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-4.0.18.tgz -O /tmp/mongodb.tgz
+        tar -xvf /tmp/mongodb.tgz
+        mkdir /tmp/data
+        ${PWD}/mongodb-linux-x86_64-4.0.18/bin/mongod --setParameter cursorTimeoutMillis=3600000 --setParameter maxBSONDepth=500 --dbpath /tmp/data --bind_ip 127.0.0.1 &> /dev/null &
+        cp ./.travis/mongoid.yml ./config/mongoid.yml
+    - name: Run Rake test
+      run: |
+        RUBYOPT="-W0"
+        bundle exec rake test:integration;

--- a/app/representers/product_test_representer.rb
+++ b/app/representers/product_test_representer.rb
@@ -46,9 +46,14 @@ module ProductTestRepresenter
        if: ->(_) { _type == 'FilteringTest' && options.filters.key?('problems') && state == :ready },
        wrap: :filters, as: :filters
 
-  hash :other_filters, getter: ->(_) { options.filters.map { |filter_type, filter_val| [filter_type.to_s.singularize, filter_val.first.to_s] }.to_h },
-                       if: ->(_) { _type == 'FilteringTest' && !options.filters['providers'] && !options.filters['problems'] && state == :ready },
-                       wrap: :filters, as: :filters
+  hash :other_filters, if: ->(_) { _type == 'FilteringTest' && !options.filters['providers'] && !options.filters['problems'] && state == :ready },
+                       wrap: :filters, as: :filters,
+                       getter: (lambda do |*|
+                         options.filters.map do |filter_type, filter_val|
+                           val = filter_type.to_s == 'age' ? filter_val.first : filter_val.first.to_s
+                           [filter_type.to_s.singularize, val]
+                         end.to_h
+                       end)
 
   self.links = {
     self: proc { product_product_test_path(product, self) },

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -198,7 +198,8 @@ module CQM
         lt.encounter_id = encounter_id_for_event(encounter_times, lt.resultDatetime)
       end
       qdmPatient.get_data_elements('physical_exam', 'performed').each do |pe|
-        pe.encounter_id = encounter_id_for_event(encounter_times, pe.relevantDatetime)
+        event_time = pe.relevantDatetime || pe.relevantPeriod&.low
+        pe.encounter_id = encounter_id_for_event(encounter_times, event_time)
       end
     end
 

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -22,6 +22,7 @@ module Validators
       warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
 
       Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
+      patient.bundleId = @bundle.id
       patient
     rescue
       add_error('File failed import', file_name: options[:file_name])


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code