### PR TITLE
update cqm_reports and flag 7.0.2 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'os'
 
 gem 'cqm-models', git: 'https://github.com/projecttacoma/cqm-models', tag: 'cypress_v7.0.0'
 gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', tag: 'cypress_v7.0.0'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', tag: 'cypress_v7.0.1'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', tag: 'cypress_v7.0.2'
 gem 'cqm-validators', '~> 4.0.2'
 
 # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,8 +29,8 @@ GIT
 
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: 51cbc2e1a0d5267798e3f9c5abbea2734079d923
-  tag: cypress_v7.0.1
+  revision: 60aa123c7808a5eabe0f7472f6e2ec02036c0e52
+  tag: cypress_v7.0.2
   specs:
     cqm-reports (4.0.0)
       cqm-models (> 3.0)

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 module Cypress
   class Application
-    VERSION = '7.0.1'.freeze
+    VERSION = '7.0.2'.freeze
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code