### PR TITLE
Only use negated valuesets relevant to measure

### DIFF
--- a/app/jobs/single_measure_calculation_job.rb
+++ b/app/jobs/single_measure_calculation_job.rb
@@ -6,9 +6,11 @@ class SingleMeasureCalculationJob < ApplicationJob
 
   def perform(patient_ids, measure_id, correlation_id, options)
     measure = Measure.find(measure_id)
+    valueset_oids = measure.value_sets.distinct(:oid)
     patients = Patient.find(patient_ids)
     qdm_patients = patients.map do |patient|
       patient.normalize_date_times
+      patient.nullify_unnessissary_negations(valueset_oids)
       patient.qdmPatient
     end
     calc_job = Cypress::CqmExecutionCalc.new(qdm_patients,
@@ -17,6 +19,7 @@ class SingleMeasureCalculationJob < ApplicationJob
                                              options)
     results = calc_job.execute(save: true)
     patients.map(&:denormalize_date_times)
+    patients.map(&:reestablish_negations)
     results
   end
 end

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -43,11 +43,14 @@ module Cypress
     # Multi_vs_negation_elements is an array of cloned elements to add to patient record to capture all of the negated valuesets
     def scoop_and_filter_data_element_codes(data_element, multi_vs_negation_elements, patient)
       # keep if data_element code and codesystem is in one of the relevant_codes
-      data_element.dataElementCodes.keep_if { |de_code| @relevant_codes.include?(code: de_code.code, system: de_code.system) }
+      data_element.dataElementCodes.keep_if do |de_code|
+        (@relevant_codes.include?(code: de_code.code, system: de_code.system) || de_code.system == '1.2.3.4.5.6.7.8.9.10')
+      end
       # Do not try to replace with negated valueset if all codes are removed
       return if data_element.dataElementCodes.blank?
 
       add_description_to_data_element(data_element)
+      return if data_element.dataElementCodes.blank?
       return unless data_element.respond_to?('negationRationale') && data_element.negationRationale
 
       replace_negated_code_with_valueset(data_element, multi_vs_negation_elements)
@@ -67,16 +70,30 @@ module Cypress
 
     def add_description_to_data_element(data_element)
       de = data_element
-      vsets = @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.system } }
+      vsets = if de.codes.any? { |code| code.system == '1.2.3.4.5.6.7.8.9.10' }
+                @valuesets.select { |vs| vs.oid == de.codes.select { |code| code.system == '1.2.3.4.5.6.7.8.9.10' }.first.code }
+              else
+                @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.system } }
+              end
       # A data element may have codes from multiple valusets, pick the first valueset for the description
+      if vsets.blank?
+        de.dataElementCodes.clear
+        return
+      end
+
       vs = vsets.first
       de.description = vs.display_name
     end
 
     # For negated elements, replace codes (that aren't direct reference codes) with valuesets.
     # If a code is in multiple valuesets, create new entries to be added to record
+    # rubocop:disable Metrics/AbcSize
     def replace_negated_code_with_valueset(data_element, multi_vs_negation_elements)
       de = data_element
+      if de.codes.any? { |code| code.system == '1.2.3.4.5.6.7.8.9.10' }
+        de.dataElementCodes.keep_if { |code| code.system == '1.2.3.4.5.6.7.8.9.10' }
+        return
+      end
       neg_vs = @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.system } }
 
       negated_valueset = neg_vs.first
@@ -94,5 +111,6 @@ module Cypress
 
       data_element.dataElementCodes = [{ code: negated_valueset.oid, system: '1.2.3.4.5.6.7.8.9.10' }]
     end
+    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -265,6 +265,9 @@ module CQM
       warnings
     end
 
+    # This method removes negations that are not for the oids provided
+    # The negations are not acutally removed, the replacement codes are modified so they will not
+    # factor in calcuations
     def nullify_unnessissary_negations(valueset_oids)
       qdmPatient.dataElements.each do |de|
         negated_vs = de.dataElementCodes.select { |dec| dec.system == '1.2.3.4.5.6.7.8.9.10' }
@@ -279,6 +282,7 @@ module CQM
       end
     end
 
+    # Revert the dataElement that had be modified by the nullify_unnessissary_negations method
     def reestablish_negations
       qdmPatient.dataElements.each do |de|
         negated_vs = de.dataElementCodes.select { |dec| dec.system == '1.2.3.4.5.6.7.8.9.10' }

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -265,6 +265,33 @@ module CQM
       warnings
     end
 
+    def nullify_unnessissary_negations(valueset_oids)
+      qdmPatient.dataElements.each do |de|
+        negated_vs = de.dataElementCodes.select { |dec| dec.system == '1.2.3.4.5.6.7.8.9.10' }
+        next if negated_vs.blank?
+
+        de.dataElementCodes.each do |dec|
+          break if valueset_oids.include?(negated_vs.first.code)
+          next if dec.system == '1.2.3.4.5.6.7.8.9.10'
+
+          dec.system.concat('NA')
+        end
+      end
+    end
+
+    def reestablish_negations
+      qdmPatient.dataElements.each do |de|
+        negated_vs = de.dataElementCodes.select { |dec| dec.system == '1.2.3.4.5.6.7.8.9.10' }
+        next if negated_vs.blank?
+
+        de.dataElementCodes.each do |dec|
+          next if dec.system == '1.2.3.4.5.6.7.8.9.10'
+
+          dec.system.delete_suffix!('NA')
+        end
+      end
+    end
+
     # Birthdate times at the epoch time boundary throws off the cql-calculation engine, workaround to add 1 second to the birthtime.
     def account_for_epoch_time_zero
       return unless qdmPatient.birthDatetime

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -40,9 +40,10 @@ module Validators
       return false unless record
 
       product_test = options['task'].product_test
+      # remove negations that are not for the measures being reported
+      valueset_oids = product_test.measures.only('value_set_ids').map { |mes| mes.value_sets.distinct(:oid) }.flatten
+      record.nullify_unnessissary_negations(valueset_oids)
 
-      # This Logic will need to be updated with CQL calculations
-      # TODO fix effectiveDateEnd and effectiveDate in cqm-execution.  effectiveDate is the end of the measurement period
       calc_job = Cypress::CqmExecutionCalc.new([record.qdmPatient],
                                                product_test.measures,
                                                options.test_execution.id.to_s,


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code