### PR TITLE
change codeSystem to system in DemographicsRandomizer [2]

### DIFF
--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -165,16 +165,17 @@ module Cypress
     def self.assign_default_demographics(patient)
       elements = []
       unless patient&.gender
-        elements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M', 'codeSystem' => '2.16.840.1.113883.5.1' }])
+        elements << QDM::PatientCharacteristicSex.new(dataElementCodes: [{ 'code' => 'M',
+                                                                           'system' => '2.16.840.1.113883.5.1' }])
       end
       unless patient&.race
-        elements << QDM::PatientCharacteristicRace.new(dataElementCodes: [{ 'code' => '2028-9', 'codeSystem' => '2.16.840.1.113883.6.238' }])
+        elements << QDM::PatientCharacteristicRace.new(dataElementCodes: [{ 'code' => '2028-9', 'system' => '2.16.840.1.113883.6.238' }])
       end
       unless patient&.ethnicity
-        elements << QDM::PatientCharacteristicEthnicity.new(dataElementCodes: [{ 'code' => '2186-5', 'codeSystem' => '2.16.840.1.113883.6.238' }])
+        elements << QDM::PatientCharacteristicEthnicity.new(dataElementCodes: [{ 'code' => '2186-5', 'system' => '2.16.840.1.113883.6.238' }])
       end
       unless patient&.payer
-        elements << QDM::PatientCharacteristicPayer.new(dataElementCodes: [{ 'code' => '1', 'codeSystem' => '2.16.840.1.113883.3.221.5' }],
+        elements << QDM::PatientCharacteristicPayer.new(dataElementCodes: [{ 'code' => '1', 'system' => '2.16.840.1.113883.3.221.5' }],
                                                         relevantPeriod: QDM::Interval.new(patient.qdmPatient.birthDatetime, nil))
       end
       patient.qdmPatient.dataElements.concat(elements)

--- a/test/unit/lib/demographics_randomizer_test.rb
+++ b/test/unit/lib/demographics_randomizer_test.rb
@@ -71,6 +71,23 @@ class DemographicsRandomizerTest < ActiveSupport::TestCase
     assert_equal('Cannot find payer element', payer_exception.message)
   end
 
+  def test_default_demographics
+    @record = Patient.new(
+      givenNames: @given_names,
+      familyName: @family_name,
+      addresses: [@patient_address],
+      telecoms: [@patient_telecom]
+    )
+    QDM::Patient.create!(cqmPatient: @record, birthDatetime: DateTime.new(1981, 6, 8, 4, 0, 0).utc)
+    @record.bundleId = @bundle.id
+    Cypress::DemographicsRandomizer.assign_default_demographics(@record)
+    Cypress::DemographicsRandomizer.update_demographic_codes(@record)
+    assert_equal @record.gender, 'M'
+    assert_equal @record.race, '2028-9'
+    assert_equal @record.ethnicity, '2186-5'
+    assert_equal @record.payer, '1'
+  end
+
   def test_random_payer
     @record = Patient.new(
       givenNames: @given_names,


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code