### PR TITLE
Show metadata for failing test execution

### DIFF
--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -45,10 +45,22 @@ end %>
       <% end %>
     <% end %>
   <% else %>
-    <p class="lead row bg-danger execution-status">
-      <%= icon('fas fa-fw text-danger', 'times-circle', :"aria-hidden" => true) %>
-      <%= execution_failure_message(execution) %>
-    </p>
+    <div class="row">
+      <div class="col-sm-7">
+        <p class="lead row bg-danger execution-status">
+          <%= icon('fas fa-fw text-danger', 'times-circle', :"aria-hidden" => true) %>
+          <%= execution_failure_message(execution) %>
+        </p>
+      </div>
+      <div class="col-sm-5">
+        <div class="execution-information bg-info">
+          <ul class="list-unstyled">
+            <li><strong>Test Date:</strong> <%= local_time(execution.updated_at) %></li>
+            <li><strong>Files Uploaded:</strong> <%= execution.artifact['file'] %></li>
+          </ul>
+        </div>
+      </div>
+    </div>
   <% end %>
 
   <% collected_errors = Cypress::ErrorCollector.collected_errors(execution) %>

--- a/features/step_definitions/measure_test.rb
+++ b/features/step_definitions/measure_test.rb
@@ -206,6 +206,7 @@ end
 Then(/^the user should see failed results$/) do
   page.refresh
   assert_text 'Failed'
+  assert_text 'Test Date'
 end
 
 Then(/^the user should see a link to view the the uploaded xml$/) do


### PR DESCRIPTION

<img width="975" alt="Screen Shot 2021-07-12 at 2 50 47 PM" src="https://user-images.githubusercontent.com/8173551/125340701-cb0cbb80-e320-11eb-804d-14ba802167bd.png">


Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code