### PR TITLE
Limit randomization of payer dates

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -135,7 +135,7 @@ module Cypress
       # If medicare, start coverage at 65th birthdate
       if is_medicare
         start_time = patient.qdmPatient.birthDatetime
-        start_time.change(year: patient.qdmPatient.birthDatetime.year + 65)
+        start_time.change(year: patient.qdmPatient.birthDatetime.year + 65, day: 1)
       elsif start_times.empty?
         patient.qdmPatient.birthDatetime
       else

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -81,12 +81,12 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     QDM::Patient.create!(cqmPatient: @record, birthDatetime: DateTime.new(1981, 6, 8, 4, 0, 0).utc)
     @record.bundleId = @bundle.id
     @prng = Random.new(Random.new_seed)
-    payer_date = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, @prng)
+    payer_date = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, false, @prng)
     # If a patient only has a birthdate, the payer start time should be the birthdate
     assert_equal payer_date, @record.qdmPatient.birthDatetime
     assessment_performed = QDM::AssessmentPerformed.new(id: 'assessment', authorDatetime: DateTime.new(2011, 3, 24, 20, 53, 20).utc)
     @record.qdmPatient.dataElements.push assessment_performed
-    payer_date_with_author_times = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, @prng)
+    payer_date_with_author_times = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, false, @prng)
     # If a patient has a birthdate and an element with an authordate, the payer start time should be between the birthdate and authorDatetime
     assert payer_date_with_author_times > @record.qdmPatient.birthDatetime
     assert payer_date_with_author_times < assessment_performed.authorDatetime

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -90,6 +90,11 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     # If a patient has a birthdate and an element with an authordate, the payer start time should be between the birthdate and authorDatetime
     assert payer_date_with_author_times > @record.qdmPatient.birthDatetime
     assert payer_date_with_author_times < assessment_performed.authorDatetime
+    # If a patient has medicare, the payer start time should be the month when the patient turns 65
+    payer_date_with_medicare = Cypress::DemographicsRandomizer.get_random_payer_start_date(@record, true, @prng)
+    assert_equal payer_date_with_medicare.year, @record.qdmPatient.birthDatetime.year + 65
+    assert_equal payer_date_with_medicare.month, @record.qdmPatient.birthDatetime.month
+    assert_equal payer_date_with_medicare.day, 1
   end
 
   def test_randomize_name


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code