### PR TITLE
CmsTestExecutionJob not CMSTestExecutionJob

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -111,7 +111,7 @@ class ProductsController < ApplicationController
     </head>"
 
     @product.product_tests.each do |pt|
-      next unless pt.is_a?(CMSProgramTest)
+      next unless pt.is_a?(CmsProgramTest)
 
       report_hash[pt.name] = {}
       pt.tasks.each do |t|

--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -32,7 +32,7 @@ class TestExecutionsController < ApplicationController
     respond_with(@test_execution) do |f|
       if @task.is_a? C1ChecklistTask
         f.html { redirect_to product_checklist_test_path(@task.product_test.product, @task.product_test) }
-      elsif @task.is_a? CMSProgramTask
+      elsif @task.is_a? CmsProgramTask
         f.html { redirect_to product_program_test_path(@task.product_test.product, @task.product_test) }
       else
         f.html { redirect_to task_test_execution_path(task_id: @task.id, id: @test_execution.id) }

--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -9,7 +9,7 @@ module ProductsHelper
       product.product_tests.measure_tests.any?
     when 'MultiMeasureTest'
       product.product_tests.multi_measure_tests.any?
-    when 'CMSProgramTest'
+    when 'CmsProgramTest'
       product.product_tests.cms_program_tests.any?
     when 'FilteringTest'
       product.product_tests.filtering_tests.any?
@@ -128,7 +128,7 @@ module ProductsHelper
   # yields test_type, title, and description for each tab that should be displayed on product show page
   #   also yeilds html_id which should be used as the html id of the <div> tag that holds the content for each tab
   def each_tab(product)
-    %w[ChecklistTest MeasureTest FilteringTest MultiMeasureTest CMSProgramTest].each do |test_type|
+    %w[ChecklistTest MeasureTest FilteringTest MultiMeasureTest CmsProgramTest].each do |test_type|
       next unless should_show_product_tests_tab?(product, test_type)
 
       if test_type == 'MeasureTest'
@@ -166,8 +166,8 @@ module ProductsHelper
       'C4 (QRDA-I and QRDA-III)'
     when 'MultiMeasureTest'
       'MultiMeasureTest'
-    when 'CMSProgramTest'
-      'CMSProgramTest'
+    when 'CmsProgramTest'
+      'CmsProgramTest'
     end
   end
 

--- a/app/helpers/test_executions_helper.rb
+++ b/app/helpers/test_executions_helper.rb
@@ -4,9 +4,9 @@ module TestExecutionsHelper
   include TestExecutionsResultsHelper
 
   def displaying_cat1?(task)
-    # A CMSProgramTask only uses the cat I upload when the reporting_program_type is eh
+    # A CmsProgramTask only uses the cat I upload when the reporting_program_type is eh
     task.is_a?(C1Task) || task.is_a?(Cat1FilterTask) || task.is_a?(C1ChecklistTask) || task.is_a?(MultiMeasureCat1Task) ||
-      (task.is_a?(CMSProgramTask) && task.product_test.reporting_program_type == 'eh')
+      (task.is_a?(CmsProgramTask) && task.product_test.reporting_program_type == 'eh')
   end
 
   def task_type_to_title(task_type)
@@ -147,7 +147,7 @@ module TestExecutionsHelper
   def tests_for_task_by_type(task, tests)
     return tests.filtering_tests.sort_by { |t| cms_int(t.cms_id) } if task.is_a?(Cat1FilterTask) || task.is_a?(Cat3FilterTask)
     return tests.multi_measure_tests.sort_by(&:reporting_program_type) if task.is_a?(MultiMeasureCat1Task) || task.is_a?(MultiMeasureCat3Task)
-    return tests.cms_program_tests.sort_by(&:name) if task.is_a?(CMSProgramTask)
+    return tests.cms_program_tests.sort_by(&:name) if task.is_a?(CmsProgramTask)
 
     tests.measure_tests.sort_by { |t| cms_int(t.cms_id) }
   end

--- a/app/jobs/cms_test_execution_job.rb
+++ b/app/jobs/cms_test_execution_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CMSTestExecutionJob < ApplicationJob
+class CmsTestExecutionJob < ApplicationJob
   include Job::Status
   queue_as :default
 

--- a/app/jobs/vendor_patient_upload_job.rb
+++ b/app/jobs/vendor_patient_upload_job.rb
@@ -81,7 +81,7 @@ class VendorPatientUploadJob < ApplicationJob
       patient, _warnings, codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
 
       # use all patient codes to build description map
-      Cypress::QRDAPostProcessor.build_code_descriptions(codes, patient, bundle)
+      Cypress::QrdaPostProcessor.build_code_descriptions(codes, patient, bundle)
 
       # shift date
       utc_start = DateTime.parse(doc_start).to_time.utc
@@ -92,9 +92,9 @@ class VendorPatientUploadJob < ApplicationJob
       end
 
       patient.update(_type: CQM::VendorPatient, correlation_id: vendor_id, bundleId: bundle.id)
-      Cypress::QRDAPostProcessor.replace_negated_codes(patient, bundle)
-      Cypress::QRDAPostProcessor.remove_unmatched_data_type_code_combinations(patient, bundle)
-      Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
+      Cypress::QrdaPostProcessor.replace_negated_codes(patient, bundle)
+      Cypress::QrdaPostProcessor.remove_unmatched_data_type_code_combinations(patient, bundle)
+      Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
       patient.save
       [true, patient]
     rescue StandardError => e

