### PR TITLE
don't error for null flavor (#1795)

### DIFF
--- a/lib/validators/smoking_gun_validator.rb
+++ b/lib/validators/smoking_gun_validator.rb
@@ -68,6 +68,8 @@ module Validators
       telecoms = { email_list: [], phone_list: [] }
       telecom_elements = doc.xpath('.//cda:ClinicalDocument/cda:recordTarget/cda:patientRole/cda:telecom')
       telecom_elements.each do |telecom_element|
+        next unless telecom_element['value']
+
         # removes all white space
         uri = URI(telecom_element['value'].delete(" \t\r\n"))
         case uri.scheme


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code