### PR TITLE
extension_whitelist is deprecated, use extension_allowlist instead

### DIFF
--- a/app/uploaders/document_uploader.rb
+++ b/app/uploaders/document_uploader.rb
@@ -7,7 +7,7 @@ class DocumentUploader < CarrierWave::Uploader::Base
     "#{APP_CONSTANTS['file_upload_root']}/test_executions/#{model.id}"
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[xml zip]
   end
 

--- a/app/uploaders/supplement_uploader.rb
+++ b/app/uploaders/supplement_uploader.rb
@@ -7,7 +7,7 @@ class SupplementUploader < CarrierWave::Uploader::Base
     "#{APP_CONSTANTS['file_upload_root']}/products/#{model.id}"
   end
 
-  def extension_whitelist
+  def extension_allowlist
     %w[doc docx xls xlsx ppt pptx jpg jpeg pdf png zip]
   end
 end

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -63,7 +63,7 @@
               <legend class="control-label">Supplemental Test Artifact</legend>
               <br />
               <% supplement_file_errors = product.errors[:supplemental_test_artifact].empty? %>
-              <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product. Allowed filetypes are #{product.supplemental_test_artifact.extension_whitelist.join(', ')}." do %>
+              <%= f.form_group class: supplement_file_errors ? '' : 'has-error', help: "Upload an additional file which will be available for download to anyone viewing this product. Allowed filetypes are #{product.supplemental_test_artifact.extension_allowlist.join(', ')}." do %>
                 <div class="fileinput fileinput-new input-group" data-provides="fileinput">
                   <div class="form-control" data-trigger="fileinput">
                     <%= icon('fas fileinput-exists', 'file', :"aria-hidden" => true) %>


### PR DESCRIPTION

![Screen Shot 2021-07-14 at 2 05 11 PM](https://user-images.githubusercontent.com/8173551/125671259-8f5f2f90-ff45-421f-afc1-732ac3139904.png)

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code