--- a/app/models/artifact.rb
+++ b/app/models/artifact.rb
@@ -30,10 +30,10 @@ class Artifact
     case content_extension
     when :zip
       errors.add(:file, 'File upload extension should be .zip') unless %w[C1Task C1ChecklistTask C3ChecklistTask C3Cat1Task
-                                                                          CMSProgramTask Cat1FilterTask MultiMeasureCat1Task
+                                                                          CmsProgramTask Cat1FilterTask MultiMeasureCat1Task
                                                                           QrdaUploadTask].include?(test_execution.task._type)
     when :xml
-      errors.add(:file, 'File upload extension should be .xml') unless %w[C2Task C3Cat3Task Cat3FilterTask CMSProgramTask
+      errors.add(:file, 'File upload extension should be .xml') unless %w[C2Task C3Cat3Task Cat3FilterTask CmsProgramTask
                                                                           MultiMeasureCat3Task QrdaUploadTask].include?(test_execution.task._type)
     else
       errors.add(:file, 'File upload extension should be .zip or .xml')

--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CMSProgramTask < Task
+class CmsProgramTask < Task
   include ::Validators
 
   after_create :initialize_program_specific_fields
@@ -12,7 +12,7 @@ class CMSProgramTask < Task
                    MeasurePeriodValidator.new]
     # Each program may have program specific validations add them
     @validators.concat program_specific_validators
-    # If the CMSProgramTask is for HL7 validation, only include QRDA validation
+    # If the CmsProgramTask is for HL7 validation, only include QRDA validation
     @validators = hl7_validators if %w[HL7_Cat_I HL7_Cat_III].include? product_test.cms_program
     @validators
   end
@@ -89,17 +89,17 @@ class CMSProgramTask < Task
 
   def mips_group_validators
     # For MIPS submissions, CMS EHR Certification ID is only required if Promoting Interoperability is included
-    [EHRCertificationIdValidator.new].concat ep_validators
+    [EhrCertificationIdValidator.new].concat ep_validators
   end
 
   def mips_indiv_validators
     # For MIPS submissions, CMS EHR Certification ID is only required if Promoting Interoperability is included
-    [EHRCertificationIdValidator.new].concat ep_validators
+    [EhrCertificationIdValidator.new].concat ep_validators
   end
 
   def mips_virtual_group_validators
     # For MIPS submissions, CMS EHR Certification ID is only required if Promoting Interoperability is included
-    [EHRCertificationIdValidator.new].concat ep_validators
+    [EhrCertificationIdValidator.new].concat ep_validators
   end
 
   def mips_apm_entity_validators

--- a/app/models/cms_program_task.rb
+++ b/app/models/cms_program_task.rb
@@ -159,7 +159,7 @@ class CMSProgramTask < Task
     te.user = user
     te.artifact = Artifact.new(file:)
     te.save!
-    CMSTestExecutionJob.perform_later(te, self)
+    CmsTestExecutionJob.perform_later(te, self)
     te.save
     te
   end

--- a/app/models/cms_program_test.rb
+++ b/app/models/cms_program_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CMSProgramTest < ProductTest
+class CmsProgramTest < ProductTest
   field :cms_program, type: String
   field :reporting_program_type, type: String
   embeds_many :program_criteria, class_name: 'ProgramCriterion'
@@ -18,7 +18,7 @@ class CMSProgramTest < ProductTest
   end
 
   def create_tasks
-    CMSProgramTask.new(product_test: self).save!
+    CmsProgramTask.new(product_test: self).save!
   end
 
   def update_with_program_tests(program_test_params)

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -211,7 +211,7 @@ class Product
     product_tests.cms_program_tests.where(reporting_program_type: 'eh').destroy if eh_ids.empty?
     CMS_IG_CONFIG['CMS Programs']['eh'][bundle.major_version]&.each do |cms_program|
       product_tests.build({ name: "#{cms_program} Test", cms_program:, measure_ids: eh_ids,
-                            reporting_program_type: 'eh' }, CMSProgramTest)
+                            reporting_program_type: 'eh' }, CmsProgramTest)
     end
   end
 
@@ -220,7 +220,7 @@ class Product
     product_tests.cms_program_tests.where(reporting_program_type: 'ep').destroy if ep_ids.empty?
     CMS_IG_CONFIG['CMS Programs']['ep'][bundle.major_version]&.each do |cms_program|
       product_tests.build({ name: "#{cms_program} Test", cms_program:, measure_ids: ep_ids,
-                            reporting_program_type: 'ep' }, CMSProgramTest)
+                            reporting_program_type: 'ep' }, CmsProgramTest)
     end
   end
 
