### PR TITLE
Ratio measure was missing in file_result partial

### DIFF
--- a/app/views/test_executions/file_result.html.erb
+++ b/app/views/test_executions/file_result.html.erb
@@ -10,13 +10,14 @@
 <br/>
 
 <% continuous_measures = @task.measures.where(measure_scoring: 'CONTINUOUS_VARIABLE').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
-   proportion_measures = @task.measures.where(measure_scoring: 'PROPORTION').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] } %>
+   proportion_measures = @task.measures.where(measure_scoring: 'PROPORTION').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
+   ratio_measures = @task.measures.where(measure_scoring: 'RATIO').only(:id, :population_sets, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] } %>
 
 <div class = 'panel panel-default' id = 'results_panel'>
   <div class = 'panel-heading'>
     <h1 class='panel-title'>Results</h1>
   </div>
   <div class = 'panel-body' id = 'display_execution_results' >
-    <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: @test_execution, file_name: @file_name, error_result: @error_result, is_passing: is_passing, on_execution_show_page: false, continuous_measures: continuous_measures, proportion_measures: proportion_measures, patient: @patient, export: false, display_calculations: true } %>
+    <%= render partial: 'test_executions/results/execution_results_for_file', locals: { execution: @test_execution, file_name: @file_name, error_result: @error_result, is_passing: is_passing, on_execution_show_page: false, continuous_measures: continuous_measures, proportion_measures: proportion_measures, ratio_measures: ratio_measures, patient: @patient, export: false, display_calculations: true } %>
   </div>
 </div>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code