### PR TITLE
update cqm-validators to 4.0.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem 'os'
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', tag: 'cypress_v7.0.0'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', tag: 'cypress_v7.0.0'
 gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', tag: 'cypress_v7.0.0'
-gem 'cqm-validators', '~> 4.0.1'
+gem 'cqm-validators', '~> 4.0.2'
 
 # Use faker to generate addresses
 gem 'faker', '~> 1.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -190,7 +190,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.10)
-    cqm-validators (4.0.1)
+    cqm-validators (4.0.2)
       nokogiri (>= 1.8.5, < 1.14.0)
     crack (0.4.5)
       rexml
@@ -603,7 +603,7 @@ DEPENDENCIES
   cqm-models!
   cqm-parsers!
   cqm-reports!
-  cqm-validators (~> 4.0.1)
+  cqm-validators (~> 4.0.2)
   cucumber-rails
   daemons
   database_cleaner-mongoid


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code