### PR TITLE
add warning if QRDA files can't be found [2]

### DIFF
--- a/app/jobs/cms_test_execution_job.rb
+++ b/app/jobs/cms_test_execution_job.rb
@@ -18,6 +18,11 @@ class CMSTestExecutionJob < ApplicationJob
       test_execution.state = :calculating
       test_execution.save
       calculate_patients(test_execution)
+      unless Patient.where(correlation_id: test_execution.id).exists?
+        msg = 'No QRDA files found. Make sure files are not in a nested folder.'
+        test_execution.execution_errors.build(message: msg, msg_type: :warning,
+                                              validator: 'Validators::ProgramCriteriaValidator')
+      end
       validate_measures(test_execution)
       test_execution.state = precalc_state
     end

--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -51,6 +51,7 @@ class VendorPatientUploadJob < ApplicationJob
     # Remove the file that is store when creating the artifact. We also want to remove the folder
     FileUtils.rm_rf(File.dirname(artifact.file.path))
 
+    failed_files['zip'] = 'No QRDA files found. Make sure files are not in a nested folder.' if patients.empty? && failed_files.empty?
     [patients, failed_files]
   end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code