### PR TITLE
update views to reflect that EP measures are now referred to EC measures

### DIFF
--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -50,8 +50,8 @@ module MeasuresHelper
   end
 
   def type_counts(measures)
-    h = measures.map(&:reporting_program_type).each_with_object(Hash.new(0)) { |type, count| count[type] += 1 } # example {"EH"=> 4,"EP" => 2}
-    h.map { |k, v| "#{v} #{reporting_category_display_name(k)}" }.join(', ') # 4 EH, 2 EP
+    h = measures.map(&:reporting_program_type).each_with_object(Hash.new(0)) { |type, count| count[type] += 1 } # example {"eh"=> 4,"ep" => 2}
+    h.map { |k, v| "#{v} #{reporting_category_display_name(k)}" }.join(', ') # 4 EH, 2 EC
   end
 
   # Format the category (type count) as it is actually shown on the measure tabs

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -50,8 +50,8 @@ module MeasuresHelper
   end
 
   def type_counts(measures)
-    h = measures.map(&:reporting_program_type).each_with_object(Hash.new(0)) { |type, count| count[type.upcase] += 1 } # example {"EH"=> 4,"EP" => 2}
-    h.map { |k, v| "#{v} #{k}" }.join(', ') # 4 EH, 2 EP
+    h = measures.map(&:reporting_program_type).each_with_object(Hash.new(0)) { |type, count| count[type] += 1 } # example {"EH"=> 4,"EP" => 2}
+    h.map { |k, v| "#{v} #{reporting_category_display_name(k)}" }.join(', ') # 4 EH, 2 EP
   end
 
   # Format the category (type count) as it is actually shown on the measure tabs
@@ -61,5 +61,14 @@ module MeasuresHelper
 
   def get_div_name(value)
     "#{value.tr(" '", '_')}_div"
+  end
+
+  def reporting_category_display_name(reporting_program_type)
+    case reporting_program_type
+    when 'ep'
+      'EC'
+    when 'eh'
+      'EH'
+    end
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -190,8 +190,8 @@ class Product
     end
     return unless build_ep
 
-    product_tests.where(name: 'EP Measures').destroy
-    product_tests.build({ name: 'EP Measures', measure_ids: ep_ids, reporting_program_type: 'ep' }, MultiMeasureTest)
+    product_tests.where(name: 'EC Measures').destroy
+    product_tests.build({ name: 'EC Measures', measure_ids: ep_ids, reporting_program_type: 'ep' }, MultiMeasureTest)
   end
 
   # eh_ids: eh measure to include in a multimeasure test

--- a/app/views/application/_cvu_plus_status_table.html.erb
+++ b/app/views/application/_cvu_plus_status_table.html.erb
@@ -21,7 +21,7 @@
         <% else %>
           <th class="status-heading" rowspan="2"><span class="sr-only">Status</span></th>
         <% end %> 
-        <th scope="col" colspan="1" class="cat1-heading">EP Measure Test</th>
+        <th scope="col" colspan="1" class="cat1-heading">EC Measure Test</th>
         <th scope="col" colspan="1" class="cat1-heading">EH Measure Test</th>
         <th scope="col" colspan="1" class="cat1-heading">CMS Program Tests</th>
     </tr>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -92,7 +92,7 @@
     </div>
       <div class="panel-body">
         <p>
-          The Cypress software includes a standard test data of synthetic patient records that exercises all of the CQMs, for Eligible Professionals (EP) and Eligible Hospitals (EH).
+          The Cypress software includes a standard test data of synthetic patient records that exercises all of the CQMs, for Eligible Clinicians (EC) and Eligible Hospitals (EH).
         </p>
         <p>
           Testers download patient data from Cypress, manipulate it with the EHR technology, and upload the results to Cypress for validation. Cypress then provides a report of any errors detected in the uploaded results.

--- a/app/views/products/_measure_selection.html.erb
+++ b/app/views/products/_measure_selection.html.erb
@@ -67,7 +67,7 @@
                       <%= 'checked' if selected_measure_ids && selected_measure_ids.include?(m.hqmf_id) %>
                       <%= 'disabled' if selected_measure_ids && !product.new_record? %>
                     >
-                    <strong><%= m.cms_id %></strong><%= " #{m.title} (#{m.reporting_program_type.upcase})" %>
+                    <strong><%= m.cms_id %></strong><%= " #{m.title} (#{reporting_category_display_name(m.reporting_program_type)})" %>
                   </label>
                 </div>
               <% end %>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -153,7 +153,7 @@
                   'parsley-class-handler': "#measures_options",
                   'parsley-error-message': 'Must select measures.',
                   'parsley-errors-container': "#simple_measures_errors_container" } %>
-                <%= f.radio_button :measure_selection, "ep", label: "Eligible Professional eCQMs", label_class: "btn btn-checkbox", disabled: !product.new_record? %>
+                <%= f.radio_button :measure_selection, "ep", label: "Eligible Clinician eCQMs", label_class: "btn btn-checkbox", disabled: !product.new_record? %>
                 <%= f.radio_button :measure_selection, "all", label: "All eCQMs", label_class: "btn btn-checkbox", disabled: !product.new_record? %>
                 <%= f.radio_button :measure_selection, "custom", label: "Custom...", label_class: "btn btn-checkbox", disabled: !product.new_record? %>
               <% end %>

--- a/app/views/products/report/_cvu_plus_report.html.erb
+++ b/app/views/products/report/_cvu_plus_report.html.erb
@@ -8,7 +8,7 @@
       <tr>
         <th scope="col">Measure Name</th>
         <th scope="col">Submeasures</th>
-        <%= "<th scope='col' class = 'text-center'>EP Measure Test</th>".html_safe %>
+        <%= "<th scope='col' class = 'text-center'>EC Measure Test</th>".html_safe %>
         <%= "<th scope='col' class = 'text-center'>EH Measure Test</th>".html_safe %>
 
       </tr>

--- a/test/models/multi_measure_test_test.rb
+++ b/test/models/multi_measure_test_test.rb
@@ -42,7 +42,7 @@ class MultiMeasureTestTest < ActiveJob::TestCase
     params = { measure_ids: measure_ids, 'cvuplus' => 'true' }
     product.update_with_tests(params)
     assert_equal 2, product.product_tests.multi_measure_tests.size, 'should have with two product test'
-    ep_measure_test = product.product_tests.where(name: 'EP Measures').first
+    ep_measure_test = product.product_tests.where(name: 'EC Measures').first
     eh_measure_test = product.product_tests.where(name: 'EH Measures').first
     assert_equal 'MultiMeasureCat3Task', ep_measure_test.tasks.first._type, 'an ep multi measure test should have a cat 3 task'
     assert_equal 'MultiMeasureCat1Task', eh_measure_test.tasks.first._type, 'an eh multi measure test should have a cat 1 task'


### PR DESCRIPTION
![Screen Shot 2022-05-25 at 3 36 27 PM](https://user-images.githubusercontent.com/8173551/170353701-91bdd3b8-1321-4e27-b455-ad7f84d9d185.png)
https://ecqi.healthit.gov/ep-ec?qt-tabs_ep=0&globalyearfilter=2022

All backend code will still refer to these measures as 'EP'

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code