@@ -230,9 +230,9 @@ class Product
 
     # The 'reporting_program_type' is used to restrict the upload type.  Use EH for Cat I, and EP for Cat III
     product_tests.build({ name: 'HL7 Cat I Test', cms_program: 'HL7_Cat_I', measure_ids:,
-                          reporting_program_type: 'eh' }, CMSProgramTest)
+                          reporting_program_type: 'eh' }, CmsProgramTest)
     product_tests.build({ name: 'HL7 Cat III Test', cms_program: 'HL7_Cat_III', measure_ids:,
-                          reporting_program_type: 'ep' }, CMSProgramTest)
+                          reporting_program_type: 'ep' }, CmsProgramTest)
   end
 
   def add_filtering_tests

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -14,7 +14,7 @@ class ProductTest
   scope :checklist_tests, -> { where(_type: 'ChecklistTest') }
   scope :filtering_tests, -> { where(_type: 'FilteringTest') }
   scope :multi_measure_tests, -> { where(_type: 'MultiMeasureTest') }
-  scope :cms_program_tests, -> { where(_type: 'CMSProgramTest') }
+  scope :cms_program_tests, -> { where(_type: 'CmsProgramTest') }
 
   belongs_to :product, index: true, touch: true
   has_many :tasks, dependent: :destroy, inverse_of: :product_test

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -23,7 +23,7 @@ class Task
 
   %w[
     C1Task C1ChecklistTask C3ChecklistTask C2Task C3Cat1Task C3Cat3Task
-    Cat1FilterTask Cat3FilterTask MultiMeasureCat1Task MultiMeasureCat3Task CMSProgramTask
+    Cat1FilterTask Cat3FilterTask MultiMeasureCat1Task MultiMeasureCat3Task CmsProgramTask
   ].each do |task_type|
     # Define methods for fetching specific types of tasks,
     # for example (Task.c1_task, Task.cat1_filter_task, etc)

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -64,7 +64,7 @@ class TestExecution
                              msg_type: :error, validator_type: :result_validation, validator: :smoking_gun)
     end
     task.product_test.build_execution_errors_for_incomplete_checked_criteria(self) if task.is_a?(C1ChecklistTask)
-    task.product_test.build_execution_errors_for_incomplete_cms_criteria(self) if task.is_a?(CMSProgramTask)
+    task.product_test.build_execution_errors_for_incomplete_cms_criteria(self) if task.is_a?(CmsProgramTask)
   end
 
   def passing?

--- a/app/views/products/_cvu_plus_product.html.erb
+++ b/app/views/products/_cvu_plus_product.html.erb
@@ -64,7 +64,7 @@
       <% end %>
 
       <% # CMS Program Test Tab %>
-      <% if test_type == 'CMSProgramTest' %>
+      <% if test_type == 'CmsProgramTest' %>
         <div id="display_measure_tests_table">
           <table class = 'table table-hover measure_tests_table'>
             <thead>

--- a/app/views/program_tests/_cms_program_test.html.erb
+++ b/app/views/program_tests/_cms_program_test.html.erb
@@ -4,7 +4,7 @@
     <div class="panel-heading">
       <h1 class="panel-title test-step"> 1 <%= icon('fas fa-fw', 'bolt', :"aria-hidden" => true) %> CMS Implementation Guide Checklist Instructions</h1>
     </div>
-    <%= render 'checklist_tests/checklist_instructions', :instructions => APP_CONSTANTS['tests']['CMSProgramTest']['instructions'] %>
+    <%= render 'checklist_tests/checklist_instructions', :instructions => APP_CONSTANTS['tests']['CmsProgramTest']['instructions'] %>
   </div>
 </div>
 <%= render 'upload_panel', :product_test => product_test, :panel_index => "2" %>

--- a/app/views/test_executions/_execution_results.html.erb
+++ b/app/views/test_executions/_execution_results.html.erb
@@ -79,7 +79,7 @@ end %>
     </ul>
   <% end %>
 
-  <% if collected_errors.files.values.any? { |err| err.count.positive? } || (@task.is_a? CMSProgramTask) %>
+  <% if collected_errors.files.values.any? { |err| err.count.positive? } || (@task.is_a? CmsProgramTask) %>
     <h2><%= "Errors and " unless passing %>Warnings</h2>
     <div id="xml-tabs" class="hidden file-error-tabs short-tabs">
       <ul>
@@ -113,7 +113,7 @@ end %>
           </li>
           <% files_with_errors << file_name %>
         <% end %>
-        <% if @task.is_a? CMSProgramTask
+        <% if @task.is_a? CmsProgramTask
           non_errored_files = file_name_id_hash.keys - files_with_errors
           non_errored_files.each do |file_name| %>
           <li>
@@ -126,7 +126,7 @@ end %>
         
       </ul>
 
