### PR TITLE
we do not need to round individual results as cqm-execution is genera…

### DIFF
--- a/lib/ext/cqm/individual_result.rb
+++ b/lib/ext/cqm/individual_result.rb
@@ -91,8 +91,6 @@ module CQM
       expected_er = episode_results.values.map(&:observation_values).sort
 
       return unless calculated_er != expected_er
-      # CQL requires a minimum of 8 decimal values.  Cap our check there.
-      return unless calculated_er.round(8) != expected_er.round(8)
 
       issues << "Calculated observations (#{calculated_er}) do not match " \
                 "expected observations (#{expected_er})"


### PR DESCRIPTION
…ting the expected and calculated

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code