### PR TITLE
Test that a filter test can be added when creating a total test zip

### DIFF
--- a/test/unit/lib/create_download_zip_test.rb
+++ b/test/unit/lib/create_download_zip_test.rb
@@ -15,6 +15,13 @@ class CreateDownloadZipTest < ActiveSupport::TestCase
       pt.create_tasks
       pt.archive_patients if pt.patient_archive.path.nil?
       pt.save!
+
+      ft = product.product_tests.build({ name: 'ftest', measure_ids: product.measure_ids }, FilteringTest)
+      ft.save
+      ft.generate_patients
+      ft.create_tasks
+      ft.archive_patients if ft.patient_archive.path.nil?
+      ft.save!
       file = Cypress::CreateTotalTestZip.create_total_test_zip(product, nil, nil, 'qrda')
 
       Zip::File.open(file) do |zip_file|


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code