-      <% if (@task.is_a? CMSProgramTask) && @task.product_test.reporting_program_type == 'eh'
+      <% if (@task.is_a? CmsProgramTask) && @task.product_test.reporting_program_type == 'eh'
         continuous_measures = @task.measures.where(measure_scoring: 'CONTINUOUS_VARIABLE').only(:id, :population_sets, :hqmf_id, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
         proportion_measures = @task.measures.where(measure_scoring: 'PROPORTION').only(:id, :population_sets, :hqmf_id, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }
         ratio_measures = @task.measures.where(measure_scoring: 'RATIO').only(:id, :population_sets, :hqmf_id, :cms_id, :description, :calculation_method).sort_by { |m| [m.cms_int] }

--- a/app/views/test_executions/_test_info.html.erb
+++ b/app/views/test_executions/_test_info.html.erb
@@ -32,7 +32,7 @@
   <% end %>
 
   <br/>
-  <% if !((task.is_a? C1ChecklistTask) || (task.is_a? CMSProgramTask)) %>
+  <% if !((task.is_a? C1ChecklistTask) || (task.is_a? CmsProgramTask)) %>
     <%= link_to 'View Patients', { controller: 'records', hqmf_id: task.product_test.measure_ids.first, task_id: task.id}, method: :get %>
     <% if (task.is_a?(Cat1FilterTask) || task.is_a?(Cat3FilterTask)) && should_display_expected_results(task) %>
       <br/>

--- a/app/views/test_executions/results/_execution_results_for_file.html.erb
+++ b/app/views/test_executions/results/_execution_results_for_file.html.erb
@@ -21,7 +21,7 @@
   <%= "#{file_name} - #{num_errors} " + (is_passing ? "warnings" : "errors and warnings") %>
 </p>
 
-<% if (@task.is_a? CMSProgramTask) && @task.product_test.reporting_program_type == 'eh' %>
+<% if (@task.is_a? CmsProgramTask) && @task.product_test.reporting_program_type == 'eh' %>
   <% if display_calculations %>
     <%= render partial: 'test_executions/results/calculation_results_for_file', locals: { execution: execution, file_name: file_name, continuous_measures: continuous_measures, proportion_measures: proportion_measures, ratio_measures: ratio_measures, result_measures: result_measures, patient: patient, export: export } %>
   <% end %>

--- a/app/views/test_executions/show.html.erb
+++ b/app/views/test_executions/show.html.erb
@@ -37,7 +37,7 @@
       { title: 'Download Test Deck', partial: 'execution_download', disable: false, disable_msg: '' },
       { title: 'Upload Files', partial: 'execution_upload', disable: @task.product_test_state == :errored, disable_msg: 'Cannot upload files to an errored test.' }
       ] %>
-  <% elsif @task.product_test.is_a? CMSProgramTest %>
+  <% elsif @task.product_test.is_a? CmsProgramTest %>
     <% steps = [
       { title: 'Upload Files', partial: 'execution_upload', disable: @task.product_test_state == :errored, disable_msg: 'Cannot upload files to an errored test.' }
       ] %>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -195,7 +195,7 @@ certifications:
     tests:
       - 'FilteringTest'
 tests:
-  CMSProgramTest:
+  CmsProgramTest:
     title: 'CMS Implementation Guide Checklist'
     instructions:
       - instruction: 'Enter the information below into your EHR and record the entered values in the inputs boxes provided.'

--- a/lib/cypress/api_measure_evaluator.rb
+++ b/lib/cypress/api_measure_evaluator.rb
@@ -513,8 +513,8 @@ module Cypress
     def import_cat1_file(doc, patient_ids, bundle_id)
       patient, _warnings, _codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
       bundle = Bundle.find(bundle_id)
-      Cypress::QRDAPostProcessor.replace_negated_codes(patient, bundle)
-      Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
+      Cypress::QrdaPostProcessor.replace_negated_codes(patient, bundle)
+      Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
       patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval', bundleId: bundle_id)
       patient.normalize_date_times
       patient.save!

