### PR TITLE
add setting to expose api documentation

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -34,7 +34,8 @@ module Admin
 
     def update_settings
       params.permit(:banner, :umls, :http_proxy, :website_domain, :website_port, :banner_message, :warning_message,
-                    :mailer_address, :mailer_port, :mailer_domain, :mailer_user_name, :mailer_password)
+                    :mailer_address, :mailer_port, :mailer_domain, :mailer_user_name, :mailer_password, :api_documentation,
+                    :api_documentation_path)
     end
   end
 end

--- a/app/models/settings.rb
+++ b/app/models/settings.rb
@@ -15,6 +15,8 @@ class Settings
   field :banner, type: Boolean, default: false
   # set to true to enable UMLS confirmation prior to login
   field :umls, type: Boolean, default: false
+  field :api_documentation, type: Boolean, default: false
+  field :api_documentation_path, type: String, default: ''
   field :banner_message, type: String, default: APP_CONSTANTS['default_banner_message']
   field :warning_message, type: String, default: APP_CONSTANTS['default_warning_message']
   # ignore roles completely -- this is essentially the same as everyone in the system being an admin, default true
@@ -69,7 +71,7 @@ class Settings
       banner_message: current.banner_message, warning_message: current.warning_message, mode: current.application_mode,
       banner: current.banner, umls: current.umls, default_url_options: current.fetch_url_settings,
       smtp_settings: current.fetch_smtp_settings, mode_settings: application_mode_settings, roles: %w[User ATL Admin None],
-      http_proxy: current.http_proxy
+      http_proxy: current.http_proxy, api_documentation: current.api_documentation, api_documentation_path: current.api_documentation_path
     }
   end
 
@@ -80,7 +82,7 @@ class Settings
       default_url_options: Rails.application.config.action_mailer.default_url_options,
       smtp_settings: Rails.application.config.action_mailer.smtp_settings, mode_settings: application_mode_settings,
       debug_features: current.enable_debug_features, server_needs_restart: current.server_needs_restart,
-      http_proxy: current.http_proxy
+      http_proxy: current.http_proxy, api_documentation: current.api_documentation, api_documentation_path: current.api_documentation_path
     }
   end
 

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -13,7 +13,8 @@
       <%= f.check_box :banner, label: "Display banner/warning?", checked: banner %>
       <%= f.check_box :umls, label: "Verify UMLS credentials", checked: umls %>
       <%= f.text_field :http_proxy, label: "HTTP Proxy", value: http_proxy %>
-
+      <%= f.check_box :api_documentation, label: "Display API Documentation?", checked: api_documentation %>
+      <%= f.text_field :api_documentation_path, label: "API Documentation Path", value: api_documentation_path %>
       <fieldset>
         <legend>Email Settings</legend>
         <%= render 'alert', :alert_type => 'warning', :messages => 'The Cypress service must be restarted after configuring email settings.' %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -34,6 +34,14 @@
             Master Patient List
             <% end %>
           </li>
+          <% if Settings.current.api_documentation %>
+          <li>
+          <%= link_to Settings.current.api_documentation_path, class: 'navbar-item', target: '_blank'   do %>
+              <%= icon('fas', 'code', :"aria-hidden" => true) %>
+              API
+              <% end %>
+          </li>
+          <% end %>
           <li <% if curr_page == :account %>class="active"<% end %>>
             <%= link_to edit_user_registration_path, class: 'navbar-item'   do %>
             <%= icon('fas fa-fw', 'user', :"aria-hidden" => true) %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code