### PR TITLE
API Measure Evaluator also needs new option passed in

### DIFF
--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -479,7 +479,7 @@ module Cypress
                                   false
                                 end
       options = { provider: pt.patients.first.providers.first, submission_program: cat3_submission_program,
-                  start_time: pt.start_date, end_time: pt.end_date }
+                  start_time: pt.start_date, end_time: pt.end_date, ry2022_submission: pt.bundle.major_version == '2021' }
       xml = Qrda3R21.new(results, pt.measures, options).render
 
       Patient.find(patient_ids).each(&:destroy)

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -192,7 +192,7 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
                                 false
                               end
     options = { provider: product_test.patients.first.providers.first, submission_program: cat3_submission_program,
-                start_time: product_test.start_date, end_time: product_test.end_date }
+                start_time: product_test.start_date, end_time: product_test.end_date, ry2022_submission: product_test.bundle.major_version == '2021' }
     Qrda3R21.new(results, product_test.measures, options).render
   end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code