### PR TITLE
when randomizing, keep payer code as a string

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -116,7 +116,7 @@ module Cypress
       if payer_element&.any? && payer_element.first.dataElementCodes &&
          payer_element.first.dataElementCodes.any?
         new_payer = payer_element.first.dataElementCodes.first
-        new_payer['code'] = payer_hash['code']
+        new_payer['code'] = payer_hash['code'].to_s
         new_payer['system'] = payer_hash['codeSystem']
         new_payer['codeSystem'] = payer_hash['codeSystemName']
         new_payer['descriptor'] = payer_hash['name']


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code