### PR TITLE
Use scoop and filter for C1 Record Sample examples

### DIFF
--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -101,7 +101,11 @@ module Cypress
           next unless patient
 
           # TODO: R2P: format patients for export
-          add_file_to_zip(z, "sample patient for #{measure_id}.html", formatter.export(patient))
+          sf_patient = patient.clone
+          sf_patient.id = patient.id
+          sf_measures = Measure.where(cms_id: measure_id)
+          Cypress::ScoopAndFilter.new(sf_measures).scoop_and_filter(sf_patient)
+          add_file_to_zip(z, "sample patient for #{measure_id}.html", formatter.export(sf_patient))
         end
       end
       file


### PR DESCRIPTION
This is related to a Google Group question.

'Medication Order' is not a data category that is included in this ECQM, and thus would not appear in any generated QRDA1 for that patient and ECQM.

Our process flow for this Measure does not include Medication Order negation as a capability because it isn't required, or so we presumed.

I was wondering if this is un-intentional, and whether we would really be required to capture this detail for accreditation with CMS 139 Fall risk, or whether we can omit that data when we capture that patient.

before
![before](https://user-images.githubusercontent.com/8173551/132757459-f5869d5b-96ac-4f5d-9195-dd6aef86762b.png)

after
![after](https://user-images.githubusercontent.com/8173551/132757469-0420bfed-d18c-4f7f-82f7-cb8fa3aebedc.png)


**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code