### PR TITLE
support a user preferred ccn

### DIFF
--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -98,6 +98,7 @@ class VendorsController < ApplicationController
   def update_preferences
     # save preferences to vendor preferred_code_systems
     @vendor.preferred_code_systems = JSON.parse(params['vendor_preferences'])
+    @vendor.preferred_ccn = params['preferred_ccn'] unless params['preferred_ccn'] == ''
     @vendor.save
     redirect_to vendor_path(@vendor)
   end

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -27,7 +27,10 @@ class MeasureTest < ProductTest
   end
 
   def generate_provider
-    self.provider = Provider.generate_provider(measure_type: measures.first.reporting_program_type) if provider.nil?
+    return unless provider.nil?
+
+    self.provider = Provider.generate_provider(measure_type: measures.first.reporting_program_type,
+                                               preferred_ccn: product.vendor.preferred_ccn)
   end
 
   # passing only if both c1 and c3_cat1 tasks pass

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -21,6 +21,7 @@ class Vendor
   field :state, type: String
   field :zip, type: String
   field :preferred_code_systems, type: Hash, default: {}
+  field :preferred_ccn, type: String
   field :favorite_user_ids, type: Array, default: []
   field :vendor_patient_analysis, type: Hash, default: {}
 

--- a/app/views/vendors/preferences.html.erb
+++ b/app/views/vendors/preferences.html.erb
@@ -24,6 +24,10 @@
   <% end %>
 
   <%= bootstrap_form_tag url: vendor_update_preferences_path(@vendor), html: {class: "vendor_preferences_form"} do |f| %>
+    <div class="panel-body">
+      <%= f.text_field :preferred_ccn, help: 'Health IT may be tailored for certain facility types (e.g., Critical Access Hospitals 
+).  In these scenarios it is appropriate to use a preferred CMS Certification Number appropriate for the facility.', label: 'Preferred CMS Certification Number', autocomplete: 'off', value: @vendor.preferred_ccn %>
+    </div>
     <div class="panel-footer">
       <%= f.submit "Save", :class => "btn btn-success", :id => "preferences_submit_button" %>
       <%= submit_tag "Cancel", :class => "btn btn-default", :type => "button", :onclick => "history.back()" %>

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -192,7 +192,8 @@ module Cypress
     end
 
     def generate_provider
-      @generated_providers << Provider.generate_provider(measure_type: @test.measures.first.reporting_program_type)
+      @generated_providers << Provider.generate_provider(measure_type: @test.measures.first.reporting_program_type,
+                                                         preferred_ccn: @test.product.vendor.preferred_ccn)
     end
 
     def assign_existing_provider(patient, provider)

--- a/lib/ext/provider.rb
+++ b/lib/ext/provider.rb
@@ -26,8 +26,7 @@ module CQM
       prov.familyName = NAMES_RANDOM['last'].sample
       prov.npi = NpiGenerator.generate
       prov.tin = rand.to_s[2..10]
-      # rjust pads with 0s to the left of the number, so the CCN is always 6 digits
-      prov.ccn = rand(1..66).to_s.rjust(2, '0') + rand(1..9899).to_s.rjust(4, '0')
+      prov.ccn = options[:preferred_ccn] || prov.ccn = rand(1..66).to_s.rjust(2, '0') + rand(1..9899).to_s.rjust(4, '0')
       prov.specialty = default_specialty(options[:measure_type])
       prov.save!
       prov

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -73,6 +73,30 @@ class ProductTestTest < ActiveJob::TestCase
     test2.create_tasks
   end
 
+  def test_preferred_ccn
+    # setup product
+    measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+    @product.update(c1_test: true, c2_test: true, c3_test: true, c4_test: true, randomize_patients: true,
+                    duplicate_patients: true, allow_duplicate_names: true, measure_ids: measure_ids)
+    vendor2 = FactoryBot.create(:vendor)
+    vendor2.preferred_ccn = '123456'
+    product2 = vendor2.products.create(name: 'test_product', c2_test: true, randomize_patients: true,
+                                       bundle_id: @bundle.id, measure_ids: measure_ids)
+
+    test1 = {}
+    test2 = {}
+    perform_enqueued_jobs do
+      # create tests with same seed
+      seed = Random.new_seed
+      test1 = @product.product_tests.create({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
+                                              bundle_id: @bundle.id, rand_seed: seed }, MeasureTest)
+      test2 = product2.product_tests.create({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
+                                              bundle_id: @bundle.id, rand_seed: seed }, MeasureTest)
+    end
+    assert_equal '123456', test2.provider.ccn
+    assert_not_equal test1.provider.ccn, test2.provider.ccn
+  end
+
   # # # # # # # # # # # # # # # # # # # #
   #   H E L P E R   F U N C T I O N S   #
   # # # # # # # # # # # # # # # # # # # #


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code