### PR TITLE
[7.0.2] Highlighting on Request, not by default

### DIFF
--- a/app/controllers/records_controller.rb
+++ b/app/controllers/records_controller.rb
@@ -84,6 +84,13 @@ class RecordsController < ApplicationController
     end
   end
 
+  # Updates the specified calculation_result with highlighting
+  def highlighted_results
+    ir = IndividualResult.find(params[:calculation_result_id])
+    ir.recalculate_with_highlighting
+    redirect_back(fallback_location: record_path(id: params[:id]))
+  end
+
   private
 
   # NOTE: case vendor will also have a bundle id

--- a/app/controllers/vendors/records_controller.rb
+++ b/app/controllers/vendors/records_controller.rb
@@ -19,7 +19,8 @@ module Vendors
         file_name = generate_file_path
         file_path = File.join(APP_CONSTANTS['vendor_file_path'], file_name)
         FileUtils.mv(temp_file_path, file_path)
-        VendorPatientUploadJob.perform_later(file_path, params['file'].original_filename, params[:vendor_id], @bundle.id.to_s)
+        include_highlighting = params[:include_highlighting] == '1'
+        VendorPatientUploadJob.perform_later(file_path, params['file'].original_filename, params[:vendor_id], @bundle.id.to_s, include_highlighting)
         redirect_to vendor_records_path(vendor_id: params[:vendor_id], bundle_id: @bundle.id)
       else
         flash[:alert] = 'No vendor patient file provided.'

--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -12,7 +12,7 @@ class VendorPatientUploadJob < ApplicationJob
     tracker.save
   end
 
-  def perform(file, _original_filename, vendor_id, bundle_id)
+  def perform(file, _original_filename, vendor_id, bundle_id, include_highlighting)
     tracker.log('Importing')
 
     vendor_patient_file = File.new(file)
@@ -26,7 +26,7 @@ class VendorPatientUploadJob < ApplicationJob
 
     # do patient calculation against bundle
     unless patients.empty?
-      generate_calculations(patients, bundle, vendor_id)
+      generate_calculations(patients, bundle, vendor_id, include_highlighting)
       PatientAnalysisJob.perform_later(bundle.id.to_s, vendor_id)
     end
     File.delete(file)
@@ -101,15 +101,15 @@ class VendorPatientUploadJob < ApplicationJob
     end
   end
 
-  def generate_calculations(patients, bundle, vendor_id)
+  def generate_calculations(patients, bundle, vendor_id, include_highlighting)
     patient_ids = patients.map { |p| p.id.to_s }
     options = { 'effectiveDate' => Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number),
-                'includeClauseResults' => true }
+                'includeClauseResults' => include_highlighting }
     tracker_index = 0
     # cqm-execution-service (using includeClauseResults) can run out of memory when it is run with a lot of patients.
     # 20 patients was selected after monitoring performance when experimenting with varying counts (from 1 to 100)
     # with all of the measures
-    patients_per_calculation = 20
+    patients_per_calculation = include_highlighting ? 20 : 200
     # Total count is the number of patient slices - (total patients / patients_per_calculation) + 1
     # multiplied by the total number of measures.
     # For example, and upload of 115 patients for 5 measures would be 6 patient slices (101 / 20) + 1 = 6

--- a/app/views/records/new.html.erb
+++ b/app/views/records/new.html.erb
@@ -15,6 +15,9 @@
         </div>
       <% end %>
     <% end %>
+    <%= f.form_group help: "Including logic highlighting provides a detailed view of measure calculation but impacts the calculation speed" do %>
+      <%= f.check_box :include_highlighting, label: 'Include Highlighting?', label_class: "btn btn-checkbox", checked: false %>
+    <% end %>
     <%= f.file_field :file, label: 'Add Patients', accept: 'application/zip' %>
 
   </div>

--- a/app/views/records/show.html.erb
+++ b/app/views/records/show.html.erb
@@ -67,18 +67,20 @@
                         </tr>
                       <% end %>
                     <% end %>
-                  <% unless @record.calculation_results.first.clause_results.empty? %>
                     <tr><td colspan="<%= pop_keys.size + 1 %>">
                     <% @record.calculation_results.where(measure_id: m.id).each_with_index do |ir, index| %>
                       <% if m.key_for_population_set(population_set_hash) == ir.population_set_key %>
