### PR TITLE
maintain support for 2020 CCDE measures

### DIFF
--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -124,13 +124,15 @@
               </tr>
               <tr><td><button class="collapsible">View Core Clinical Data Element</button>
               <div class="collapse-content">
-                <% statement_name = APP_CONSTANTS['result_measures'].select { |rm| rm['hqmf_id'] == m.hqmf_id }.first['statement_name'] %>
+                <% result_measure = APP_CONSTANTS['result_measures'].select { |rm| rm['hqmf_id'] == m.hqmf_id }.first %>
+                <% statement_name = result_measure['statement_name'] %>
+                <% encounter_tuple_name = result_measure['encounter_tuple_name'] %>
                 <% statement_results = ir.statement_results.select { |sr| sr['statement_name'] == statement_name }.first['raw'] %>
                 <% ir.episode_results&.keys&.each_with_index do |encounterId, index| %>
                   <ul>Encounter - <%= index + 1 %>
                   <% statement_results.each do |key, statement_result| %>
-                    <% encounter_result = statement_result.select { |sr| sr['EncounterId'] == encounterId }.first %>
-                    <% next unless encounter_result['FirstResult'] %>
+                    <% encounter_result = statement_result.select { |sr| sr[encounter_tuple_name] == encounterId }.first %>
+                    <% next unless encounter_result && encounter_result['FirstResult'] %>
                     <ul><%= "#{key} (#{encounter_result['FirstResult']['value']} #{encounter_result['FirstResult']['unit']})" %></ul>
                   <% end %>
                   </ul>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -232,12 +232,18 @@ zip_file_size_limit: 20_971_520 # bytes (20 MB)
 
 # These eCQMs store a list of "Results" within the statement_results of an Individual Result
 result_measures:
+  # CMS529v1
+  - hqmf_id : '2C928085-7198-38EE-0171-9D44015105A3'
+    statement_name : 'Results'
+    encounter_tuple_name : 'Encounterid'
   # CMS529v2
   - hqmf_id : '2C928082-74C2-3313-0174-E01E3F200882'
     statement_name : 'Results'
+    encounter_tuple_name : 'EncounterId'
   # CMS844v2
   - hqmf_id : '2C928082-74B3-1D8C-0174-BC5D6372017F'
     statement_name : 'Results'
+    encounter_tuple_name : 'EncounterId'
 
 # These measures do not 
 telehealth_ineligible_measures:

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -257,7 +257,7 @@ module CQM
     def update_ccde_measure_relevance(measure, individual_result)
       statement_name = APP_CONSTANTS['result_measures'].select { |rm| rm['hqmf_id'] == measure.hqmf_id }.first['statement_name']
       statement_results = individual_result.statement_results.select { |sr| sr['statement_name'] == statement_name }.first['raw']
-      measure_relevance_hash[measure.id.to_s]['IPP'] = true if statement_results.any? { |_key, value| value.first['FirstResult'] }
+      measure_relevance_hash[measure.id.to_s]['IPP'] = true if statement_results.any? { |_key, value| !value.empty? && value.first['FirstResult'] }
     end
 
     # Return true if the patient is relevant for one of the population keys in one of the measures passed in


### PR DESCRIPTION
Add back old HQMF_ID
The 2020 measure used the tuple name "Encounterid" for the encounter id.  The 2021 measure uses the tuple name "EncounterId"

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code