### PR TITLE
Add program specific constraints to expected measure check [1]

### DIFF
--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -125,7 +125,7 @@ class CMSProgramTask < Task
   def ep_validators
     [::Validators::CMSQRDA3SchematronValidator.new(product_test.bundle.version, as_warnings: false),
      ::Validators::QrdaCat3Validator.new(nil, false, true, false, product_test.bundle),
-     Cat3PopulationValidator.new(product_test.measure_ids)]
+     Cat3PopulationValidator.new(product_test.expected_measures)]
   end
 
   # Program Specific fields to be added to checklist portion of test

--- a/app/models/cms_program_test.rb
+++ b/app/models/cms_program_test.rb
@@ -28,6 +28,15 @@ class CMSProgramTest < ProductTest
     save!
   end
 
+  def expected_measures
+    # If measures are limited by program, expected measures will be a subset of all of the measure ids
+    if CMS_IG_CONFIG['Program Specific Measures'][cms_program]
+      CMS_IG_CONFIG['Program Specific Measures'][cms_program][bundle.major_version] & measure_ids
+    else
+      measure_ids
+    end
+  end
+
   # After a test execution is complete, add error messages for each criterion that is not found
   def build_execution_errors_for_incomplete_cms_criteria(execution)
     program_criteria.each do |crit|

--- a/config/cms_ig.yml
+++ b/config/cms_ig.yml
@@ -30,6 +30,19 @@ CMS Programs:
       - HQR_IQR
       - HQR_PI_IQR
       - HQR_IQR_VOL
+Program Specific Measures:
+  PCF:
+    # CMS122v9, CMS130v9, CMS165v9
+    '2020':
+      [ '2C928085-7198-38EE-0171-9D78A0D406B3',
+        '2C928085-7198-38EE-0171-9D6E026B066B',
+        '2C928085-7198-38EE-0171-9DA6456007AB']
+    # CMS122v10, CMS130v10, CMS165v10
+    '2021':
+      [ '2C928082-74C2-3313-0174-C60BD07B02A6',
+        '2C928082-74C2-3313-0174-DAF39F2C0658',
+        '2C928082-7505-CAF9-0175-2382D1BD06B1']
+
 Program Criterion:
   CCN:
     name: 'CMS Certification Number'

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -97,10 +97,27 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
     perform_enqueued_jobs do
       te = task.execute(file, @user)
       te.reload
-      assert_equal 18, te.execution_errors.size
+      assert_equal 17, te.execution_errors.size
       assert_equal 1, te.execution_errors.where(validator: 'Validators::ProgramValidator').size
-      assert_equal 13, te.execution_errors.where(validator: 'Validators::Cat3PopulationValidator').size
+      assert_equal 12, te.execution_errors.where(validator: 'Validators::Cat3PopulationValidator').size
       assert_equal 4, te.execution_errors.where(validator: 'Validators::ProgramCriteriaValidator').size
+    end
+  end
+
+  def test_should_not_warn_for_missing_non_pcf_measure
+    setup_ep
+    task = @product.product_tests.cms_program_tests.where(cms_program: 'MIPS_INDIV').first.tasks.first
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'cms_test_qrda_cat3_cv.xml'))
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      assert_equal 1, te.execution_errors.where(message: 'Document does not state it is reporting measure CMS134v6').size
+    end
+    task = @product.product_tests.cms_program_tests.where(cms_program: 'PCF').first.tasks.first
+    perform_enqueued_jobs do
+      te = task.execute(file, @user)
+      te.reload
+      assert_equal 0, te.execution_errors.where(message: 'Document does not state it is reporting measure CMS134v6').size
     end
   end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code