### PR TITLE
use a different 'Other' payer code

### DIFF
--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -428,8 +428,9 @@ class ProductTest
     # Since this is a CMS IG requirement, only do this for CVU+ or C3 tests
     return expected_results unless product.cvuplus? || product.c3_test?
 
-    required_codes = { 'PAYER' => %w[1 2 6 349], 'SEX' => %w[M F], 'RACE' => %w[2106-3 2076-8 2054-5 2028-9 1002-5 2131-1],
+    required_codes = { 'PAYER' => %w[1 2 6 9 349], 'SEX' => %w[M F], 'RACE' => %w[2106-3 2076-8 2054-5 2028-9 1002-5 2131-1],
                        'ETHNICITY' => %w[2135-2 2186-5] }.freeze
+    equivalent_codes = { '9' => '349', '349' => '9' }
     new_hash = expected_results
     new_hash.each_value do |pop_set_hash|
       pop_set_hash.each_value do |pop_set|
@@ -440,7 +441,7 @@ class ProductTest
           sup_data[pop_key] = { 'RACE' => {}, 'ETHNICITY' => {}, 'SEX' => {}, 'PAYER' => {} } unless sup_data[pop_key]
           required_codes.each do |sup_data_type, codes|
             codes.each do |code|
-              sup_data[pop_key][sup_data_type][code] = 0 unless sup_data[pop_key][sup_data_type][code]
+              sup_data[pop_key][sup_data_type][code] = 0 unless (sup_data[pop_key][sup_data_type][code] || sup_data[pop_key][sup_data_type][equivalent_codes[code]])
             end
           end
         end

--- a/app/models/product_test.rb
+++ b/app/models/product_test.rb
@@ -423,6 +423,7 @@ class ProductTest
     self.rand_seed = Random.new_seed.to_s unless rand_seed
   end
 
+  # rubocop:disable Metrics/MethodLength
   # Adds 0's for all missing populations (e.g., if DENEX is 0) or missing demographics (e.g., no Payer 349 in the DENEX)
   def expected_results_with_all_supplemental_codes
     # Since this is a CMS IG requirement, only do this for CVU+ or C3 tests
@@ -441,7 +442,9 @@ class ProductTest
           sup_data[pop_key] = { 'RACE' => {}, 'ETHNICITY' => {}, 'SEX' => {}, 'PAYER' => {} } unless sup_data[pop_key]
           required_codes.each do |sup_data_type, codes|
             codes.each do |code|
-              sup_data[pop_key][sup_data_type][code] = 0 unless (sup_data[pop_key][sup_data_type][code] || sup_data[pop_key][sup_data_type][equivalent_codes[code]])
+              unless sup_data[pop_key][sup_data_type][code] || sup_data[pop_key][sup_data_type][equivalent_codes[code]]
+                sup_data[pop_key][sup_data_type][code] = 0
+              end
             end
           end
         end
@@ -449,5 +452,6 @@ class ProductTest
     end
     new_hash
   end
+  # rubocop:enable Metrics/MethodLength
 end
 # rubocop:enable Metrics/ClassLength

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -128,18 +128,28 @@ randomization:
       codeSystem     : 2.16.840.1.113883.3.221.5
       codeSystemName : SOP
       codeCMS        : A
+      useInExport    : true
     - type           : MC
       code           : 2
       name           : Medicaid
       codeSystem     : 2.16.840.1.113883.3.221.5
       codeSystemName : SOP
       codeCMS        : B
+      useInExport    : true
     - type           : OT
       code           : 349
       name           : Other
       codeSystem     : 2.16.840.1.113883.3.221.5
       codeSystemName : SOP
       codeCMS        : D
+      useInExport    : false
+    - type           : OT
+      code           : 9
+      name           : MISCELLANEOUS/OTHER
+      codeSystem     : 2.16.840.1.113883.3.221.5
+      codeSystemName : SOP
+      codeCMS        : D
+      useInExport    : true
 references:
   bundles:
     current:

--- a/lib/cypress/demographics_randomizer.rb
+++ b/lib/cypress/demographics_randomizer.rb
@@ -159,12 +159,13 @@ module Cypress
     end
 
     def self.sample_payer(patient, prng)
-      payer_hash = APP_CONSTANTS['randomization']['payers'].sample(random: prng)
+      exportable_payer = APP_CONSTANTS['randomization']['payers'].select { |payer| payer['useInExport'] == true }
+      payer_hash = exportable_payer.sample(random: prng)
       # Some measures need Medicare patients, inflate the probability by trying again if one isn't found the first time
-      payer_hash = APP_CONSTANTS['randomization']['payers'].sample(random: prng) unless payer_hash['name'] == 'Medicare'
+      payer_hash = exportable_payer.sample(random: prng) unless payer_hash['name'] == 'Medicare'
       while payer_hash['name'] == 'Medicare' &&
             Time.at(patient.qdmPatient.birthDatetime).in_time_zone > Time.at(patient.bundle.effective_date).in_time_zone.years_ago(65)
-        payer_hash = APP_CONSTANTS['randomization']['payers'].sample
+        payer_hash = exportable_payer.sample
       end
       payer_hash
     end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code