### PR TITLE
encounter ID is now a SHOULD not a MUST requirement in CMS IG

### DIFF
--- a/lib/validators/core_clinical_data_element_validator.rb
+++ b/lib/validators/core_clinical_data_element_validator.rb
@@ -71,7 +71,7 @@ module Validators
           add_error(msg, file_name: options[:file_name], location: ccde.path) unless encounter_ids.include?(related_to_id_string)
         else
           msg = "Encounter Reference missing for Core Clinical Data Element entry #{ccde_id_string}"
-          add_error(msg, file_name: options[:file_name], location: ccde.path)
+          add_warning(msg, file_name: options[:file_name], location: ccde.path)
         end
       end
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code