### PR TITLE
update cqm gems to fix nokogiri vulnerablity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,9 @@ gem 'mustache'
 gem 'os'
 
 gem 'cqm-models', '~> 3.1.1'
-gem 'cqm-parsers', '~> 3.2.0.1'
-gem 'cqm-reports', '~> 3.1.8'
-gem 'cqm-validators', '~> 3.1.2'
+gem 'cqm-parsers', '~> 3.2.0.2'
+gem 'cqm-reports', '~> 3.1.9'
+gem 'cqm-validators', '~> 3.1.3'
 
 # Use faker to generate addresses
 gem 'faker', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,7 +145,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.9)
     cqm-models (3.1.1)
-    cqm-parsers (3.2.0.1)
+    cqm-parsers (3.2.0.2)
       activesupport (~> 6.0)
       builder (~> 3.1)
       cqm-models (~> 3.0)
@@ -156,13 +156,13 @@ GEM
       mongoid (~> 7.0.5)
       mongoid-tree (~> 2.1)
       mustache
-      nokogiri (>= 1.8.5, < 1.13.0)
+      nokogiri (>= 1.8.5, < 1.14.0)
       protected_attributes_continued (~> 1.4.0)
       rubyzip (~> 1.3)
       typhoeus
       uuid (~> 2.3.7)
       zip-zip (~> 0.3)
-    cqm-reports (3.1.8)
+    cqm-reports (3.1.9)
       cqm-models (~> 3.0)
       cqm-validators (~> 3.0)
       erubis (~> 2.7)
@@ -170,11 +170,11 @@ GEM
       memoist (~> 0.9)
       mongoid-tree (> 2.0)
       mustache
-      nokogiri (>= 1.8.5, < 1.13.0)
+      nokogiri (>= 1.8.5, < 1.14.0)
       uuid (~> 2.3)
       zip-zip (~> 0.3)
-    cqm-validators (3.1.2)
-      nokogiri (>= 1.8.5, < 1.13.0)
+    cqm-validators (3.1.3)
+      nokogiri (>= 1.8.5, < 1.14.0)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -247,7 +247,7 @@ GEM
     dumb_delegator (1.0.0)
     erubi (1.10.0)
     erubis (2.7.0)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     execjs (2.8.1)
     factory_bot (6.2.0)
@@ -318,7 +318,7 @@ GEM
     mime-types-data (3.2021.0225)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.8.0)
     minitest (5.15.0)
     minitest-rails (6.0.1)
       minitest (~> 5.10)
@@ -350,8 +350,8 @@ GEM
     netrc (0.11.0)
     newrelic_rpm (7.1.0)
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.3)
+      mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.1)
@@ -586,9 +586,9 @@ DEPENDENCIES
   carrierwave-mongoid
   codecov
   cqm-models (~> 3.1.1)
-  cqm-parsers (~> 3.2.0.1)
-  cqm-reports (~> 3.1.8)
-  cqm-validators (~> 3.1.2)
+  cqm-parsers (~> 3.2.0.2)
+  cqm-reports (~> 3.1.9)
+  cqm-validators (~> 3.1.3)
   cucumber-rails
   daemons
   database_cleaner-mongoid


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code