### PR TITLE
revert only 1 negation checklist.

### DIFF
--- a/app/models/checklist_test.rb
+++ b/app/models/checklist_test.rb
@@ -82,10 +82,6 @@ class ChecklistTest < ProductTest
         codeless_indices << index
       else
         # A coded attribute needs to have the valueset specified
-        # skip a negated attribute if one has already been chosen
-        next if @negation_already_selected && attribute['attribute_name'] == 'negationRationale'
-
-        @negation_already_selected = true if attribute['attribute_name'] == 'negationRationale'
         code_indices << index
       end
     end
@@ -111,8 +107,6 @@ class ChecklistTest < ProductTest
       next if (checklist_measures.include? measure.hqmf_id) || (checklist_measures.size > max_num_checklist_measures - 1)
 
       checklist_measures << measure.hqmf_id
-      # set negation_already_selected to false before going through criteria for this measure
-      @negation_already_selected = false
       measure_criteria_map[measure].each do |criteria|
         att_index = attribute_index(criteria)
         # slice source_data_criteria to remove fields unrelated to the checklist test

--- a/test/models/checklist_test_test.rb
+++ b/test/models/checklist_test_test.rb
@@ -28,19 +28,6 @@ class ChecklistTestTest < ActiveJob::TestCase
     assert_equal 2, @test.attribute_index(attributes3), 'should return index for dischargeDisposition with a valueset oid'
   end
 
-  def test_multiple_negations_attribute_index
-    attributes1 = { 'dataElementAttributes' => [{ 'attribute_name' => 'relevantPeriod', 'attribute_valueset' => nil },
-                                                { 'attribute_name' => 'negationRationale', 'attribute_valueset' => '1.1.2.3' }] }
-    attributes2 = { 'dataElementAttributes' => [{ 'attribute_name' => 'relevantPeriod', 'attribute_valueset' => nil },
-                                                { 'attribute_name' => 'id', 'attribute_valueset' => nil }] }
-    attributes3 = { 'dataElementAttributes' => [{ 'attribute_name' => 'relevantPeriod', 'attribute_valueset' => nil },
-                                                { 'attribute_name' => 'negationRationale', 'attribute_valueset' => '1.1.2.3' },
-                                                { 'attribute_name' => 'dischargeDisposition', 'attribute_valueset' => '1.1.2.3' }] }
-    assert_equal 1, @test.attribute_index(attributes1), 'should return index for negationRationale with a valueset oid'
-    assert_equal 0, @test.attribute_index(attributes2), 'should return index for relevantPeriod'
-    assert_equal 2, @test.attribute_index(attributes3), 'should return index for dischargeDisposition with a valueset oid'
-  end
-
   def test_create_checked_criteria
     @test.create_checked_criteria
     assert @test.checked_criteria.count.positive?, 'should create checked criteria for one measure'


### PR DESCRIPTION
This is being reverted because it can cause issues if a measure only has the negated criteria.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code