### PR TITLE
update carrierwave to 2.2 to remove mimemagic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'responders'
 # Roar is a framework for parsing and rendering REST documents
 gem 'roar-rails'
 
-gem 'carrierwave', '~> 2.1.0'
+gem 'carrierwave', '~> 2.2.0'
 gem 'carrierwave-mongoid', require: 'carrierwave/mongoid'
 
 # AJAX file uploads

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,7 @@ gem 'responders'
 # Roar is a framework for parsing and rendering REST documents
 gem 'roar-rails'
 
-gem 'carrierwave', '~> 2.2.0'
+gem 'carrierwave', '~> 2.2.2'
 gem 'carrierwave-mongoid', require: 'carrierwave/mongoid'
 
 # AJAX file uploads

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -579,7 +579,7 @@ DEPENDENCIES
   cancancan
   capybara
   capybara-accessible
-  carrierwave (~> 2.2.0)
+  carrierwave (~> 2.2.2)
   carrierwave-mongoid
   codecov
   cqm-models (~> 3.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,12 +115,12 @@ GEM
       xpath (~> 3.2)
     capybara-accessible (0.3.0)
       capybara (>= 3.12.0)
-    carrierwave (2.1.1)
+    carrierwave (2.2.2)
       activemodel (>= 5.0.0)
       activesupport (>= 5.0.0)
       addressable (~> 2.6)
       image_processing (~> 1.1)
-      mimemagic (>= 0.3.0)
+      marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     carrierwave-mongoid (1.3.0)
@@ -257,7 +257,7 @@ GEM
       railties (>= 5.0.0)
     faker (1.5.0)
       i18n (~> 0.5)
-    ffi (1.15.1)
+    ffi (1.15.3)
     font-awesome-sass (5.0.13)
       sassc (>= 1.11)
     globalid (0.4.2)
@@ -316,9 +316,6 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2021.0225)
-    mimemagic (0.4.3)
-      nokogiri (~> 1)
-      rake
     mini_magick (4.11.0)
     mini_mime (1.1.0)
     mini_portile2 (2.5.3)
@@ -427,7 +424,7 @@ GEM
       thor (>= 0.20.3, < 2.0)
     rainbow (3.0.0)
     raindrops (0.19.2)
-    rake (13.0.3)
+    rake (13.0.6)
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -582,7 +579,7 @@ DEPENDENCIES
   cancancan
   capybara
   capybara-accessible
-  carrierwave (~> 2.1.0)
+  carrierwave (~> 2.2.0)
   carrierwave-mongoid
   codecov
   cqm-models (~> 3.1.1)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code