-                        <button class="collapsible">View Logic Highlighting</button>
-                        <div class="collapse-content">
-                          <%= render 'patient_measure_highlighting', :measure => m, :index => index, :individual_result => ir %>
-                        </div>
+                        <% if ir.clause_results.empty? %>
+                          <%= link_to "Get Highlighted Result", highlighted_results_record_path(:id => @record.id, :calculation_result_id => ir.id), method: :get %>
+                        <% else %>
+                          <button class="collapsible">View Logic Highlighting</button>
+                          <div class="collapse-content">
+                            <%= render 'patient_measure_highlighting', :measure => m, :index => index, :individual_result => ir %>
+                          </div>
+                        <% end %>
                       <% end %>
                     <% end %>
                   </td></tr>
-                  <% end %>
 
                   <% if APP_CONSTANTS['risk_variable_measures'].map { |rvm| rvm['hqmf_id'] }.include? m.hqmf_id %>
                     <% @record.calculation_results.where(measure_id: m.id).each_with_index do |ir, index| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,6 +98,9 @@ Rails.application.routes.draw do
     collection do
       get :download_mpl
     end
+    member do
+      get 'highlighted_results/:calculation_result_id', action: 'highlighted_results', as: 'highlighted_results'
+    end
   end
 
   resources :version, only: [:index]

--- a/test/unit/lib/cypress/highlighting_test.rb
+++ b/test/unit/lib/cypress/highlighting_test.rb
@@ -2,8 +2,12 @@
 
 require 'test_helper'
 
-class HighlightingTest < ActiveJob::TestCase
+class HighlightingTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+  include ActiveJob::TestHelper
+
   def setup
+    @user = FactoryBot.create(:admin_user)
     @bundle = FactoryBot.create(:executable_bundle)
     @vendor = Vendor.create!(name: 'test_vendor_name')
     @patient = FactoryBot.create(:vendor_test_patient, bundleId: @bundle._id, correlation_id: @vendor.id)
@@ -17,6 +21,35 @@ class HighlightingTest < ActiveJob::TestCase
     perform_enqueued_jobs do
       SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, @vendor.id.to_s, options)
       ir = IndividualResult.where(correlation_id: @vendor.id.to_s, measure_id: measure.id, patient_id: @patient.id).first
+      logic_html = Highlighting.new(measure, ir).render
+      document = Nokogiri::HTML(logic_html)
+      ir.clause_results.each do |cr|
+        next unless %w[TRUE FALSE].include? cr.final
+
+        html_id = "#{cr.statement_name}_#{cr.localId}"
+        assert document.at_xpath(".//span[@id='#{html_id}' and @class='clause-true']") if cr.final == 'TRUE'
+        assert_nil document.at_xpath(".//span[@id='#{html_id}' and @class='clause-true']") if cr.final == 'FALSE'
+      end
+    end
+  end
+
+  def test_add_highting_results
+    measure = @bundle.measures.first
+    effective_date = Time.at(@bundle.measure_period_start).in_time_zone.to_formatted_s(:number)
+    options = { 'effectiveDate' => effective_date, 'includeClauseResults' => false }
+    perform_enqueued_jobs do
+      SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, @vendor.id.to_s, options)
+      ir = IndividualResult.where(correlation_id: @vendor.id.to_s, measure_id: measure.id, patient_id: @patient.id).first
+      assert_empty ir.clause_results
+
+      @controller = RecordsController.new
+      for_each_logged_in_user([ADMIN]) do
+        get :highlighted_results, params: { format: :format_does_not_matter, calculation_result_id: ir.id, id: ir.patient_id }
+      end
+
+      ir.reload
+      assert ir.clause_results.size.positive?
+
       logic_html = Highlighting.new(measure, ir).render
       document = Nokogiri::HTML(logic_html)
       ir.clause_results.each do |cr|


### PR DESCRIPTION
Every Calculation Result (Master Patient List, Vendor Patient, Test Patient) will now have the option to 'Get Highlighted Result'
![Before withtout highlighting](https://user-images.githubusercontent.com/8173551/176480594-e1bda2ab-96e9-45a3-b23d-3192355b97e1.png)

After click the user can now use the 'View Logic Highlighting' button as the have done previously
![After with view highligting box](https://user-images.githubusercontent.com/8173551/176480858-3310987d-e3ac-4ee1-aa3f-58272caac0ac.png)


Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [x] Internal ticket for this PR: https://jira.mitre.org/browse/CYPRESS-985
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code