### PR TITLE
In C1 Record Sample, swap 'class' with 'clazz'

### DIFF
--- a/lib/validators/checklist_criteria_validator.rb
+++ b/lib/validators/checklist_criteria_validator.rb
@@ -86,6 +86,7 @@ module Validators
     end
 
     def extract_attribute_from_data_element(data_element, attribute_name)
+      attribute_name = 'clazz' if attribute_name == 'class'
       attribute = data_element[attribute_name]
       attribute ||= data_element.send(attribute_name)
       attribute


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code