### PR TITLE
If there aren't any calculated episode_results, use an empty array fo…

### DIFF
--- a/lib/ext/individual_result.rb
+++ b/lib/ext/individual_result.rb
@@ -54,7 +54,8 @@ module CQM
     end
 
     def compare_observations(calculated, issues = [])
-      calculated_er = calculated['episode_results'].values.map(&:observation_values).sort
+      # If there aren't any calculated episode_results, use an empty array for comparison
+      calculated_er = calculated['episode_results'] ? calculated['episode_results'].values.map(&:observation_values).sort : []
       expected_er = episode_results.values.map(&:observation_values).sort
 
       return unless calculated_er != expected_er


### PR DESCRIPTION
…r comparison

![Screen Shot 2021-05-25 at 1 54 10 PM](https://user-images.githubusercontent.com/8173551/119545457-d56afa00-bd60-11eb-9dda-bb7ed76ed7f4.png)

This error happens when a patient who should have calculations does not have them.  For example, they might not have enough information in the QRDA file to get the patient into the correct populations.

This can be reproduced with a C1 test (with duplication enabled) and upload one of the files that is split.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code