### PR TITLE
Vendor Patient Totals needs to shift to account for Last Updated column [1]

### DIFF
--- a/app/views/records/_records_list.html.erb
+++ b/app/views/records/_records_list.html.erb
@@ -50,7 +50,9 @@
       <!-- will show aggregate record populations -->
       <tr>
         <%# add an extra cell for delete column -> could be delete all option? %>
+        <%# add an extra cell for Last Updated %>
         <% if @vendor %>
+          <td></td>
           <td></td>
         <% end %>
         <th scope="row">Total</th>


### PR DESCRIPTION
Earlier we included a new column for last updated (in vendor patients), we never included a column placeholder in the totals.

![Screen Shot 2022-03-02 at 9 26 22 AM](https://user-images.githubusercontent.com/8173551/156380638-a3066584-06c6-402e-ac5b-08fa92f6a991.png)
-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code