### PR TITLE
update location of name for Query types in DCAB

### DIFF
--- a/lib/cypress/data_criteria_attribute_builder.rb
+++ b/lib/cypress/data_criteria_attribute_builder.rb
@@ -331,7 +331,7 @@ module Cypress
         @unions[statement['name']] = []
         @unionlist << statement
       elsif query_source['expression']['type'] && query_source['expression']['type'] == 'Query'
-        @root_data_criteria[statement['name']] = query_source['expression']['source'][0]['expression']['codes']['name']
+        @root_data_criteria[statement['name']] = query_source['expression']['source'][0]['expression']['name']
       elsif query_source['expression']['type'] && query_source['expression']['type'] == 'ExpressionRef'
         @root_data_criteria[statement['name']] = query_source['expression']['name']
       elsif query_source['expression']['type'] && query_source['expression']['type'] == 'Last'


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code