### PR TITLE
Pass in options as symbols not strings

### DIFF
--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -104,8 +104,8 @@ class VendorPatientUploadJob < ApplicationJob
 
   def generate_calculations(patients, bundle, vendor_id, include_highlighting)
     patient_ids = patients.map { |p| p.id.to_s }
-    options = { 'effectiveDate' => Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number),
-                'includeClauseResults' => include_highlighting }
+    options = { effectiveDate: Time.at(bundle.measure_period_start).in_time_zone.to_formatted_s(:number),
+                includeClauseResults: include_highlighting }
     tracker_index = 0
     # cqm-execution-service (using includeClauseResults) can run out of memory when it is run with a lot of patients.
     # 20 patients was selected after monitoring performance when experimenting with varying counts (from 1 to 100)

--- a/config/initializers/version.rb
+++ b/config/initializers/version.rb
@@ -1,5 +1,5 @@
 module Cypress
   class Application
-    VERSION = '7.0.2'.freeze
+    VERSION = '7.0.2.1'.freeze
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code