### PR TITLE
Allow for measure specific timing constraints

### DIFF
--- a/app/helpers/qrda_helper.rb
+++ b/app/helpers/qrda_helper.rb
@@ -1,0 +1,19 @@
+module QrdaHelper
+  def measure_ids_from_cat_1_file(doc)
+    measure_ids = doc.xpath("//cda:entry/cda:organizer[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.98']]" \
+      "/cda:reference[@typeCode='REFR']/cda:externalDocument[@classCode='DOC']" \
+      "/cda:id[@root='2.16.840.1.113883.4.738']/@extension")
+    return nil unless measure_ids
+
+    measure_ids.map(&:value)
+  end
+
+  def measure_ids_from_cat_3_file(doc)
+    measure_ids = doc.xpath("//cda:entry/cda:organizer[./cda:templateId[@root='2.16.840.1.113883.10.20.27.3.1']]" \
+      "/cda:reference[@typeCode='REFR']/cda:externalDocument[@classCode='DOC']" \
+      "/cda:id[@root='2.16.840.1.113883.4.738']/@extension")
+    return nil unless measure_ids
+
+    measure_ids
+  end
+end

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -249,6 +249,12 @@ telehealth_ineligible_measures:
    '2C928085-7198-38EE-0171-9999E27A042B',
    '2C928085-7198-38EE-0171-996032910386' ]
 
+# These measures have specific timing constraints
+timing_constraints:
+  - hqmf_id : '2C928085-7198-38EE-0171-9D44015105A3'
+    start_time : '20210701'
+    end_time : '20220630'
+
 telehealth_modifier_codes:
   [ '95', 'GQ', 'GT' ]
 

--- a/lib/validators/cat3_population_validator.rb
+++ b/lib/validators/cat3_population_validator.rb
@@ -4,6 +4,7 @@ module Validators
   class Cat3PopulationValidator < QrdaFileValidator
     include Validators::Validator
     include ::CqmValidators::ReportedResultExtractor
