### PR TITLE
Changed version and ami group for recipe

### DIFF
--- a/contrib/cypress.json
+++ b/contrib/cypress.json
@@ -4,7 +4,7 @@
     "aws_secret_key": "",
     "default_user": "ubuntu",
     "default_pwd": "CypressPwd",
-    "cypress_version": "cypress_5.1.0",
+    "cypress_version": "cypress_6.2.0",
     "cvu_version": "cypress-validation-utility_3.2.2-production-1510258734",
     "chef_version": "13.8.5",
     "vpc_id": "",
@@ -24,6 +24,7 @@
       "ami_virtualization_type": "hvm",
       "ssh_username": "ubuntu",
       "ami_name": "cypress_{{ user `cypress_version` }}",
+      "ami_groups": "all",
       "ami_block_device_mappings": [ {
         "device_name": "/dev/sda1",
         "volume_size": 40,


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code