### PR TITLE
ignore annotations when comparing units of measure

### DIFF
--- a/lib/ext/individual_result.rb
+++ b/lib/ext/individual_result.rb
@@ -247,12 +247,18 @@ module CQM
         next if calculated_statement_results[result_name].empty?
 
         original_values = value.map(&:FirstResult).compact.empty? ? [] : value.map(&:FirstResult).compact&.sort_by! { |fr| fr['value'] }
+        calculated_values = calculated_statement_results[result_name].map(&:FirstResult).compact&.sort_by! { |fr| fr['value'] }
         statement_result_hash = { name: result_name,
-                                  original: original_values,
-                                  reported: calculated_statement_results[result_name].map(&:FirstResult).compact&.sort_by! { |fr| fr['value'] } }
+                                  original: values_without_annotations(original_values),
+                                  reported: values_without_annotations(calculated_values) }
         combined_statement_results << statement_result_hash
       end
       combined_statement_results
+    end
+
+    # remove all annotations from values using brackets {}
+    def values_without_annotations(values)
+      values.each { |val| val['unit'] = val['unit']&.gsub(/{.*?}/, '') }
     end
 
     # Returns an issue when expected risk variables are missing.  Does not validate the content of the returned risk variables, just existence.


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code