### PR TITLE
Birthdate times at the epoch time boundary throws off the cql-calcula…

### DIFF
--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -24,6 +24,8 @@ module CQM
     # every patient actually in the database is of a valid type.
     validates :_type, inclusion: %w[CQM::BundlePatient CQM::VendorPatient CQM::ProductTestPatient CQM::TestExecutionPatient]
 
+    before_save :account_for_epoch_time_zero
+
     after_initialize do
       self[:addresses] ||= [CQM::Address.new(
         use: 'HP',
@@ -261,6 +263,16 @@ module CQM
       Cypress::QRDAPostProcessor.remove_telehealth_encounters(self, codes_modifiers, warnings, ineligible_measures) unless codes_modifiers.empty?
       save
       warnings
+    end
+
+    # Birthdate times at the epoch time boundary throws off the cql-calculation engine, workaround to add 1 second to the birthtime.
+    def account_for_epoch_time_zero
+      return unless qdmPatient.birthDatetime.to_i.zero?
+
+      qdmPatient.birthDatetime = qdmPatient.birthDatetime.change(sec: 1)
+      return unless qdmPatient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first
+
+      qdmPatient.dataElements.where(_type: QDM::PatientCharacteristicBirthdate).first.birthDatetime = qdmPatient.birthDatetime
     end
   end
 

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -267,6 +267,7 @@ module CQM
 
     # Birthdate times at the epoch time boundary throws off the cql-calculation engine, workaround to add 1 second to the birthtime.
     def account_for_epoch_time_zero
+      return unless qdmPatient.birthDatetime
       return unless qdmPatient.birthDatetime.to_i.zero?
 
       qdmPatient.birthDatetime = qdmPatient.birthDatetime.change(sec: 1)

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -226,15 +226,19 @@ class PatientTest < ActiveSupport::TestCase
     record = BundlePatient.new(familyName: 'epoch', givenNames: ['boundary'], bundleId: @bundle.id)
     epoch_birth_datetime = DateTime.new(1970, 1, 1, 0, 0, 0).utc
     shifted_birth_datetime = DateTime.new(1970, 1, 1, 0, 0, 1).utc
-    QDM::Patient.create!(cqmPatient: record, birthDatetime: epoch_birth_datetime)
+    patient_characteristic_birthdate = QDM::PatientCharacteristicBirthdate.new(birthDatetime: epoch_birth_datetime)
+    QDM::Patient.create!(cqmPatient: record, birthDatetime: epoch_birth_datetime, dataElements: [patient_characteristic_birthdate])
     assert_equal shifted_birth_datetime, record.qdmPatient.birthDatetime
+    assert_equal shifted_birth_datetime, record.qdmPatient.dataElements.first.birthDatetime
   end
 
   def test_preserve_birth_datetime
     # Birthdates not on 1 January 1970 00:00 UTC will be preserved
     record = BundlePatient.new(familyName: 'non epoch', givenNames: ['boundary'], bundleId: @bundle.id)
     original_birth_datetime = DateTime.new(1970, 2, 1, 0, 0, 0).utc
-    QDM::Patient.create!(cqmPatient: record, birthDatetime: original_birth_datetime)
+    patient_characteristic_birthdate = QDM::PatientCharacteristicBirthdate.new(birthDatetime: original_birth_datetime)
+    QDM::Patient.create!(cqmPatient: record, birthDatetime: original_birth_datetime, dataElements: [patient_characteristic_birthdate])
     assert_equal original_birth_datetime, record.qdmPatient.birthDatetime
+    assert_equal original_birth_datetime, record.qdmPatient.dataElements.first.birthDatetime
   end
 end

--- a/test/models/patient_test.rb
+++ b/test/models/patient_test.rb
@@ -220,4 +220,21 @@ class PatientTest < ActiveSupport::TestCase
     assert_nil denormalized_element.relevantPeriod.low
     assert_equal time_value_end, denormalized_element.relevantPeriod.high
   end
+
+  def test_account_for_epoch_time_boundary
+    # Birthdates on 1 January 1970 00:00 UTC will be shifted to 1 January 1970 00:01 UTC to avoid calculation issues
+    record = BundlePatient.new(familyName: 'epoch', givenNames: ['boundary'], bundleId: @bundle.id)
+    epoch_birth_datetime = DateTime.new(1970, 1, 1, 0, 0, 0).utc
+    shifted_birth_datetime = DateTime.new(1970, 1, 1, 0, 0, 1).utc
+    QDM::Patient.create!(cqmPatient: record, birthDatetime: epoch_birth_datetime)
+    assert_equal shifted_birth_datetime, record.qdmPatient.birthDatetime
+  end
+
+  def test_preserve_birth_datetime
+    # Birthdates not on 1 January 1970 00:00 UTC will be preserved
+    record = BundlePatient.new(familyName: 'non epoch', givenNames: ['boundary'], bundleId: @bundle.id)
+    original_birth_datetime = DateTime.new(1970, 2, 1, 0, 0, 0).utc
+    QDM::Patient.create!(cqmPatient: record, birthDatetime: original_birth_datetime)
+    assert_equal original_birth_datetime, record.qdmPatient.birthDatetime
+  end
 end


### PR DESCRIPTION
…tion engine, workaround to add 1 second to the birthtime.

https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2262

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code