### PR TITLE
Docker ruby 32

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Pinned to the latest ruby 2.7.3 version of the Passenger base Docker image 
+# Pinned to the latest ruby 3.2 version of the Passenger base Docker image 
 FROM phusion/passenger-ruby32:2.5.0
 
 RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pinned to the latest ruby 2.7.3 version of the Passenger base Docker image 
-FROM phusion/passenger-ruby27:1.0.15
+FROM phusion/passenger-ruby32:2.5.0
 
 RUN mv /etc/apt/sources.list.d /etc/apt/sources.list.d.bak
 RUN apt update && apt install -y ca-certificates


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code