### PR TITLE
Cat3PopulationValidator should fail more gracefully when Measure can't be found.

### DIFF
--- a/lib/validators/cat3_population_validator.rb
+++ b/lib/validators/cat3_population_validator.rb
@@ -62,7 +62,9 @@ module Validators
 
     def validate_population_ids(doc, options)
       measure_ids_from_file(doc).each do |measure_id|
-        measure = options['test_execution'].task.bundle.measures.find_by(hqmf_id: measure_id.value.upcase)
+        measure = find_measure_to_validate(measure_id.value.upcase, options)
+        next unless measure
+
         measure.population_sets_and_stratifications_for_measure.each do |pop_set_hash|
           results, _errors = extract_results_by_ids(measure, pop_set_hash[:population_set_id], doc, pop_set_hash[:stratification_id])
           measure.population_keys.each do |key|
@@ -75,6 +77,12 @@ module Validators
           end
         end
       end
+    end
+
+    def find_measure_to_validate(measure_id, options)
+      return nil unless options['test_execution'].task.bundle.measures.distinct(:hqmf_id).include? measure_id
+
+      options['test_execution'].task.bundle.measures.find_by(hqmf_id: measure_id)
     end
 
     def validate_demographics(reported_result, pop_key, pop_set_hash, options)

--- a/test/fixtures/qrda/cat_III/ep_test_qrda_cat3_good_invalid_id.xml
+++ b/test/fixtures/qrda/cat_III/ep_test_qrda_cat3_good_invalid_id.xml
@@ -1,0 +1,488 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ClinicalDocument xmlns="urn:hl7-org:v3" xmlns:cda="urn:hl7-org:v3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <!--
+    ********************************************************
+    CDA Header
+    ********************************************************
+  -->
+  <realmCode code="US"/>
+  <typeId extension="POCD_HD000040" root="2.16.840.1.113883.1.3"/>
+  <!-- QRDA Category III template ID (this template ID differs from QRDA III comment only template ID). -->
+  <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.1.1"/>
+  <id extension="CypressExtension" root="c8b86f50-6c13-0136-96fe-6a00008fee70"/>
+  <!-- SHALL QRDA III document type code -->
+  <code code="55184-6" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Reporting Document Architecture Calculated Summary Report"/>
+  <!-- SHALL Title, SHOULD have this content -->
+  <title>QRDA Calculated Summary Report</title>
+  <!-- SHALL  -->
+  <effectiveTime value="20180717172137"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en"/>
+  <!-- SHOULD The version of the file being submitted. -->
+  <versionNumber value="1"/>
+  <!-- SHALL contain recordTarget and ID - but ID is nulled to NA. This is an aggregate summary report. Therefore CDA's required patient identifier is nulled. -->
+  <recordTarget>
+    <patientRole>
+      <id nullFlavor="NA"/>
+    </patientRole>
+  </recordTarget>
+  <!-- SHALL have 1..* author. MAY be device or person. 
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+  <author>
+    <time value="20180717172137"/>
+    <assignedAuthor>
+      <!-- Registry author ID -->
+      <id extension="authorExtension" root="authorRoot"/>
+      <assignedAuthoringDevice>
+        <manufacturerModelName>deviceModel</manufacturerModelName>
+        <softwareName>deviceName</softwareName>
+      </assignedAuthoringDevice>
+      <representedOrganization>
+        <!-- Represents unique registry organization TIN -->
+        <id extension="authorsOrganizationExt" root="authorsOrganizationRoot"/>
+        <!-- Contains name - specific registry not required-->
+        <name/>
+      </representedOrganization>
+    </assignedAuthor>
+  </author>
+  <!-- SHALL have 1..* author. MAY be device or person.
+    The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+  <!-- The custodian of the CDA document is the same as the legal authenticator in this
+  example and represents the reporting organization. -->
+  <!-- SHALL -->
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <!-- Represents unique registry organization TIN -->
+        <id extension="custodianOrganizationExt" root="custodianOrganizationRoot"/>
+        <!-- Contains name - specific registry not required-->
+        <name/>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <!-- The legal authenticator of the CDA document is a single person who is at the
+    same organization as the custodian in this example. This element must be present. -->
+  <!-- SHALL -->
+  <legalAuthenticator>
+    <!-- SHALL -->
+    <time value="20180717172137"/>
+    <!-- SHALL -->
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <!-- SHALL ID -->
+      <id extension="legalAuthenticatorExt" root="legalAuthenticatorRoot"/>
+      <assignedPerson>
+        <name>
+          <given/>
+          <family/>
+        </name>
+      </assignedPerson>
+      <representedOrganization>
+        <!-- Represents unique registry organization TIN -->
+        <id extension="legalAuthenticatorOrgExt" root="legalAuthenticatorOrgRoot"/>
+        <!-- Contains name - specific registry not required-->
+        <name/>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  <documentationOf typeCode="DOC">
+    <serviceEvent classCode="PCPR">
+      <!-- care provision -->
+      <!-- No provider data found in the patient record
+         putting in a fake provider -->
+      <effectiveTime>
+        <low value="20020716"/>
+        <high value="20180717172137"/>
+      </effectiveTime>
+      <!-- You can include multiple performers, each with an NPI, TIN, CCN. -->
+      <performer typeCode="PRF">
+        <time>
+          <low value="20020716"/>
+          <high value="20180717172137"/>
+        </time>
+        <assignedEntity>
+          <!-- This is the provider NPI -->
+          <id extension="111111111" root="2.16.840.1.113883.4.6"/>
+          <representedOrganization>
+            <!-- This is the organization TIN -->
+            <id extension="1234567" root="2.16.840.1.113883.4.2"/>
+            <!-- This is the organization CCN -->
+            <id extension="54321" root="2.16.840.1.113883.4.336"/>
+          </representedOrganization>
+        </assignedEntity>
+      </performer>
+    </serviceEvent>
+  </documentationOf>
+  <!--
+********************************************************
+CDA Body
+********************************************************
+-->
+  <component>
+    <structuredBody>
+      <!--
+********************************************************
+QRDA Category III Reporting Parameters
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- This is the templateId for Reporting Parameters section -->
+          <templateId root="2.16.840.1.113883.10.20.17.2.1"/>
+          <!-- This is the templateId for the QRDA III Reporting Parameters Section -->
+          <templateId root="2.16.840.1.113883.10.20.27.2.2"/>
+          <code code="55187-9" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Reporting Parameters</title>
+          <text>
+            <list>
+              <item>Reporting period: January 1st, 2012 00:00 - December 31st, 2012 23:59</item>
+            </list>
+          </text>
+          <entry typeCode="DRIV">
+            <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F609ADD3CD46E8D34505077D8A053792"/>
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20120101000000"/>
+                <high value="20121231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+      <!--
+********************************************************
+Measure Section
+********************************************************
+-->
+      <component>
+        <section>
+          <!-- Implied template Measure Section templateId -->
+          <templateId root="2.16.840.1.113883.10.20.24.2.2"/>
+          <!-- In this case the query is using an eMeasure -->
+          <!-- QRDA Category III Measure Section template -->
+          <templateId extension="2017-06-01" root="2.16.840.1.113883.10.20.27.2.1"/>
+          <code code="55186-1" codeSystem="2.16.840.1.113883.6.1"/>
+          <title>Measure Section</title>
+          <text/>
+          <entry>
+            <organizer classCode="CLUSTER" moodCode="EVN">
+              <!-- Implied template Measure Reference templateId -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.98"/>
+              <!-- SHALL 1..* (one for each referenced measure) Measure Reference and Results template -->
+              <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.1"/>
+              <id extension="40280382-5FA6-FE85-0160-0918E74D2075"/>
+              <statusCode code="completed"/>
+              <reference typeCode="REFR">
+                <externalDocument classCode="DOC" moodCode="EVN">
+                  <!-- SHALL: required Id but not restricted to the eMeasure Document/Id-->
+                  <!-- QualityMeasureDocument/id This is the version specific identifier for eMeasure -->
+                  <id extension="40280382-5FA6-FE85-0160-0918E74D2076" root="2.16.840.1.113883.4.738"/>
+                  <!-- SHOULD This is the title of the eMeasure -->
+                  <text>Static Measure</text>
+                  <!-- SHOULD: setId is the eMeasure version neutral id  -->
+                  <setId root="7B2A9277-43DA-4D99-9BEE-6AC271A07747"/>
+                  <!-- This is the sequential eMeasure Version number -->
+                  <versionNumber value="1"/>
+                </externalDocument>
+              </reference>
+              <component>
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.14"/>
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.30"/>
+                  <code code="72510-1" codeSystem="2.16.840.1.113883.6.1" codeSystemName="2.16.840.1.113883.6.1" displayName="Performance Rate"/>
+                  <statusCode code="completed"/>
+                  <value value="0.0" xsi:type="REAL"/>
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="D285D0D1-0AB5-4228-A5A3-F3DE5952F4AF"/>
+                      <code code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ObservationValue" displayName="Numerator"/>
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <component>
+                <!--   MEASURE DATA REPORTING FOR    IPP  EA122D3D-5348-43DB-96A5-2D044ACAAA4D  -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- Measure Data template -->
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.5"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion"/>
+                  <statusCode code="completed"/>
+                  <value code="IPOP" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" xsi:type="CD"/>
+                  <!-- Aggregate Count -->
+                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                      <value value="1" xsi:type="INT"/>
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                    </observation>
+                  </entryRelationship>
+                  <!--    SEX Supplemental Data Reporting for IPP  EA122D3D-5348-43DB-96A5-2D044ACAAA4D      -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Sex Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.6"/>
+                      <id nullFlavor="NA"/>
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="F" codeSystem="2.16.840.1.113883.5.1" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--     ETHNICITY Supplemental Data Reporting  for IPP  EA122D3D-5348-43DB-96A5-2D044ACAAA4D     -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Ethnicity Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.7"/>
+                      <id nullFlavor="NA"/>
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="2186-5" codeSystem="2.16.840.1.113883.6.238" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--      RACE Supplemental Data Reporting  for IPP  EA122D3D-5348-43DB-96A5-2D044ACAAA4D -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Race Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.8"/>
+                      <id nullFlavor="NA"/>
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="1002-5" codeSystem="2.16.840.1.113883.6.238" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--         PAYER Supplemental Data Reporting   for IPP  EA122D3D-5348-43DB-96A5-2D044ACAAA4D   -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Payer Supplemental Data -->
+                      <templateId extension="2016-02-01" root="2.16.840.1.113883.10.20.27.3.9"/>
+                      <id nullFlavor="NA"/>
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="1" codeSystem="2.16.840.1.113883.3.221.5" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="EA122D3D-5348-43DB-96A5-2D044ACAAA4D"/>
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <component>
+                <!--   MEASURE DATA REPORTING FOR    DENOM  C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9  -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- Measure Data template -->
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.5"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion"/>
+                  <statusCode code="completed"/>
+                  <value code="DENOM" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" xsi:type="CD"/>
+                  <!-- Aggregate Count -->
+                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                      <value value="1" xsi:type="INT"/>
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                    </observation>
+                  </entryRelationship>
+                  <!--    SEX Supplemental Data Reporting for DENOM  C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9      -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Sex Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.6"/>
+                      <id nullFlavor="NA"/>
+                      <code code="76689-9" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="F" codeSystem="2.16.840.1.113883.5.1" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--     ETHNICITY Supplemental Data Reporting  for DENOM  C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9     -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Ethnicity Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.7"/>
+                      <id nullFlavor="NA"/>
+                      <code code="69490-1" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="2186-5" codeSystem="2.16.840.1.113883.6.238" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--      RACE Supplemental Data Reporting  for DENOM  C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9 -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Race Supplemental Data -->
+                      <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.8"/>
+                      <id nullFlavor="NA"/>
+                      <code code="72826-1" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="1002-5" codeSystem="2.16.840.1.113883.6.238" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <!--         PAYER Supplemental Data Reporting   for DENOM  C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9   -->
+                  <!--                            Supplemental Data Template                                                  -->
+                  <entryRelationship typeCode="COMP">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <!-- Payer Supplemental Data -->
+                      <templateId extension="2016-02-01" root="2.16.840.1.113883.10.20.27.3.9"/>
+                      <id nullFlavor="NA"/>
+                      <code code="48768-6" codeSystem="2.16.840.1.113883.6.1"/>
+                      <statusCode code="completed"/>
+                      <value code="1" codeSystem="2.16.840.1.113883.3.221.5" xsi:type="CD"/>
+                      <entryRelationship inversionInd="true" typeCode="SUBJ">
+                        <!-- Aggregate Count template -->
+                        <observation classCode="OBS" moodCode="EVN">
+                          <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                          <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                          <value value="1" xsi:type="INT"/>
+                          <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                        </observation>
+                      </entryRelationship>
+                    </observation>
+                  </entryRelationship>
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="C7A5DF86-5533-48EA-A9C6-04A3F5DB6BE9"/>
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <component>
+                <!--   MEASURE DATA REPORTING FOR    NUMER  D285D0D1-0AB5-4228-A5A3-F3DE5952F4AF  -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- Measure Data template -->
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.5"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion"/>
+                  <statusCode code="completed"/>
+                  <value code="NUMER" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" xsi:type="CD"/>
+                  <!-- Aggregate Count -->
+                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                      <value value="0" xsi:type="INT"/>
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                    </observation>
+                  </entryRelationship>
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="D285D0D1-0AB5-4228-A5A3-F3DE5952F4AF"/>
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+              <component>
+                <!--   MEASURE DATA REPORTING FOR    DENEX  0C45DCFF-89D6-4ECF-90C3-2D9B0EE91279  -->
+                <observation classCode="OBS" moodCode="EVN">
+                  <!-- Measure Data template -->
+                  <templateId extension="2016-09-01" root="2.16.840.1.113883.10.20.27.3.5"/>
+                  <code code="ASSERTION" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="Assertion"/>
+                  <statusCode code="completed"/>
+                  <value code="DENEX" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" xsi:type="CD"/>
+                  <!-- Aggregate Count -->
+                  <entryRelationship inversionInd="true" typeCode="SUBJ">
+                    <observation classCode="OBS" moodCode="EVN">
+                      <templateId root="2.16.840.1.113883.10.20.27.3.3"/>
+                      <code code="MSRAGG" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode" displayName="rate aggregation"/>
+                      <value value="0" xsi:type="INT"/>
+                      <methodCode code="COUNT" codeSystem="2.16.840.1.113883.5.84" codeSystemName="ObservationMethod" displayName="Count"/>
+                    </observation>
+                  </entryRelationship>
+                  <reference typeCode="REFR">
+                    <externalObservation classCode="OBS" moodCode="EVN">
+                      <id root="0C45DCFF-89D6-4ECF-90C3-2D9B0EE91279"/>
+                    </externalObservation>
+                  </reference>
+                </observation>
+              </component>
+            </organizer>
+          </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!-- This is the templateId for Reporting Parameters Act -->
+              <templateId root="2.16.840.1.113883.10.20.17.3.8"/>
+              <id extension="F609ADD3CD46E8D34505077D8A053792"/>
+              <code code="252116004" codeSystem="2.16.840.1.113883.6.96" displayName="Observation Parameters"/>
+              <effectiveTime>
+                <low value="20170101000000"/>
+                <high value="20171231235959"/>
+              </effectiveTime>
+            </act>
+          </entry>
+        </section>
+      </component>
+    </structuredBody>
+  </component>
+</ClinicalDocument>

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -61,6 +61,18 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
     end
   end
 
+  def test_ep_task_returns_appropriate_error_for_incorrect_measure_id
+    setup_ep
+    task = @product.product_tests.cms_program_tests.where(cms_program: 'MIPS_VIRTUALGROUP').first.tasks.first
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'ep_test_qrda_cat3_good_invalid_id.xml'))
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      assert_equal :failed, te.state
+      assert_equal 1, te.execution_errors.where(message: 'Invalid HQMF ID Found: 40280382-5FA6-FE85-0160-0918E74D2076').size
+    end
+  end
+
   def test_ep_task_with_errors_for_cv_measure
     setup_ep
     task = @product.product_tests.cms_program_tests.where(cms_program: 'MIPS_VIRTUALGROUP').first.tasks.first


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [x] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-843
- [x] Internal ticket links to this PR
- [x] Code diff has been done and been reviewed
- [x] Tests are included and test edge cases
- [x] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code