--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -172,12 +172,12 @@ module Cypress
         doc.root.add_namespace_definition('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
         doc.root.add_namespace_definition('sdtc', 'urn:hl7-org:sdtc')
         patient, _warnings, codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-        Cypress::QRDAPostProcessor.build_code_descriptions(codes, patient, bundle)
+        Cypress::QrdaPostProcessor.build_code_descriptions(codes, patient, bundle)
         patient['bundleId'] = bundle.id
         patient.update(_type: CQM::BundlePatient, correlation_id: bundle.id)
-        Cypress::QRDAPostProcessor.replace_negated_codes(patient, bundle)
-        Cypress::QRDAPostProcessor.remove_unmatched_data_type_code_combinations(patient, bundle)
-        Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
+        Cypress::QrdaPostProcessor.replace_negated_codes(patient, bundle)
+        Cypress::QrdaPostProcessor.remove_unmatched_data_type_code_combinations(patient, bundle)
+        Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(patient) if bundle.major_version.to_i > 2021
         patient.save!
         report_progress('patients', (index * 100 / qrda_files.length)) if (index % 10).zero?
       end

--- a/lib/cypress/create_download_zip.rb
+++ b/lib/cypress/create_download_zip.rb
@@ -39,7 +39,7 @@ module Cypress
 
           folder_name = "#{m._type.underscore.dasherize}s/#{m.cms_id}#{filter_folder}"
 
-          add_file_to_zip(z, "#{folder_name}/records/#{m.cms_id}_#{m.id}.qrda.zip", m.patient_archive.read) unless m.is_a?(CMSProgramTest)
+          add_file_to_zip(z, "#{folder_name}/records/#{m.cms_id}_#{m.id}.qrda.zip", m.patient_archive.read) unless m.is_a?(CmsProgramTest)
           add_execution_data(z, m, options, folder_name)
         end
       end
@@ -51,7 +51,7 @@ module Cypress
         most_recent_execution = task.most_recent_execution
         next unless most_recent_execution
 
-        if product_test.is_a?(CMSProgramTest)
+        if product_test.is_a?(CmsProgramTest)
           # append test type
           folder_name = "#{folder_name}#{product_test.cms_program.underscore.dasherize}"
           options[:report_hash][product_test.name].each do |file_name, text|

--- a/lib/cypress/product_status_values.rb
+++ b/lib/cypress/product_status_values.rb
@@ -6,7 +6,7 @@ module Cypress
 
     def cms_status_values(product)
       h = {}
-      h['CMS Program Tests'] = STATUS_NAMES.zip(product_test_statuses(product.product_tests.cms_program_tests, 'CMSProgramTask')).to_h
+      h['CMS Program Tests'] = STATUS_NAMES.zip(product_test_statuses(product.product_tests.cms_program_tests, 'CmsProgramTask')).to_h
       h
     end
 

--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Cypress
-  module QRDAPostProcessor
+  module QrdaPostProcessor
     # checks for placeholder negation code_system
     def self.replace_negated_codes(patient, bundle)
       mapped_codes = bundle.mapped_codes

--- a/lib/cypress/scoop_and_filter.rb
+++ b/lib/cypress/scoop_and_filter.rb
@@ -60,7 +60,7 @@ module Cypress
 
       # add data element valueset and other potentially relevant valueset descriptions
       codes = (multi_vs_negation_elements + [data_element]).map { |de| "#{de.dataElementCodes.first.code}:#{de.dataElementCodes.first.system}" }
-      Cypress::QRDAPostProcessor.build_code_descriptions(codes, patient, patient.bundle)
+      Cypress::QrdaPostProcessor.build_code_descriptions(codes, patient, patient.bundle)
     end
 
     def data_element_category_and_status(data_element)

--- a/lib/ext/patient.rb
+++ b/lib/ext/patient.rb
@@ -281,7 +281,7 @@ module CQM
 
     def remove_telehealth_codes(ineligible_measures)
       warnings = []
-      Cypress::QRDAPostProcessor.remove_telehealth_encounters(self, codes_modifiers, warnings, ineligible_measures) unless codes_modifiers.empty?
+      Cypress::QrdaPostProcessor.remove_telehealth_encounters(self, codes_modifiers, warnings, ineligible_measures) unless codes_modifiers.empty?
       save
       warnings
     end

--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -86,7 +86,7 @@ namespace :cypress do
           _patient, _warnings, codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
 
           # build code descriptions for original patient
-          Cypress::QRDAPostProcessor.build_code_descriptions(codes, p, p.bundle)
+          Cypress::QrdaPostProcessor.build_code_descriptions(codes, p, p.bundle)
 
           p.save
         end

--- a/lib/validators/calculating_smoking_gun_validator.rb
+++ b/lib/validators/calculating_smoking_gun_validator.rb
@@ -14,8 +14,8 @@ module Validators
 
       # check for single code negation errors
       product_test = ProductTest.find(@test_id)
-      errors = Cypress::QRDAPostProcessor.issues_for_negated_single_codes(patient, @bundle, product_test.measures)
-      unit_errors = Cypress::QRDAPostProcessor.issues_for_mismatched_units(patient, @bundle, product_test.measures)
+      errors = Cypress::QrdaPostProcessor.issues_for_negated_single_codes(patient, @bundle, product_test.measures)
+      unit_errors = Cypress::QrdaPostProcessor.issues_for_mismatched_units(patient, @bundle, product_test.measures)
       if product_test.product.c3_test
         errors.each { |e| add_error e, file_name: options[:file_name] }
       else
@@ -24,8 +24,8 @@ module Validators
       unit_errors.each { |e| add_warning e, file_name: options[:file_name], cms: true }
       warnings.each { |e| add_warning e.message, file_name: options[:file_name], location: e.location }
 
-      Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
-      Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(patient) if @bundle.major_version.to_i > 2021
+      Cypress::QrdaPostProcessor.replace_negated_codes(patient, @bundle)
+      Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(patient) if @bundle.major_version.to_i > 2021
       patient.bundleId = @bundle.id
       patient
     rescue StandardError

--- a/lib/validators/cat3_population_validator.rb
+++ b/lib/validators/cat3_population_validator.rb
@@ -100,7 +100,7 @@ module Validators
     end
 
     def validate_demographics(reported_result, pop_key, pop_set_hash, options)
-      return unless %w[CMSProgramTask C3Cat3Task MultiMeasureCat3Task].include? options['test_execution'].task._type
+      return unless %w[CmsProgramTask C3Cat3Task MultiMeasureCat3Task].include? options['test_execution'].task._type
       #  Skip demographic validators if population is missing
       # Skip if there is a stratification_id.  Stratifications do not report demographics
       return if reported_result[pop_key].nil? || pop_set_hash[:stratification_id]

--- a/lib/validators/cms_schematron_validator.rb
+++ b/lib/validators/cms_schematron_validator.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Validators
-  class CMSSchematronValidator < QrdaFileValidator
+  class CmsSchematronValidator < QrdaFileValidator
     include Validators::Validator
     include ::CqmValidators
     def initialize(schematron_file, name, as_warnings, bundle_version = Settings.current.default_bundle)
@@ -34,21 +34,21 @@ module Validators
     end
   end
 
-  class CMSQRDA3SchematronValidator < CMSSchematronValidator
+  class CMSQRDA3SchematronValidator < CmsSchematronValidator
     def initialize(bundle_version = Settings.current.default_bundle, as_warnings: false)
       super(Rails.root.join('resources', 'schematron', schematron_folder_for_bundle_version(bundle_version), 'EP', 'EP_CAT_III.sch').to_s,
             self.class.to_s, as_warnings, bundle_version)
     end
   end
 
-  class CMSQRDA1HQRSchematronValidator < CMSSchematronValidator
+  class CMSQRDA1HQRSchematronValidator < CmsSchematronValidator
     def initialize(bundle_version = Settings.current.default_bundle, as_warnings: false)
       super(Rails.root.join('resources', 'schematron', schematron_folder_for_bundle_version(bundle_version), 'EH', 'EH_CAT_I.sch').to_s,
             self.class.to_s, as_warnings, bundle_version)
     end
   end
 
-  class CMSQRDA1PQRSSchematronValidator < CMSSchematronValidator
+  class CMSQRDA1PQRSSchematronValidator < CmsSchematronValidator
     def initialize(bundle_version = Settings.current.default_bundle, as_warnings: false)
       super(Rails.root.join('resources', 'schematron', schematron_folder_for_bundle_version(bundle_version), 'EP', 'EP_CAT_I.sch').to_s,
             self.class.to_s, as_warnings, bundle_version)

--- a/lib/validators/core_clinical_data_element_validator.rb
+++ b/lib/validators/core_clinical_data_element_validator.rb
@@ -16,7 +16,7 @@ module Validators
 
       doc = get_document(file)
       case options.task._type
-      when 'CMSProgramTask'
+      when 'CmsProgramTask'
         verify_patient_ids(doc, options)
         verify_ccde_program(doc, options)
       when 'C3Cat1Task'

--- a/lib/validators/ehr_certification_id_validator.rb
+++ b/lib/validators/ehr_certification_id_validator.rb
@@ -4,7 +4,7 @@
 # (Promoting Interoperability Section (V2) identifier: urn:hl7ii:2.16.840.1.113883.10.20.27.2.5:2017-06-01)
 # is present in a QRDA III document.
 module Validators
-  class EHRCertificationIdValidator < QrdaFileValidator
+  class EhrCertificationIdValidator < QrdaFileValidator
     include Validators::Validator
 
     def validate(file, options = {})

--- a/lib/validators/measure_period_validator.rb
+++ b/lib/validators/measure_period_validator.rb
@@ -17,15 +17,15 @@ module Validators
       @product_test = @options['test_execution'].task.product_test
       @doc_start_time = measure_period_start(@document)
       @doc_end_time = measure_period_end(@document)
-      validate_encounter_during_reporting_period if (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
+      validate_encounter_during_reporting_period if (@product_test.is_a? CmsProgramTest) && @product_test.reporting_program_type == 'eh'
       validate_timing
     end
 
     def validate_timing
       timing_constraint = find_timing_constraints
-      if timing_constraint && (@product_test.product.shift_patients || (@product_test.is_a? CMSProgramTest))
+      if timing_constraint && (@product_test.product.shift_patients || (@product_test.is_a? CmsProgramTest))
         validate_measurement_period(timing_constraint['start_time'], timing_constraint['end_time'])
-      elsif (@product_test.is_a? CMSProgramTest) && @product_test.reporting_program_type == 'eh'
+      elsif (@product_test.is_a? CmsProgramTest) && @product_test.reporting_program_type == 'eh'
         # For EH measures, Reports are for a single quarter
         validate_quarters_measurement_period
       else

--- a/lib/validators/program_criteria_validator.rb
+++ b/lib/validators/program_criteria_validator.rb
@@ -55,13 +55,13 @@ module Validators
       unless options.task.product_test.cms_program == 'HL7_Cat_I'
         patient_has_pcp_and_other_element(patient, options)
         # check for single code negation errors
-        errors = Cypress::QRDAPostProcessor.issues_for_negated_single_codes(patient, options.task.bundle, options.task.product_test.measures)
-        unit_errors = Cypress::QRDAPostProcessor.issues_for_mismatched_units(patient, options.task.bundle, options.task.product_test.measures)
+        errors = Cypress::QrdaPostProcessor.issues_for_negated_single_codes(patient, options.task.bundle, options.task.product_test.measures)
+        unit_errors = Cypress::QrdaPostProcessor.issues_for_mismatched_units(patient, options.task.bundle, options.task.product_test.measures)
         errors.each { |e| add_error e, file_name: options[:file_name] }
         unit_errors.each { |e| add_error e, file_name: options[:file_name] }
       end
-      Cypress::QRDAPostProcessor.replace_negated_codes(patient, options.task.bundle)
-      Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(patient) if options.task.bundle.major_version.to_i > 2021
+      Cypress::QrdaPostProcessor.replace_negated_codes(patient, options.task.bundle)
+      Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(patient) if options.task.bundle.major_version.to_i > 2021
     end
 
     # Check that a patient as a patient_characteristic_payer and atleast 1 other (non-demographic) data criteria

--- a/test/factories/execution_error.rb
+++ b/test/factories/execution_error.rb
@@ -94,7 +94,7 @@ FactoryBot.define do
 
     factory :ehr_certification_id_validator do
       msg_type { 'error' }
-      validator { 'Validators::EHRCertificationIdValidator' }
+      validator { 'Validators::EhrCertificationIdValidator' }
       validation_type { 'result_validation' }
       cms { false }
 

--- a/test/integration/api_measure_evaluator_test.rb
+++ b/test/integration/api_measure_evaluator_test.rb
@@ -211,7 +211,7 @@ class ApiMeasureEvaluatorTest < ActionController::TestCase
   # Import and save Cat I file
   def import_cat1_file(doc)
     patient, _warnings = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-    Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
+    Cypress::QrdaPostProcessor.replace_negated_codes(patient, @bundle)
     patient.update(_type: CQM::TestExecutionPatient, correlation_id: 'api_eval', bundleId: @bundle.id)
     patient.save!
     patient.id

--- a/test/jobs/single_measure_calculation_job_test.rb
+++ b/test/jobs/single_measure_calculation_job_test.rb
@@ -36,7 +36,7 @@ class SingleMeasureCalculationJobTest < ActiveJob::TestCase
       SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, 'what', options)
       # Calculation will fail when a patient has a DeviceApplied (since it isn't in QDM 5.6)
       assert @patient.calculation_results.empty?
-      Cypress::QRDAPostProcessor.remove_invalid_qdm_56_data_types(@patient) if @bundle.major_version.to_i > 2021
+      Cypress::QrdaPostProcessor.remove_invalid_qdm_56_data_types(@patient) if @bundle.major_version.to_i > 2021
       @patient.save
       # Calculation will now pass since the DeviceApplied has been removed
       SingleMeasureCalculationJob.perform_now([@patient.id.to_s], measure.id.to_s, 'what', options)

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test_helper'
-class CMSProgramTaskTest < ActiveSupport::TestCase
+class CmsProgramTaskTest < ActiveSupport::TestCase
   include ::Validators
   include ActiveJob::TestHelper
 
@@ -60,7 +60,7 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
       assert_equal 4, te.execution_errors.where(validator: 'Validators::Cat3PopulationValidator', msg_type: :error).size # One for each demographic
       assert_equal 1, te.execution_errors.where(message: 'Document does not state it is reporting measure CMS32v7', msg_type: :warning).size
       assert_equal 2, te.execution_errors.where(validator: 'Validators::ProgramCriteriaValidator').size
-      assert_equal 1, te.execution_errors.where(validator: 'Validators::EHRCertificationIdValidator').size
+      assert_equal 1, te.execution_errors.where(validator: 'Validators::EhrCertificationIdValidator').size
     end
   end
 

--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -246,7 +246,7 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
     pcv = ProgramCriteriaValidator.new(pt)
     pcv.instance_variable_set(:@file, execution.build_document(file))
     pcv.import_patient(options, @product.product_tests.first.measure_ids)
-    tej = CMSTestExecutionJob.new
+    tej = CmsTestExecutionJob.new
     tej.calculate_patients(execution)
     assert_equal execution.tracker.log_message[0], '50% of calculations complete'
   end

--- a/test/unit/html_test.rb
+++ b/test/unit/html_test.rb
@@ -103,10 +103,10 @@ class HTMLTest < ActiveSupport::TestCase
 
     # import and build code descriptions
     patient, _warnings, codes = QRDA::Cat1::PatientImporter.instance.parse_cat1(doc)
-    Cypress::QRDAPostProcessor.build_code_descriptions(codes, patient, @bundle)
+    Cypress::QrdaPostProcessor.build_code_descriptions(codes, patient, @bundle)
     patient['bundleId'] = @bundle.id
     patient.update(_type: CQM::BundlePatient, correlation_id: @bundle.id)
-    Cypress::QRDAPostProcessor.replace_negated_codes(patient, @bundle)
+    Cypress::QrdaPostProcessor.replace_negated_codes(patient, @bundle)
     patient.save!
     saved_patient = Patient.find(patient.id)
 

--- a/test/unit/lib/cypress/qrda_post_processor_test.rb
+++ b/test/unit/lib/cypress/qrda_post_processor_test.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-class QRDAPostProcessorTest < ActiveSupport::TestCase
+class QrdaPostProcessorTest < ActiveSupport::TestCase
   def setup
     @bundle = FactoryBot.create(:executable_bundle)
     @patient = BundlePatient.new(givenNames: ['Patient'], familyName: 'Test', bundleId: @bundle.id)
@@ -17,7 +17,7 @@ class QRDAPostProcessorTest < ActiveSupport::TestCase
     @patient.qdmPatient.dataElements.push QDM::MedicationAdministered.new(dataElementCodes: medication_codes)
     assert_equal 1, @patient.qdmPatient.substances.size
     assert_equal 1, @patient.qdmPatient.medications.size
-    Cypress::QRDAPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
+    Cypress::QrdaPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
     # Since both medication and substance code match the codes available for their QDM type, no data elements are removed
     assert_equal 1, @patient.qdmPatient.substances.size
     assert_equal 1, @patient.qdmPatient.medications.size
@@ -34,7 +34,7 @@ class QRDAPostProcessorTest < ActiveSupport::TestCase
     @patient.qdmPatient.dataElements.push QDM::MedicationAdministered.new(dataElementCodes: medication_codes)
     assert_equal 2, @patient.qdmPatient.substances.size
     assert_equal 2, @patient.qdmPatient.medications.size
-    Cypress::QRDAPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
+    Cypress::QrdaPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
     # The medication element using the substance_codes and the substance elment using the medication code will be removed
     assert_equal 1, @patient.qdmPatient.substances.size
     assert_equal '1', @patient.qdmPatient.substances.first.dataElementCodes.first.code
@@ -53,7 +53,7 @@ class QRDAPostProcessorTest < ActiveSupport::TestCase
     @patient.qdmPatient.dataElements.push QDM::MedicationAdministered.new(dataElementCodes: medication_codes)
     assert_equal 2, @patient.qdmPatient.substances.size
     assert_equal 2, @patient.qdmPatient.medications.size
-    Cypress::QRDAPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
+    Cypress::QrdaPostProcessor.remove_unmatched_data_type_code_combinations(@patient, @bundle)
     # since categorized_codes is empty, no elements will be removed
     assert_equal 2, @patient.qdmPatient.substances.size
     assert_equal 2, @patient.qdmPatient.medications.size

--- a/test/unit/lib/patient_zipper_test.rb
+++ b/test/unit/lib/patient_zipper_test.rb
@@ -163,19 +163,19 @@ class PatientZipperTest < ActiveSupport::TestCase
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert_equal false, codefound, 'code should not be found prior to replace_negated_codes'
     # Should replace with a code from the valueset
-    Cypress::QRDAPostProcessor.replace_negated_codes(imported_patient, patient.bundle)
+    Cypress::QrdaPostProcessor.replace_negated_codes(imported_patient, patient.bundle)
     codefound = imported_patient.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert codefound, 'replaced code should equal original code'
     assert imported_patient.save
     # Should not replace a code when valuesets do not exist
     ValueSet.destroy_all
-    Cypress::QRDAPostProcessor.replace_negated_codes(cloned_import, patient.bundle)
+    Cypress::QrdaPostProcessor.replace_negated_codes(cloned_import, patient.bundle)
     codefound = cloned_import.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == original_code }
     assert_not codefound, 'Without valusets the code should not be replaced'
     assert cloned_import.save
     # Should replace with the default code
     APP_CONSTANTS['version_config']['~>2020.0']['default_negation_codes'][negated_oid] = { 'code' => '123', 'codeSystem' => 'SNOMEDCT' }
