### PR TITLE
update performance when loading product pages

### DIFF
--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -130,7 +130,7 @@ class Product
     new_ids = measure_ids_from_params(params) || old_ids
     update(params)
     (new_ids - old_ids).each do |measure_id|
-      m = bundle.measures.find_by(hqmf_id: measure_id)
+      m = bundle.measures.only(:cms_id, :title).find_by(hqmf_id: measure_id)
       product_tests.build({ name: m.title, measure_ids: [measure_id], cms_id: m.cms_id }, MeasureTest)
     end
     # remove measure and checklist tests if their measure ids have been removed

--- a/lib/cypress/product_status_values.rb
+++ b/lib/cypress/product_status_values.rb
@@ -2,69 +2,64 @@
 
 module Cypress
   module ProductStatusValues
+    STATUS_NAMES = %w[passing failing errored not_started total].freeze
+
     def cms_status_values(product)
       h = {}
-      h['CMS Program Tests'] = %w[passing failing errored not_started total].zip(product_test_statuses(product.product_tests.cms_program_tests,
-                                                                                                       'CMSProgramTask')).to_h
+      h['CMS Program Tests'] = STATUS_NAMES.zip(product_test_statuses(product.product_tests.cms_program_tests, 'CMSProgramTask')).to_h
       h
     end
 
     def ep_status_values(product)
       h = {}
-      ep_measure_tests = product.product_tests.multi_measure_tests.where(name: 'EP Measures')
-      h['EP Measure Test'] = %w[passing failing errored not_started total].zip(product_test_statuses(ep_measure_tests,
-                                                                                                     'MultiMeasureCat3Task')).to_h
+      ep_measure_tests = product.product_tests.only(:tasks, :name).multi_measure_tests.where(name: 'EP Measures')
+      h['EP Measure Test'] = STATUS_NAMES.zip(product_test_statuses(ep_measure_tests, 'MultiMeasureCat3Task')).to_h
       h
     end
 
     def eh_status_values(product)
       h = {}
-      eh_measure_tests = product.product_tests.multi_measure_tests.where(name: 'EH Measures')
-      h['EH Measure Test'] = %w[passing failing errored not_started total].zip(product_test_statuses(eh_measure_tests,
-                                                                                                     'MultiMeasureCat1Task')).to_h
+      eh_measure_tests = product.product_tests.only(:tasks, :name).multi_measure_tests.where(name: 'EH Measures')
+      h['EH Measure Test'] = STATUS_NAMES.zip(product_test_statuses(eh_measure_tests, 'MultiMeasureCat1Task')).to_h
       h
     end
 
     def c1_status_values(product)
       h = {}
-      statuses = %w[passing failing errored not_started total]
-      h['Checklist'] = statuses.zip(checklist_status_vals(product.product_tests.checklist_tests.first, 'C1')).to_h
+      h['Checklist'] = STATUS_NAMES.zip(checklist_status_vals(product.product_tests.checklist_tests.first, 'C1')).to_h
       if h['Checklist']['total'].zero?
         default_number = CAT1_CONFIG['number_of_checklist_measures']
         h['Checklist']['not_started'] = product.measure_ids.size < default_number ? product.measure_ids.size : default_number
       end
-      h['QRDA Category I'] = %w[passing failing errored not_started total].zip(product_test_statuses(product.product_tests.measure_tests,
-                                                                                                     'C1Task')).to_h
+      h['QRDA Category I'] = STATUS_NAMES.zip(product_test_statuses(product.product_tests.only(:tasks).measure_tests, 'C1Task')).to_h
       h
     end
 
     def c2_status_values(product)
       h = {}
-      h['QRDA Category III'] = %w[passing failing errored not_started total].zip(product_test_statuses(product.product_tests.measure_tests,
-                                                                                                       'C2Task')).to_h
+      h['QRDA Category III'] = STATUS_NAMES.zip(product_test_statuses(product.product_tests.only(:tasks).measure_tests, 'C2Task')).to_h
       h
     end
 
     def c3_status_values(product)
       h = {}
-      statuses = %w[passing failing errored not_started total]
-      h['Checklist'] = statuses.zip(checklist_status_vals(product.product_tests.checklist_tests.first, 'C3')).to_h
+      h['Checklist'] = STATUS_NAMES.zip(checklist_status_vals(product.product_tests.checklist_tests.first, 'C3')).to_h
       if h['Checklist']['total'].zero?
         default_number = CAT1_CONFIG['number_of_checklist_measures']
         h['Checklist']['not_started'] = product.measure_ids.size < default_number ? product.measure_ids.size : default_number
         h['Checklist']['not_started'] = 0 unless product.eh_tests?
       end
-      cat1_status_values = product_test_statuses(product.product_tests.measure_tests.filter(&:eh_measures?), 'C3Cat1Task')
-      cat3_status_values = product_test_statuses(product.product_tests.measure_tests.filter(&:ep_measures?), 'C3Cat3Task')
-      h['QRDA Category I'] = %w[passing failing errored not_started total].zip(cat1_status_values).to_h
-      h['QRDA Category III'] = %w[passing failing errored not_started total].zip(cat3_status_values).to_h
+      cat1_status_values = product_test_statuses(product.product_tests.only(:tasks, :measure_ids).measure_tests.filter(&:eh_measures?), 'C3Cat1Task')
+      cat3_status_values = product_test_statuses(product.product_tests.only(:tasks, :measure_ids).measure_tests.filter(&:ep_measures?), 'C3Cat3Task')
+      h['QRDA Category I'] = STATUS_NAMES.zip(cat1_status_values).to_h
+      h['QRDA Category III'] = STATUS_NAMES.zip(cat3_status_values).to_h
       h
     end
 
     def c4_status_values(filtering_tests)
       h = {}
-      h['QRDA Category I'] = %w[passing failing errored not_started total].zip(product_test_statuses(filtering_tests, 'Cat1FilterTask')).to_h
-      h['QRDA Category III'] = %w[passing failing errored not_started total].zip(product_test_statuses(filtering_tests, 'Cat3FilterTask')).to_h
+      h['QRDA Category I'] = STATUS_NAMES.zip(product_test_statuses(filtering_tests.only(:tasks), 'Cat1FilterTask')).to_h
+      h['QRDA Category III'] = STATUS_NAMES.zip(product_test_statuses(filtering_tests.only(:tasks), 'Cat3FilterTask')).to_h
       h
     end
 


### PR DESCRIPTION
Page Load goes from ~15 to ~8 seconds
Creating a Product with all measures comes down 15ish seconds

![image](https://user-images.githubusercontent.com/8173551/169102826-59bf3f7b-e8ce-4a6b-91f2-cb2198049481.png)

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code