### PR TITLE
Round to 8th decimal places in observations

### DIFF
--- a/lib/ext/cqm/individual_result.rb
+++ b/lib/ext/cqm/individual_result.rb
@@ -91,6 +91,8 @@ module CQM
       expected_er = episode_results.values.map(&:observation_values).sort
 
       return unless calculated_er != expected_er
+      # CQL requires a minimum of 8 decimal values.  Cap our check there.
+      return unless calculated_er.round(8) != expected_er.round(8)
 
       issues << "Calculated observations (#{calculated_er}) do not match " \
                 "expected observations (#{expected_er})"

--- a/lib/validators/expected_results_validator.rb
+++ b/lib/validators/expected_results_validator.rb
@@ -67,6 +67,8 @@ module Validators
     def check_observations(expected_result, reported_result, measure_id)
       expected_result[:observations].each do |population, expected_observation|
         next if reported_result[:observations][population].to_d == expected_observation['value'].to_d
+        # CQL requires a minimum of 8 decimal values.  Cap our check there.
+        next if reported_result[:observations][population].to_d.round(8) == expected_observation['value'].to_d.round(8)
 
         err = %(Expected #{population} Observation value #{expected_observation['value']}
         does not match reported value #{reported_result[:observations][population]})


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code