### PR TITLE
parameter name is now zip not z

### DIFF
--- a/lib/cypress/create_total_test_zip.rb
+++ b/lib/cypress/create_total_test_zip.rb
@@ -41,7 +41,7 @@ module Cypress
         CreateDownloadZip.add_file_to_zip(zip, "filteringtest_#{pt.cms_id}_#{pt.id}.html.zip".tr(' ', '_'),
                                           pt.html_archive.read)
       end
-      CreateDownloadZip.add_file_to_zip(z, 'filtering_criteria.html', filtering_list)
+      CreateDownloadZip.add_file_to_zip(zip, 'filtering_criteria.html', filtering_list)
     end
 
     def self.add_html_files(zip, tests)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code