+    include QrdaHelper
 
     # These are the demographic codes specified in the CMS IG for Payer, Sex, Race and Ethnicity
     REQUIRED_CODES = { 'PAYER' => %w[A B C D],
@@ -61,7 +62,7 @@ module Validators
     end
 
     def validate_population_ids(doc, options)
-      measure_ids_from_file(doc).each do |measure_id|
+      measure_ids_from_cat_3_file(doc).each do |measure_id|
         measure = find_measure_to_validate(measure_id.value.upcase, options)
         next unless measure
 
@@ -146,15 +147,6 @@ module Validators
     def population_count_selector
       "cda:entryRelationship/cda:observation[./cda:templateId[@root='2.16.840.1.113883.10.20.27.3.3']"\
       " and ./cda:code[@code='MSRAGG'] and ./cda:methodCode[@code='COUNT']]/cda:value/@value"
-    end
-
-    def measure_ids_from_file(doc)
-      measure_ids = doc.xpath("//cda:entry/cda:organizer[./cda:templateId[@root='2.16.840.1.113883.10.20.27.3.1']]" \
-        "/cda:reference[@typeCode='REFR']/cda:externalDocument[@classCode='DOC']" \
-        "/cda:id[@root='2.16.840.1.113883.4.738']/@extension")
-      return nil unless measure_ids
-
-      measure_ids
     end
   end
 end

--- a/lib/validators/measure_period_validator.rb
+++ b/lib/validators/measure_period_validator.rb
@@ -22,7 +22,7 @@ module Validators
     end
 
     def validate_timing
-      timing_constraint = APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids_from_cat_1_file(@document).include? tc['hqmf_id'] }
+      timing_constraint = find_timing_constraints
       if timing_constraint && (@product_test.is_a? CMSProgramTest)
         validate_measurement_period(timing_constraint['start_time'], timing_constraint['end_time'])
       elsif (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
@@ -135,6 +135,14 @@ module Validators
     end
 
     private
+
+    def find_timing_constraints
+      # We need to look for measure ids in QRDA I and QRDA III files
+      timing_constraint = APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids_from_cat_1_file(@document).include? tc['hqmf_id'] }
+      timing_constraint || APP_CONSTANTS['timing_constraints'].detect do |tc|
+        measure_ids_from_cat_3_file(@document).map(&:value).include? tc['hqmf_id']
+      end
+    end
 
     def error_options
       { location: '/',

--- a/lib/validators/measure_period_validator.rb
+++ b/lib/validators/measure_period_validator.rb
@@ -1,6 +1,7 @@
 module Validators
   class MeasurePeriodValidator < QrdaFileValidator
     include Validators::Validator
+    include QrdaHelper
 
     # All Encounter end times
     DISCHARGE_SELECTOR = "//cda:encounter[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.23']]/cda:effectiveTime/cda:high/@value".freeze
@@ -16,26 +17,32 @@ module Validators
       @product_test = @options['test_execution'].task.product_test
       @doc_start_time = measure_period_start(@document)
       @doc_end_time = measure_period_end(@document)
-      if (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
+      validate_encounter_during_reporting_period if (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
+      validate_timing
+    end
+
+    def validate_timing
+      timing_constraint = APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids_from_cat_1_file(@document).include? tc['hqmf_id'] }
+      if timing_constraint && (@product_test.is_a? CMSProgramTest)
+        validate_measurement_period(timing_constraint['start_time'], timing_constraint['end_time'])
+      elsif (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
         # For EH measures, Reports are for a single quarter
         validate_quarters_measurement_period
-        # For EH measures, and enounter or procedure needs to end during the quarter reported
-        validate_encounter_during_reporting_period
       else
         # Otherwise, measurement period should be for the correct year.
         validate_measurement_period
       end
     end
 
-    def validate_measurement_period
+    def validate_measurement_period(measure_start = nil, measure_end = nil)
       # Validate that start and end date are reported
-      validate_start
-      validate_end
+      validate_start(measure_start)
+      validate_end(measure_end)
     end
 
-    def validate_start
+    def validate_start(measure_start = nil)
       # Precise to day
-      measure_start = Time.at(@product_test.measure_period_start).utc.strftime('%Y%m%d')
+      measure_start ||= Time.at(@product_test.measure_period_start).utc.strftime('%Y%m%d')
       if !@doc_start_time
         msg = 'Document needs to report the Measurement Start Date'
         add_error(msg, error_options)
@@ -47,9 +54,9 @@ module Validators
       end
     end
 
-    def validate_end
+    def validate_end(measure_end = nil)
       # Precise to day
-      measure_end = Time.at(@product_test.effective_date).utc.strftime('%Y%m%d')
+      measure_end ||= Time.at(@product_test.effective_date).utc.strftime('%Y%m%d')
       if !@doc_end_time
         msg = 'Document needs to report the Measurement End Date'
         add_error(msg, error_options)

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -4,6 +4,7 @@ module Validators
   class ProgramCriteriaValidator < QrdaFileValidator
     include Validators::Validator
     include ::CqmValidators
+    include QrdaHelper
 
     def initialize(program_test)
       @criteria_list = program_test.program_criteria
@@ -19,7 +20,7 @@ module Validators
       @file = file
       @doc = get_document(file)
       # Perform measure calculation for uploaded Cat I files
-      import_patient(options, measure_ids_from_file(@doc)) if options.task.product_test.reporting_program_type == 'eh'
+      import_patient(options, measure_ids_from_cat_1_file(@doc)) if options.task.product_test.reporting_program_type == 'eh'
       # Validate to correct HQMF ids are being reported
       add_cqm_validation_error_as_execution_error(Cat1Measure.instance.validate(@doc, file_name: options[:file_name]),
                                                   'CqmValidators::Cat1Measure',
@@ -34,15 +35,6 @@ module Validators
         criteria.file_name = options[:file_name]
         criteria.save
       end
-    end
-
-    def measure_ids_from_file(doc)
-      measure_ids = doc.xpath("//cda:entry/cda:organizer[./cda:templateId[@root='2.16.840.1.113883.10.20.24.3.98']]" \
-        "/cda:reference[@typeCode='REFR']/cda:externalDocument[@classCode='DOC']" \
-        "/cda:id[@root='2.16.840.1.113883.4.738']/@extension")
-      return nil unless measure_ids
-
-      measure_ids.map(&:value)
     end
 
     def import_patient(options, measure_ids)

--- a/test/unit/lib/validators/measure_period_validator_test.rb
+++ b/test/unit/lib/validators/measure_period_validator_test.rb
@@ -9,6 +9,62 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     @vendor_user.test_executions << @test_execution
   end
 
+  def test_file_with_good_measure_specific_mp
+    measure_id = 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'
+    APP_CONSTANTS['timing_constraints'].first['hqmf_id'] = measure_id
+    APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170101'
+    APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
+    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+                            reporting_program_type: 'eh')
+    pt.create_tasks
+    te = pt.tasks.first.test_executions.build
+    @validator.validate(file, 'test_execution' => te)
+    assert_empty @validator.errors
+  end
+
+  def test_file_with_bad_measure_specific_mp_start_qrda_1
+    measure_id = 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'
+    APP_CONSTANTS['timing_constraints'].first['hqmf_id'] = measure_id
+    APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170102'
+    APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
+    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+                            reporting_program_type: 'eh')
+    pt.create_tasks
+    te = pt.tasks.first.test_executions.build
+    @validator.validate(file, 'test_execution' => te)
+    assert_equal 'Reported Measurement Period should start on 20170102', @validator.errors[0].message
+  end
+
+  def test_file_with_bad_measure_specific_mp_start_qrda_3
+    measure_id = '40280382-5FA6-FE85-0160-0918E74D2075'
+    APP_CONSTANTS['timing_constraints'].first['hqmf_id'] = measure_id
+    APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170102'
+    APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'ep_test_qrda_cat3_missing_measure.xml')).read
+    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'MIPS_APMENTITY', measure_ids: [measure_id],
+                            reporting_program_type: 'ep')
+    pt.create_tasks
+    te = pt.tasks.first.test_executions.build
+    @validator.validate(file, 'test_execution' => te)
+    assert_equal 'Reported Measurement Period should start on 20170102', @validator.errors[0].message
+  end
+
+  def test_file_with_bad_measure_specific_mp_end_qrda_1
+    measure_id = 'BE65090C-EB1F-11E7-8C3F-9A214CF093AE'
+    APP_CONSTANTS['timing_constraints'].first['hqmf_id'] = measure_id
+    APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170101'
+    APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171230'
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
+    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+                            reporting_program_type: 'eh')
+    pt.create_tasks
+    te = pt.tasks.first.test_executions.build
+    @validator.validate(file, 'test_execution' => te)
+    assert_equal 'Reported Measurement Period should end on 20171230', @validator.errors[0].message
+  end
+
   def test_file_with_good_mp
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'ep_test_qrda_cat3_missing_measure.xml')).read
     @validator.validate(file, 'test_execution' => @test_execution)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-846
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code