### PR TITLE
We do not need to remove 'Records' that was a model in Health Data St…

### DIFF
--- a/lib/tasks/cypress.rake
+++ b/lib/tasks/cypress.rake
@@ -11,7 +11,6 @@ namespace :cypress do
       before = Vendor.all.count
       Vendor.destroy_all
       diff = before - Vendor.all.count
-      Record.destroy_all(test_id: { '$ne' => nil })
       Artifact.destroy_all
       puts "removed #{diff} Vendors"
     end


### PR DESCRIPTION
…andards

https://github.com/projectcypress/health-data-standards/blob/master/lib/health-data-standards/models/record.rb

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code