-    Cypress::QRDAPostProcessor.replace_negated_codes(cloned_import2, patient.bundle)
+    Cypress::QrdaPostProcessor.replace_negated_codes(cloned_import2, patient.bundle)
     codefound = cloned_import2.qdmPatient.procedures.first.dataElementCodes.any? { |dec| dec[:code] == '123' }
     assert codefound, 'replaced code should equal default code'
     assert cloned_import2.save

--- a/test/unit/lib/validators/measure_period_validator_test.rb
+++ b/test/unit/lib/validators/measure_period_validator_test.rb
@@ -19,7 +19,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170101'
     APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
-    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+    pt = CmsProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
                             reporting_program_type: 'eh', product: @product)
     pt.create_tasks
     te = pt.tasks.first.test_executions.build
@@ -35,7 +35,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170102'
     APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
-    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+    pt = CmsProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
                             reporting_program_type: 'eh', product: @product)
     pt.create_tasks
     te = pt.tasks.first.test_executions.build
@@ -51,7 +51,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170102'
     APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171231'
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'ep_test_qrda_cat3_missing_measure.xml')).read
-    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'MIPS_APMENTITY', measure_ids: [measure_id],
+    pt = CmsProgramTest.new(name: 'CMS Program Test', cms_program: 'MIPS_APMENTITY', measure_ids: [measure_id],
                             reporting_program_type: 'ep', product: @product)
     pt.create_tasks
     te = pt.tasks.first.test_executions.build
