### PR TITLE
remove patients associated with test executions

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -81,6 +81,7 @@ class ProductTest
     CQM::IndividualResult.where(:patient_id.in => patient_ids).delete
     test_execution_ids.each do |test_execution_id|
       CQM::IndividualResult.where(correlation_id: test_execution_id).delete
+      CQM::TestExecutionPatient.where(correlation_id: test_execution_id).delete
     end
     ProductTest.in(id: product_test_ids).delete
   end

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -79,6 +79,9 @@ class ProductTest
     # long after the parent data was destroyed.
     Artifact.where(:test_execution_id.in => test_execution_ids).destroy
     CQM::IndividualResult.where(:patient_id.in => patient_ids).delete
+    test_execution_ids.each do |test_execution_id|
+      CQM::IndividualResult.where(correlation_id: test_execution_id).delete
+    end
     ProductTest.in(id: product_test_ids).delete
   end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code