### PR TITLE
store latest test execution id

### DIFF
--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -21,6 +21,8 @@ class TestExecutionsController < ApplicationController
 
   def create
     authorize! :execute_task, @task.product_test.product.vendor
+    @task.latest_test_execution_id = nil
+    @task.save
     @test_execution = @task.execute(results_params, current_user)
     @has_eh_tests = @task.product_test.product.eh_tests?
     @has_ep_tests = @task.product_test.product.ep_tests?

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -21,6 +21,8 @@ class TestExecutionsController < ApplicationController
 
   def create
     authorize! :execute_task, @task.product_test.product.vendor
+    # Setting latest_test_execution_id to nil here will allow for AJAX reload to run
+    # latest_test_execution_id will be reset when @task.execute is run later
     @task.latest_test_execution_id = nil
     @task.save
     @test_execution = @task.execute(results_params, current_user)

--- a/app/jobs/test_execution_job.rb
+++ b/app/jobs/test_execution_job.rb
@@ -10,6 +10,8 @@ class TestExecutionJob < ApplicationJob
   end
   def perform(test_execution, task, options = {})
     test_execution.state = :running
+    task.latest_test_execution_id = test_execution.id.to_s
+    task.save
     test_execution.validate_artifact(task.validators, test_execution.artifact, options.merge('test_execution' => test_execution, 'task' => task))
     test_execution.save
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -61,6 +61,7 @@ class Task
   # returns the most recent execution for this task
   # if there are none, returns nil
   def most_recent_execution
+    # if latest_test_execution_id is stored, use it.  Else, look it up.
     if latest_test_execution_id
       TestExecution.find(latest_test_execution_id)
     else

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -6,6 +6,7 @@ class Task
   include GlobalID::Identification
   field :options, type: Hash
   field :expected_results, type: Hash
+  field :latest_test_execution_id, type: String
 
   belongs_to :product_test, inverse_of: :tasks, touch: true
   has_many :test_executions, dependent: :destroy
@@ -60,6 +61,10 @@ class Task
   # returns the most recent execution for this task
   # if there are none, returns nil
   def most_recent_execution
-    test_executions.any? ? test_executions.order_by(created_at: 'desc').limit(1).first : nil
+    if latest_test_execution_id
+      TestExecution.find(latest_test_execution_id)
+    else
+      test_executions.any? ? test_executions.order_by(created_at: 'desc').limit(1).first : nil
+    end
   end
 end

--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -100,5 +100,15 @@ namespace :cypress do
       end
       print "#{CQM::ProductTestPatient.all.count} patients were updated in #{Time.new.in_time_zone - start} seconds\n"
     end
+
+    task most_recent_executions: :setup do
+      Task.all.each do |task|
+        next if task.latest_test_execution_id
+
+        latest_te_id = task.test_executions.any? ? task.test_executions.order_by(created_at: 'desc').limit(1).first : nil
+        task.latest_test_execution_id = latest_te_id.id.to_s
+        task.save
+      end
+    end
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code