### PR TITLE
[WIP] Limit valueset comparisons to codes found in patient records

### DIFF
--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -179,6 +179,6 @@
       <% sf_title = sf_measures.first.cms_id %>
     <% end %>
     <h4>Patient Data for <%= sf_title %></h4>
-    <%= QdmPatient.new(Cypress::ScoopAndFilter.new(sf_measures).scoop_and_filter(sf_patient), false).render.html_safe %>
+    <%= QdmPatient.new(Cypress::ScoopAndFilter.new(sf_measures, sf_patient.code_description_hash).scoop_and_filter(sf_patient), false).render.html_safe %>
   </div>
 </div>

--- a/features/step_definitions/record.rb
+++ b/features/step_definitions/record.rb
@@ -136,7 +136,7 @@ Then(/^the user sees details$/) do
   page.assert_text @patient.gender
   @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
   sf_patient = @patient.clone
-  Cypress::ScoopAndFilter.new(@measures).scoop_and_filter(sf_patient)
+  Cypress::ScoopAndFilter.new(@measures, sf_patient.code_description_hash).scoop_and_filter(sf_patient)
   sf_patient.qdmPatient.dataElements.each do |data_criteria|
     page.assert_text data_criteria['description']
   end
@@ -192,7 +192,7 @@ Then(/^the user should see vendor patient details$/) do
   assert page.first(:xpath, './/span[@id="ED Visit_24" and @class="clause-true"]'), 'clause should highlighted as true'
   @measures = @bundle.measures.where(:_id.in => @patient.calculation_results.map(&:measure_id))
   sf_patient = @patient.clone
-  Cypress::ScoopAndFilter.new(@measures).scoop_and_filter(sf_patient)
+  Cypress::ScoopAndFilter.new(@measures, sf_patient.code_description_hash).scoop_and_filter(sf_patient)
   sf_patient.qdmPatient.dataElements.each do |data_criteria|
     page.assert_text data_criteria['description']
   end

--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -56,7 +56,9 @@ module Cypress
     def self.zip(file, patients, format)
       patients = apply_sort_to patients
       measures, sd, ed = measure_start_end(patients)
-      patient_scoop_and_filter = Cypress::ScoopAndFilter.new(measures)
+      code_description_hash = {}
+      patients.each { |p| code_description_hash.merge!(p.code_description_hash) }
+      patient_scoop_and_filter = Cypress::ScoopAndFilter.new(measures, code_description_hash)
 
       # TODO: R2P: make sure patient exporter works (use correct one)
       formatter = if format.to_sym == :qrda

--- a/test/factories/patients.rb
+++ b/test/factories/patients.rb
@@ -59,6 +59,17 @@ FactoryBot.define do
         patient.measure_relevance_hash = {}
         patient.measure_relevance_hash[proportion_ir.measure_id.to_s] = { 'IPP' => false }
         patient.measure_relevance_hash[cv_ir.measure_id.to_s] = { 'IPP' => true, 'MSRPOPL' => true }
+        patient.code_description_hash = { '210:2_16_840_1_113883_6_96' => 'Value Set Name 5',
+                                          '60:2_16_840_1_113883_6_12' => 'Value Set Name 3',
+                                          '24:2_16_840_1_113883_6_96' => 'Value Set Name 2',
+                                          '504:2_16_840_1_113883_6_96' => 'Value Set Name 7',
+                                          '720:2_16_840_1_113883_6_96' => 'Value Set Name 8',
+                                          '5814:2_16_840_1_113883_6_96' => 'Value Set Name 17',
+                                          'F:2_16_840_1_113883_5_1' => 'description',
+                                          '21112-8:2_16_840_1_113883_6_1' => 'description',
+                                          '2186-5:2_16_840_1_113883_6_238' => 'description',
+                                          '1:2_16_840_1_113883_3_221_5' => 'description',
+                                          '1002-5:2_16_840_1_113883_6_238' => 'description' }
         patient.providers << provider
         patient.save!
       end
@@ -70,6 +81,17 @@ FactoryBot.define do
       qdmPatient { FactoryBot.build(:qdm_patient) }
 
       after(:create) do |patient|
+        patient.code_description_hash = { '210:2_16_840_1_113883_6_96' => 'Value Set Name 5',
+                                          '60:2_16_840_1_113883_6_12' => 'Value Set Name 3',
+                                          '24:2_16_840_1_113883_6_96' => 'Value Set Name 2',
+                                          '504:2_16_840_1_113883_6_96' => 'Value Set Name 7',
+                                          '720:2_16_840_1_113883_6_96' => 'Value Set Name 8',
+                                          '5814:2_16_840_1_113883_6_96' => 'Value Set Name 17',
+                                          'F:2_16_840_1_113883_5_1' => 'description',
+                                          '21112-8:2_16_840_1_113883_6_1' => 'description',
+                                          '2186-5:2_16_840_1_113883_6_238' => 'description',
+                                          '1:2_16_840_1_113883_3_221_5' => 'description',
+                                          '1002-5:2_16_840_1_113883_6_238' => 'description' }
         provider = create(:default_provider)
         patient.providers << provider
         patient.save!
@@ -83,12 +105,12 @@ FactoryBot.define do
 
       after(:create) do |patient|
         patient.measure_relevance_hash = {}
-        patient.code_description_hash = { '210:2_16_840_1_113883_6_96' => 'description',
-                                          '60:2_16_840_1_113883_6_12' => 'description',
-                                          '24:2_16_840_1_113883_6_96' => 'description',
-                                          '504:2_16_840_1_113883_6_96' => 'description',
-                                          '720:2_16_840_1_113883_6_96' => 'description',
-                                          '5814:2_16_840_1_113883_6_96' => 'description',
+        patient.code_description_hash = { '210:2_16_840_1_113883_6_96' => 'Value Set Name 5',
+                                          '60:2_16_840_1_113883_6_12' => 'Value Set Name 3',
+                                          '24:2_16_840_1_113883_6_96' => 'Value Set Name 2',
+                                          '504:2_16_840_1_113883_6_96' => 'Value Set Name 7',
+                                          '720:2_16_840_1_113883_6_96' => 'Value Set Name 8',
+                                          '5814:2_16_840_1_113883_6_96' => 'Value Set Name 17',
                                           'F:2_16_840_1_113883_5_1' => 'description',
                                           '21112-8:2_16_840_1_113883_6_1' => 'description',
                                           '2186-5:2_16_840_1_113883_6_238' => 'description',

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -58,8 +58,9 @@ class PatientZipperTest < ActiveSupport::TestCase
                                                                           dataElementCodes: [QDM::Code.new('6', '2.16.840.1.113883.6.96')])
     patient.qdmPatient.dataElements.push QDM::PhysicalExamPerformed.new(relevantDatetime: DateTime.new(2011, 3, 24, 20, 53, 20).utc,
                                                                         dataElementCodes: [QDM::Code.new('24', '2.16.840.1.113883.6.96')])
+    patient.code_description_hash["#{faked_inpatient_vs.concepts.first.code}:2_16_840_1_113883_6_96"] = 'faked_inpatient_vs'
+    patient.code_description_hash['6:2_16_840_1_113883_6_96'] = 'Value Set Name 1'
     patient.save
-
     Cypress::PatientZipper.zip(file, [patient], format)
     file.close
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code