### PR TITLE
Automatically record inputted attribute value for direct reference code

### DIFF
--- a/app/models/checklist_source_data_criteria.rb
+++ b/app/models/checklist_source_data_criteria.rb
@@ -39,6 +39,13 @@ class ChecklistSourceDataCriteria
     # Don't do this for negated valuesets
     return unless negated_valueset == false
 
+    # Automatically record inputted attribute value for direct reference code
+    if source_data_criteria['dataElementAttributes'] && attribute_index
+      att_vset = source_data_criteria['dataElementAttributes'][attribute_index]['attribute_valueset']
+      # An 'attribute valueset' is a direct reference code if it isn't a valid oid
+      self.attribute_code = att_vset if att_vset && ValueSet.where(oid: att_vset).empty?
+    end
+
     # Only do this when the direct reference code is the only valueset for the data criteria
     valuesets = get_all_valuesets_for_dc(measure_id)
     valueset = valuesets.size == 1 ? valuesets.first : nil


### PR DESCRIPTION
Here is an example from CMS22

<img width="1129" alt="Screen Shot 2022-06-07 at 4 23 29 PM" src="https://user-images.githubusercontent.com/8173551/172475541-ab925c8c-335e-44fb-aac6-62021ef23d3e.png">


Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code