### PR TITLE
pass in format when printing c1 and c4 criteria

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -199,8 +199,8 @@ class ProductsController < ApplicationController
   def patients
     crit_exists = !@product.product_tests.checklist_tests.empty?
     filt_exists = !@product.product_tests.filtering_tests.empty?
-    criteria_list = crit_exists ? render_to_string(template: 'checklist_tests/print_criteria', layout: 'report') : nil
-    filtering_list = filt_exists ? render_to_string(template: 'checklist_tests/print_filtering', layout: 'report') : nil
+    criteria_list = crit_exists ? render_to_string(template: 'checklist_tests/print_criteria', layout: 'report', formats: :html) : nil
+    filtering_list = filt_exists ? render_to_string(template: 'checklist_tests/print_filtering', layout: 'report', formats: :html) : nil
     file = Cypress::CreateTotalTestZip.create_total_test_zip(@product, criteria_list, filtering_list, 'qrda')
     send_data file.read, type: 'application/zip', disposition: 'attachment', filename: "#{@product.name}_#{@product.id}.zip".tr(' ', '_')
   end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code