### PR TITLE
Always include xsi prefix

### DIFF
--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -59,6 +59,7 @@ class VendorPatientUploadJob < ApplicationJob
   def add_patient(data, validator, vendor_id, bundle)
     doc = Nokogiri::XML::Document.parse(data)
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
     doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
 
     # basic CDA schema validation

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -25,6 +25,7 @@ class TestExecution
   def build_document(file)
     doc = Nokogiri::XML(file)
     doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+    doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
     doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
     doc
   end

--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -167,6 +167,7 @@ module Cypress
         qrda = qrda_file.get_input_stream.read
         doc = Nokogiri::XML::Document.parse(qrda)
         doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+        doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         patient, _warnings, codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
         Cypress::QRDAPostProcessor.build_code_descriptions(codes, patient, bundle)

--- a/lib/validators/qrda_file_validator.rb
+++ b/lib/validators/qrda_file_validator.rb
@@ -11,6 +11,7 @@ module Validators
       raise ArgumentError, 'Argument was not an XML document' unless doc.root
 
       doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+      doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
       doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
       doc
     end

--- a/lib/validators/smoking_gun_validator.rb
+++ b/lib/validators/smoking_gun_validator.rb
@@ -98,6 +98,7 @@ module Validators
     def build_document(document)
       doc = document.is_a?(Nokogiri::XML::Document) ? document : Nokogiri::XML(document.to_s)
       doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+      doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
       doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
       doc
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code