### PR TITLE
Additional eCQM changes for EC programs (#1857)

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -205,7 +205,7 @@ class ProductTest
   end
 
   def start_date
-    if hybrid_measures? && product.shift_patients
+    if timing_constraint? && product.shift_patients
       Date.parse(APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids.include? tc['hqmf_id'] }.start_time).in_time_zone
     else
       Time.at(product.measure_period_start).in_time_zone
@@ -213,11 +213,21 @@ class ProductTest
   end
 
   def end_date
-    if hybrid_measures? && product.shift_patients
+    if timing_constraint? && product.shift_patients
       Date.parse(APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids.include? tc['hqmf_id'] }.end_time).in_time_zone
     else
       Time.at(product.effective_date).in_time_zone
     end
+  end
+
+  def timing_constraint?
+    APP_CONSTANTS['timing_constraints'].any? { |tc| measure_ids.include? tc['hqmf_id'] }
+  end
+
+  def additional_shift
+    shifted_start = Date.parse(APP_CONSTANTS['timing_constraints'].detect { |tc| measure_ids.include? tc['hqmf_id'] }.start_time).in_time_zone
+    product_start = Time.at(product.measure_period_start).in_time_zone
+    shifted_start - product_start
   end
 
   def update_with_checklist_tests(checklist_test_params)

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -432,6 +432,10 @@ timing_constraints:
     start_time : '20240701'
     end_time : '20250630'
     quarters : [['20240701', '20240930'],['20241001', '20241231'], ['20250101', '20250331'],['20250401', '20250630']]
+  # CMS1056v1
+  - hqmf_id : '2C928082-86DB-6718-0186-E05C1EB0010E'
+    start_time : '20250101'
+    end_time : '20251231'
 
 telehealth_modifier_codes:
   [ '95', 'GQ', 'GT' ]
@@ -452,6 +456,15 @@ overidden_category:
   # CMS161v12
   - hqmf_id : '2C928084-82EA-D7C5-0182-FED24F5E08CF'
     category : 'Retired'
+  # CMS314v1
+  - hqmf_id : '2C928082-86DB-6718-0187-03D1ACEE0811'
+    category : 'Eligible Clinician eCQMs'
+  # CMS1188v1
+  - hqmf_id : '2C928082-86DB-6718-0186-E6F01B5C037F'
+    category : 'Eligible Clinician eCQMs'
+  # CMS1056v1
+  - hqmf_id : '2C928082-86DB-6718-0186-E05C1EB0010E'
+    category : 'Eligible Clinician eCQMs (2025 Performance Period)'
 
 
 unit_matches:

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -41,7 +41,7 @@ module Cypress
       if @test.product.shift_patients
         date_shift = @test.bundle.start_date_offset
         # for hybrid_measures, shift an additional 6 months to account for July-June Measurement Period
-        date_shift += 15_638_400 if @test.hybrid_measures?
+        date_shift += @test.additional_shift if @test.timing_constraint?
         patients.each do |patient|
           patient.qdmPatient.shift_dates(date_shift)
         end


### PR DESCRIPTION
* Additional eCQM changes for EC programs

* rename bundle_start to product_start

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code