### PR TITLE
Display QRDA version associated with the test

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,7 @@ Metrics/ClassLength:
     - 'app/models/settings.rb'
     - 'app/models/test_execution.rb'
     - 'app/controllers/records_controller.rb'
+    - 'lib/ext/bundle.rb'
     - 'lib/ext/individual_result.rb'
     - 'lib/ext/patient.rb'
     - 'lib/cypress/api_measure_evaluator.rb'
@@ -122,6 +123,7 @@ Metrics/ModuleLength:
   Exclude:
     - 'lib/cypress/data_criteria_attribute_builder.rb'
     - 'app/helpers/patient_analysis_helper.rb'
+    - 'app/helpers/test_executions_helper.rb'
 Metrics/ParameterLists:
   Exclude:
     - 'app/helpers/records_helper.rb'

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -189,6 +189,17 @@ module ProductsHelper
     end
   end
 
+  def cms_program_test_display_name(program_test)
+    case program_test.cms_program
+    when 'HL7_Cat_I'
+      "HL7 Cat I (#{program_test.bundle.qrda_version_display_name}) Test"
+    when 'HL7_Cat_III'
+      "HL7 Cat III (#{program_test.bundle.qrda3_version_display_name}) Test"
+    else
+      program_test.name
+    end
+  end
+
   def description_for(product, test_type, is_qrda_1_measure_test: true)
     case test_type
     when 'ChecklistTest'

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -75,8 +75,12 @@ module TestExecutionsHelper
     msg << " for #{test.cms_id} #{test.name}"
   end
 
-  def get_upload_type(is_displaying_cat1)
-    is_displaying_cat1 ? 'zip file of QRDA Category I documents' : 'QRDA Category III XML document'
+  def get_upload_type(is_displaying_cat1, bundle)
+    if is_displaying_cat1
+      "zip file of QRDA Category I (#{bundle.qrda_version_display_name}) documents"
+    else
+      "QRDA Category III (#{bundle.qrda3_version_display_name}) XML document"
+    end
   end
 
   def execution_failure_message(execution)

--- a/app/views/products/_cvu_plus_product.html.erb
+++ b/app/views/products/_cvu_plus_product.html.erb
@@ -77,7 +77,7 @@
               <% # A Multi Measure Test only has a single task %>
               <% task = program_test.tasks.first %>
               <tr>
-                <td><%= link_to program_test.name, product_program_test_path(@product, program_test) %></td>
+                <td><%= link_to cms_program_test_display_name(program_test), product_program_test_path(@product, program_test) %></td>
                 <td class="no-wrap" id = "<%= id_for_html_wrapper_of_task(task) %>">
                   <%= render 'filtering_test_link', :test => program_test, :task => task, :parent_reloading => true %>
                 </td>

--- a/app/views/test_executions/_execution_upload.html.erb
+++ b/app/views/test_executions/_execution_upload.html.erb
@@ -16,7 +16,7 @@
   </p>
 <% else %>
   <p class = 'description' id='execution_upload_label'>
-    <%= "Upload results from the EHR system in the form of a #{get_upload_type(displaying_cat1?(task))} to get test results. This will automatically run a test execution." %>
+    <%= "Upload results from the EHR system in the form of a #{get_upload_type(displaying_cat1?(task), task.bundle)} to get test results. This will automatically run a test execution." %>
   </p>
 <% end %>
 

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -27,7 +27,9 @@ version_config:
         IPP: 'IPOP'
       schematron: "2020.0.0"
       qrda_version: "r5_2"
+      qrda_version_display_name: "STU 5.2"
       qrda3_version: "r2_1"
+      qrda3_version_display_name: "STU 2.1"
       default_negation_codes:
         2.16.840.1.113883.3.526.3.1184:
           code: "854901"
@@ -43,7 +45,9 @@ version_config:
         IPP: 'IPOP'
       schematron: "2021.0.0"
       qrda_version: "r5_2"
+      qrda_version_display_name: "STU 5.2"
       qrda3_version: "r2_1"
+      qrda3_version_display_name: "STU 2.1"
       default_negation_codes:
         2.16.840.1.113883.3.526.3.1184:
           code: "854901"
@@ -58,8 +62,10 @@ version_config:
       modified_population_labels:
         IPP: 'IPOP'
       schematron: "2022.0.0"
-      qrda_version: "r5_2"
+      qrda_version: "r5_3"
+      qrda_version_display_name: "STU 5.3"
       qrda3_version: "r2_1"
+      qrda3_version_display_name: "R1"
       default_negation_codes:
         2.16.840.1.113883.3.526.3.1184:
           code: "854901"

--- a/features/step_definitions/filtering_test.rb
+++ b/features/step_definitions/filtering_test.rb
@@ -88,12 +88,12 @@ Then(/^the user should see the CAT 1 test$/) do
   # but rspec overloads assert which causes other issues. May look into later
   # expect(page).to have_content('a zip file of QRDA Category I documents')
   sleep(0.5)
-  assert page.has_content?('a zip file of QRDA Category I documents')
+  assert page.has_content?('a zip file of QRDA Category I')
 end
 
 Then(/^the user should see the CAT 3 test$/) do
   sleep(0.5)
-  assert page.has_content?('a QRDA Category III XML document')
+  assert page.has_content?('a QRDA Category III')
 end
 
 Then(/^the user should not see provider information$/) do

--- a/lib/ext/bundle.rb
+++ b/lib/ext/bundle.rb
@@ -82,6 +82,14 @@ class Bundle
     ApplicationController.helpers.config_for_version(version).qrda3_version
   end
 
+  def qrda_version_display_name
+    ApplicationController.helpers.config_for_version(version).qrda_version_display_name
+  end
+
+  def qrda3_version_display_name
+    ApplicationController.helpers.config_for_version(version).qrda3_version_display_name
+  end
+
   def cms_schematron
     ApplicationController.helpers.config_for_version(version).schematron
   end

--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -77,8 +77,8 @@ class TestExecutionHelper < ActiveSupport::TestCase
   end
 
   def test_get_upload_type
-    assert_equal 'zip file of QRDA Category I documents', get_upload_type(true)
-    assert_equal 'QRDA Category III XML document', get_upload_type(false)
+    assert_equal 'zip file of QRDA Category I (STU 5.2) documents', get_upload_type(true, @bundle)
+    assert_equal 'QRDA Category III (STU 2.1) XML document', get_upload_type(false, @bundle)
   end
 
   def test_get_error_counts_no_execution


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code