### PR TITLE
When grouping related Data Elements, match the id as a string

### DIFF
--- a/lib/cypress/clinical_randomizer.rb
+++ b/lib/cypress/clinical_randomizer.rb
@@ -137,7 +137,7 @@ module Cypress
     end
 
     def self.group_reference(related, grouped_de, data_elements, added)
-      match_idx = data_elements.index { |x| x.id == related }
+      match_idx = data_elements.index { |x| x.id.to_s == related }
 
       # if can't find reference
       return unless match_idx


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code