### PR TITLE
round observations to 8th digit

### DIFF
--- a/lib/ext/cqm/individual_result.rb
+++ b/lib/ext/cqm/individual_result.rb
@@ -48,6 +48,8 @@ module CQM
         %w[IPP DENOM NUMER DENEX DENEXCEP MSRPOPL MSRPOPLEXCEP].each do |pop|
           original_value, calculated_value, pop = extract_calcuated_and_original_results(calculated, pop)
           next unless original_value != calculated_value
+          # CQL requires a minimum of 8 decimal values.  Cap our check there.
+          next unless original_value.round(8) != calculated_value.round(8)
 
           pop_statement = options[:population_set].populations[pop].hqmf_id
           pop_statement << " Stratification #{options[:stratification_id]}" if options[:stratification_id]


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code