### PR TITLE
Update Scoop and Filter

### DIFF
--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -106,6 +106,7 @@ module Cypress
       end
       neg_vs = @valuesets.select { |vs| vs.concepts.any? { |c| c.code == de.codes.first.code && c.code_system_oid == de.codes.first.system } }
       neg_vs.keep_if { |nvs| value_set_appropriate_for_data_element(de, nvs.oid) }
+      return if neg_vs.blank?
 
       negated_valueset = neg_vs.first
       neg_vs.drop(1).each do |additional_vs|

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -112,7 +112,8 @@ module Cypress
         next if additional_vs.oid[0, 3] == 'drc'
 
         de_for_additional_vs = data_element.clone
-        de_for_additional_vs.id = BSON::ObjectId.new.to_s
+        # Create Ids from the source data element and the oid so they remain consistent
+        de_for_additional_vs.id = BSON::ObjectId.from_data("#{data_element.id}#{additional_vs.oid}").to_s
         de_for_additional_vs.dataElementCodes = [{ code: additional_vs.oid, system: '1.2.3.4.5.6.7.8.9.10' }]
         multi_vs_negation_elements << de_for_additional_vs
       end

--- a/test/fixtures/artifacts/CMS134v6.json
+++ b/test/fixtures/artifacts/CMS134v6.json
@@ -13005,7 +13005,7 @@
     {
       "anatomicalLocationSite": null,
       "authorDatetime": null,
-      "codeListId": "2.16.840.1.113883.3.464.1003.109.12.1012",
+      "codeListId": "1.16.17.18",
       "components": null,
       "dataElementCodes": [
 

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -122,9 +122,13 @@ class PatientZipperTest < ActiveSupport::TestCase
     patient.save
 
     # Add the negated code to a second valueset
-    vs = patient.bundle.measures.first.value_sets.first
-    vs.concepts.create(code: modified_procedure.codes.first.code, code_system_oid: modified_procedure.codes.first.system)
-    vs.save
+    measure = patient.bundle.measures.find_by(cms_id: 'CMS134v6')
+    valueset_oids = measure.source_data_criteria.map { |sdc| sdc.codeListId if sdc._type == 'QDM::ProcedurePerformed' }.compact
+    valueset_oids[0, 2].each do |valueset_oid|
+      vs = patient.bundle.value_sets.find_by(oid: valueset_oid)
+      vs.concepts.create(code: modified_procedure.codes.first.code, code_system_oid: modified_procedure.codes.first.system)
+      vs.save
+    end
 
     Cypress::PatientZipper.zip(file, [patient], format)
     file.close

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -89,8 +89,15 @@ class PatientZipperTest < ActiveSupport::TestCase
     patient = @static_patient
     modified_procedure = patient.qdmPatient.procedures.first
     modified_procedure.negationRationale = modified_procedure.codes.first
-    original_code = modified_procedure.codes.first.code
-    patient.save
+
+    # Add the negated code to a valueset
+    measure = patient.bundle.measures.find_by(cms_id: 'CMS134v6')
+    valueset_oids = measure.source_data_criteria.map { |sdc| sdc.codeListId if sdc._type == 'QDM::ProcedurePerformed' }.compact
+    valueset_oids[0, 1].each do |valueset_oid|
+      vs = patient.bundle.value_sets.find_by(oid: valueset_oid)
+      modified_procedure.dataElementCodes.first[:code] = vs.concepts.first.code
+      patient.save
+    end
 
     Cypress::PatientZipper.zip(file, [patient], format)
     file.close
@@ -103,7 +110,7 @@ class PatientZipperTest < ActiveSupport::TestCase
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         assert_equal 1, doc.xpath('//cda:code[@nullFlavor="NA"]').size, 'There should be 1 negated code in the exported QRDA'
         assert_equal 1, doc.xpath("//cda:patientRole/cda:id[@extension='#{patient.id}']").size, 'The id should match the original patient id'
-        confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, original_code)
+        confirm_imported_patient_can_be_saved_after_replaced_codes(doc, patient, modified_procedure.dataElementCodes.first[:code])
         count += 1
       end
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

This solves Two issues:

1) Only negate valuesets when they are appropriate for the data criteria.  For example, some codes could be in a "Communication" valueset and a "Diagnosis" valueset.  It does not make sense to negate a diagnosis valueset in a communication entry.
2) Keep Ids consistent when creating negate data elements for multiple valuesets.  This allows for 'Known Good' files to be consistent with the original test deck and allows for files that have been split for de-duplication to be consistent. 

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code