### PR TITLE
add flag for option cms identifiers. these will be warnings

### DIFF
--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -135,9 +135,11 @@ class CMSProgramTask < Task
     program_criteria.each do |criterion_key, criterion_hash|
       description = criterion_hash['description'][product_test.cms_program] || criterion_hash['description'][product_test.reporting_program_type]
       conf = criterion_hash['conf'][product_test.cms_program] || criterion_hash['conf'][product_test.reporting_program_type]
+      is_optional = criterion_hash['optional'] ? true : false
       product_test.program_criteria << ProgramCriterion.new(criterion_key: criterion_key,
                                                             criterion_name: criterion_hash['name'],
                                                             criterion_description: description,
+                                                            criterion_optional: is_optional,
                                                             cms_conf: conf)
     end
   end

--- a/app/models/cms_program_test.rb
+++ b/app/models/cms_program_test.rb
@@ -33,8 +33,13 @@ class CMSProgramTest < ProductTest
     program_criteria.each do |crit|
       next if crit.criterion_verified
 
-      msg = "#{crit.criterion_name} not complete"
-      execution.execution_errors.build(message: msg, msg_type: :error, validator: 'Validators::ProgramCriteriaValidator')
+      msg_type = crit.criterion_optional ? :warning : :error
+      msg = if msg_type == :warning
+              "Warning - #{crit.criterion_name} not complete"
+            else
+              "#{crit.criterion_name} not complete"
+            end
+      execution.execution_errors.build(message: msg, msg_type: msg_type, validator: 'Validators::ProgramCriteriaValidator')
     end
   end
 end

--- a/app/models/program_criterion.rb
+++ b/app/models/program_criterion.rb
@@ -10,6 +10,7 @@ class ProgramCriterion
   field :cms_conf, type: String
   field :entered_value, type: String
   field :criterion_verified, type: Boolean, default: false
+  field :criterion_optional, type: Boolean, default: false
   field :file_name, type: String
 
   embedded_in :cms_program_test

--- a/config/cms_ig.yml
+++ b/config/cms_ig.yml
@@ -44,6 +44,7 @@ Program Criterion:
       - HQR_IQR_VOL
   HIC:
     name: 'Medicare HIC Number'
+    optional: true
     description:
       eh: 'Medicare HIC Number is not required for HQR but should be submitted if the payer is Medicare and the patient has an HIC number assigned.'
     conf:
@@ -66,6 +67,7 @@ Program Criterion:
       - HQR_IQR_VOL
   MBI:
     name: 'Medicare Beneficiary Identifier'
+    optional: true
     description:
       eh: 'Medicare Beneficiary Identifier (MBI) is not required for HQR but should be submitted if the payer is Medicare and the patient has an MBI number assigned.'
     conf:

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -116,7 +116,8 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
       te.reload
       assert_equal 12, te.execution_errors.size
       assert_equal 1, te.execution_errors.where(validator: 'Validators::MeasurePeriodValidator').size
-      assert_equal 6, te.execution_errors.where(validator: 'Validators::ProgramCriteriaValidator').size
+      assert_equal 4, te.execution_errors.where(validator: 'Validators::ProgramCriteriaValidator', msg_type: :error).size
+      assert_equal 2, te.execution_errors.where(validator: 'Validators::ProgramCriteriaValidator', msg_type: :warning).size
       assert_equal 5, te.execution_errors.where(validator: 'Validators::CMSQRDA1HQRSchematronValidator').size
     end
   end


### PR DESCRIPTION
This is what the checklist will look like (Passing, but no checkmarks for the optional criteria)

![screencapture-localhost-3000-products-60c8a9bcc1c38805ab685668-program-tests-60c8a9bcc1c38805ab68566b-2021-06-15-09_54_46](https://user-images.githubusercontent.com/8173551/122065391-e76c1580-cdbf-11eb-82d6-ae3ea02c4dd4.png)

This is what the result page looks like

![screencapture-localhost-3000-tasks-60c8a9bdc1c38805ab68567b-test-executions-60c8ae28c1c3883126e68ec8-2021-06-15-09_54_57](https://user-images.githubusercontent.com/8173551/122065500-feab0300-cdbf-11eb-9cb6-02ba6d674d9c.png)


**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code