### PR TITLE
[Cypress 7] Support not showing Observations when a patient meets the DENEX

### DIFF
--- a/app/views/records/_calculation_results.html.erb
+++ b/app/views/records/_calculation_results.html.erb
@@ -43,7 +43,7 @@
         </td>
       <% end %>
       <% if observation_values[r.id] %>
-        <td class="text-center"><% observation_values[r.id].each do |ov| %><%= ov.join('|') %><br/><% end %></td>
+        <td class="text-center"><% observation_values[r.id].each do |ov| %><%= ov&.join('|') %><br/><% end %></td>
       <% end %>
     <% end %>
   </tr>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code