### PR TITLE
report on 'errored' tests

### DIFF
--- a/app/views/products/report/_certification_report.html.erb
+++ b/app/views/products/report/_certification_report.html.erb
@@ -218,3 +218,14 @@
   <%= render partial: 'products/report/failing_measure_tests', locals: { title: 'C4 QRDA Category III Failing Measure Tests', tasks: c4_cat3_failing_tasks, c3: false, c4: true } %>
 </section>
 <% end %>
+
+<% errored_tasks = @product.product_tests.collect { |pt| pt.tasks }.flatten.collect { |task| task if task.errored? }.compact %>
+<% unless errored_tasks.empty? %>
+  <section>
+    <h1>Errored Tests</h1>
+    <% errored_tasks.each do |errored_task| %>
+      <% execution = errored_task.most_recent_execution %>
+      <p><%= "#{errored_task.product_test.cms_id} - #{execution.task._type[0, 2]} Execution:" %>  An internal error occurred (<code><%= execution.error_summary %></code>)</p>
+    <% end %>
+  </section>
+<% end %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code