@@ -67,7 +67,7 @@ class MeasurePeriodValidatorTest < ActiveSupport::TestCase
     APP_CONSTANTS['timing_constraints'].first['start_time'] = '20170101'
     APP_CONSTANTS['timing_constraints'].first['end_time'] = '20171230'
     file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
-    pt = CMSProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
+    pt = CmsProgramTest.new(name: 'CMS Program Test', cms_program: 'HQR_PI', measure_ids: [measure_id],
                             reporting_program_type: 'eh', product: @product)
     pt.create_tasks
     te = pt.tasks.first.test_executions.build

--- a/test/unit/product_report_test.rb
+++ b/test/unit/product_report_test.rb
@@ -50,19 +50,19 @@ class ProductReportTest < ActionController::TestCase
         'report_text' => 'CMS159v8 - patient_characteristic, expired not complete'
       }
     ],
-    'CMSProgramTest' => [
+    'CmsProgramTest' => [
       {
         'factory_name' => :cms_program_test_build_execution_errors_for_incomplete_cms_criteria,
         'report_text' => 'Tax Identification Number not complete'
       }
     ],
-    'CMSSchematronValidator' => [
+    'CmsSchematronValidator' => [
       {
         'factory_name' => :cms_schematron_validator_validate,
         'report_text' => 'CONF:CMS_3'
       }
     ],
-    'EHRCertificationIdValidator' => [
+    'EhrCertificationIdValidator' => [
       {
         'factory_name' => :ehr_certification_id_validator_validate,
         'report_text' => 'CMS EHR Certification ID'


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code