### PR TITLE
remove second cqm execution service

### DIFF
--- a/contrib/upgrade_cypress_70.sh
+++ b/contrib/upgrade_cypress_70.sh
@@ -26,12 +26,12 @@ apt-get update
 if [ $(dpkg-query -W -f='${Status}' cypress 2>/dev/null | grep -c "ok installed") -eq 1 ];
 then
   printf "${GREEN}---> Attempting to upgrade Cypress...${NC}\n"
-  apt-get -y --allow-change-held-packages install cypress cqm-execution-service cqm-execution-service-55
+  apt-get -y --allow-change-held-packages install cypress cqm-execution-service
   cypress run rake db:migrate
-  systemctl restart cypress cqm-execution-service cqm-execution-service-55
+  systemctl restart cypress cqm-execution-service
   cypress run rake tmp:cache:clear
   cypress run rake db:migrate
-  systemctl restart cypress cqm-execution-service cqm-execution-service-55
+  systemctl restart cypress cqm-execution-service
   cypress run rake tmp:cache:clear
 else
   printf "${RED}---> Cypress not found, continuing...${NC}\n"


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code