### PR TITLE
workaround for carrierwave returning invalid/invalid contentType with…

### DIFF
--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -20,7 +20,11 @@ class Artifact
   def correct_file_type
     return unless file_changed?
 
-    content_extension = file.content_type ? MIME_FILE_TYPES[file.content_type] : nil
+    content_extension = if file.content_type == 'invalid/invalid'
+                          file.file.extension == 'xml' ? :xml : nil
+                        else
+                          file.content_type ? MIME_FILE_TYPES[file.content_type] : nil
+                        end
     case content_extension
     when :zip
       errors.add(:file, 'File upload extension should be .zip') unless %w[C1Task C1ChecklistTask C3ChecklistTask C3Cat1Task


### PR DESCRIPTION
… BOM

https://stackoverflow.com/questions/64859491/carrierwave-sets-mime-type-to-invalid-invalid
https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2233

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code