### PR TITLE
submission should be OQR for CMS996

### DIFF
--- a/app/models/c2_task.rb
+++ b/app/models/c2_task.rb
@@ -37,8 +37,8 @@ class C2Task < Task
   # rubocop:disable Metrics/AbcSize
   def good_results
     # Set the Submission Program to MIPS_INDIV if there is a C3 test and the test is for an ep measure.
-    cat3_submission_program = if product_test&.product&.c3_test
-                                product_test&.measures&.first&.reporting_program_type == 'ep' ? 'MIPS_INDIV' : false
+    cat3_submission_program = if product_test&.product&.c3_test && product_test&.ep_measures?
+                                product_test&.submission_program
                               else
                                 false
                               end

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -252,6 +252,16 @@ class ProductTest
     measures.pluck(:reporting_program_type).include?('ep')
   end
 
+  def submission_program
+    if eh_measures?
+      return APP_CONSTANTS['oqr_measures'].intersection(measure_ids).blank? ? 'HQR_IQR' : 'HQR_OQR'
+    elsif ep_measures?
+      return 'MIPS_INDIV'
+    end
+
+    false
+  end
+
   # A measure test has a C1 Task if the product has C1 criteria, or C3 criteria with EH measures
   def c1_task?
     product.c1_test || (product.c3_test && eh_measures?)

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -333,6 +333,10 @@ measures_without_future_data:
   [ '2C928083-786E-690D-0178-7090965F028D',
     '2C928082-7FAC-C041-017F-B3038B3E0469' ]
 
+# CMS996v3
+oqr_measures:
+  [ '2C928083-7F47-C81F-017F-79354C281550' ]
+
 # These measures have specific timing constraints
 timing_constraints:
   # CMS529v1

--- a/lib/cypress/patient_zipper.rb
+++ b/lib/cypress/patient_zipper.rb
@@ -37,17 +37,17 @@ module Cypress
 
     # rubocop:disable Metrics/PerceivedComplexity
     def export(patient)
-      cat1_submission_program = if patient.product_test&.product&.c3_test || patient.product_test&.product&.cvuplus
-                                  patient.product_test&.measures&.first&.reporting_program_type == 'eh' ? 'HQR_IQR' : false
-                                else
-                                  false
-                                end
+      cat1_program = if (patient.product_test&.product&.c3_test || patient.product_test&.product&.cvuplus) && patient.product_test&.eh_measures?
+                       patient.product_test&.submission_program
+                     else
+                       false
+                     end
       options = { provider: patient.providers.first,
                   patient_addresses: patient.addresses,
                   patient_telecoms: patient.telecoms,
                   patient_email: patient.email,
                   medicare_beneficiary_identifier: patient.medicare_beneficiary_identifier,
-                  submission_program: cat1_submission_program,
+                  submission_program: cat1_program,
                   start_time:, end_time: }
       if patient.bundle.major_version.to_i > 2021
         Qrda1R5.new(patient, measures, options).render

--- a/test/factories/product_tests.rb
+++ b/test/factories/product_tests.rb
@@ -39,8 +39,8 @@ FactoryBot.define do
                                                                     'ETHNICITY' => { '2186-5' => 1 },
                                                                     'SEX' => { 'F' => 1 },
                                                                     'PAYER' => { '1' => 1 } },
-                                                       'NUMER' => {},
-                                                       'DENEX' => {} } } } }
+                                                       'NUMER' => { 'RACE' => {}, 'ETHNICITY' => {}, 'SEX' => {}, 'PAYER' => {} },
+                                                       'DENEX' => { 'RACE' => {}, 'ETHNICITY' => {}, 'SEX' => {}, 'PAYER' => {} } } } } }
       expected_results { expected_result }
       measure_ids { ['40280382-5FA6-FE85-0160-0918E74D2075'] }
       association :provider, factory: :default_provider

--- a/test/models/c2_task_test.rb
+++ b/test/models/c2_task_test.rb
@@ -74,6 +74,11 @@ class C2TaskTest < ActiveSupport::TestCase
     xml = Tempfile.new(['good_results_debug_file', '.xml'])
     xml.write task.good_results
     perform_enqueued_jobs do
+      doc = File.open(xml) { |f| Nokogiri::XML(f) }
+      doc.root.add_namespace_definition('cda', 'urn:hl7-org:v3')
+      doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
+      # There should not be an intendedRecipient of "MIPS_INDIV"
+      assert_equal 0, doc.xpath('//cda:informationRecipient/cda:intendedRecipient/cda:id[@extension="MIPS_INDIV"]').size
       te = task.execute(xml, @user)
       te.reload
       assert_empty te.execution_errors, 'test execution with known good results should not have any errors'

--- a/test/models/measure_test_test.rb
+++ b/test/models/measure_test_test.rb
@@ -120,6 +120,7 @@ class MeasureTestTest < ActiveJob::TestCase
     @product.c3_test = true
     pt = @product.product_tests.build({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
     pt.create_tasks
+    assert_equal pt.submission_program, 'MIPS_INDIV', 'product test should be for the MIPS_INDIV program'
     assert pt.tasks.c2_task, 'product test should have a c2_task'
     assert pt.tasks.c3_cat3_task, 'product test should have a c3_cat3_task'
   end
@@ -128,8 +129,22 @@ class MeasureTestTest < ActiveJob::TestCase
     @product.c3_test = true
     pt = @product.product_tests.build({ name: 'mtest', measure_ids: ['AE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
     pt.create_tasks
+    assert_equal pt.submission_program, 'HQR_IQR', 'product test should be for the HQR_IQR program'
     assert pt.tasks.c1_task, 'product test should have a c1_task'
     assert pt.tasks.c3_cat1_task, 'product test should have a c3_cat1_task'
+  end
+
+  def test_create_task_for_oqr_measure
+    @product.c3_test = true
+    pt = @product.product_tests.build({ name: 'mtest', measure_ids: ['AE65090C-EB1F-11E7-8C3F-9A214CF093AE'] }, MeasureTest)
+    pt.create_tasks
+    assert_equal pt.submission_program, 'HQR_IQR', 'product test should be for the HQR_IQR program'
+    original_oqr_measures = APP_CONSTANTS['oqr_measures']
+    # modify the config file to include 'AE65090C-EB1F-11E7-8C3F-9A214CF093AE' as the OQR measure
+    APP_CONSTANTS['oqr_measures'] = ['AE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+    assert_equal pt.submission_program, 'HQR_OQR', 'product test should be for the HQR_IQR program'
+    # set the config file back
+    APP_CONSTANTS['oqr_measures'] = original_oqr_measures
   end
 
   def test_create_task_c1_and_c2


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code