### PR TITLE
Determine random patient using measure relevance, not master_patient_ids

### DIFF
--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -47,7 +47,8 @@ class FilteringTest < ProductTest
     # select a random patient
     prng = Random.new(rand_seed.to_i)
 
-    rand_patient = patients.select { |p| p.patient_relevant?(measures.pluck(:_id), ['IPP']) }.sample
+    measure_object_ids = measures.pluck(:_id)
+    rand_patient = patients.select { |p| p.patient_relevant?(measure_object_ids, ['IPP']) }.sample
     # iterate over the filters and assign random codes
     params = { measures: measures, patients: patients, incl_addr: incl_addr, effective_date: created_at, prng: prng }
     options['filters'].each do |k, _v|

--- a/app/models/filtering_test.rb
+++ b/app/models/filtering_test.rb
@@ -46,9 +46,8 @@ class FilteringTest < ProductTest
 
     # select a random patient
     prng = Random.new(rand_seed.to_i)
-    mpl_ids = master_patient_ids
 
-    rand_patient = patients.select { |p| p.original_patient_id.in?(mpl_ids) }.sample
+    rand_patient = patients.select { |p| p.patient_relevant?(measures.pluck(:_id), ['IPP']) }.sample
     # iterate over the filters and assign random codes
     params = { measures: measures, patients: patients, incl_addr: incl_addr, effective_date: created_at, prng: prng }
     options['filters'].each do |k, _v|


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code