### PR TITLE
update precalculation task, and date offset to align with 2022

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -38,7 +38,7 @@ version_config:
       CMSQRDA3SchematronValidator_warnings:
       CMSQRDA1HQRSchematronValidator_warnings:
   '~>2021.0.0':
-      start_date_offset: 2
+      start_date_offset: 3
       modified_population_labels:
         IPP: 'IPOP'
       schematron: "2021.0.0"

--- a/lib/tasks/bundle.rake
+++ b/lib/tasks/bundle.rake
@@ -7,7 +7,7 @@ namespace :bundle do
     Upload precalculate bundle file with extension .zip
   )
   task :precalculate_bundle, [:file] => :setup do |_, args|
-    bundle = Cypress::CqlBundleImporter.import(File.new(args.file), Tracker.new, true)
+    bundle = Cypress::CqlBundleImporter.import(File.new(args.file), Tracker.new, include_highlighting: true)
     measure_id_mapping = Tempfile.new('measure-id-mapping.csv')
     CSV.open(measure_id_mapping, 'w') do |csv|
       bundle.measures.each do |measure|


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code