### PR TITLE
Display the Direct Reference Code and not the OID in the checklist test

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -75,7 +75,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       mongodb:
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     services:
       mongodb:

--- a/Gemfile
+++ b/Gemfile
@@ -113,6 +113,7 @@ group :development, :test do
   gem 'cucumber-rails', require: false
   gem 'database_cleaner-mongoid'
   gem 'overcommit'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
   gem 'poltergeist'
   gem 'pry'
   gem 'pry-nav'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -428,6 +428,7 @@ GEM
     parser (3.3.6.0)
       ast (~> 2.4.1)
       racc
+    phantomjs (2.1.1.0)
     poltergeist (1.18.1)
       capybara (>= 2.1, < 4)
       cliver (~> 0.3.1)
@@ -716,6 +717,7 @@ DEPENDENCIES
   newrelic_rpm
   os
   overcommit
+  phantomjs
   poltergeist
   pry
   pry-nav

--- a/app/helpers/checklist_tests_helper.rb
+++ b/app/helpers/checklist_tests_helper.rb
@@ -72,6 +72,15 @@ module ChecklistTestsHelper
     vs.first.display_name
   end
 
+  def valueset_oid_or_code(oid)
+    return oid unless direct_reference_code?(oid)
+
+    vs = ValueSet.where(oid:)
+    return oid unless vs&.first
+
+    vs.first.concepts.first.code
+  end
+
   def lookup_valueset_long_name(oid)
     vs = ValueSet.where(oid:)
     return oid unless vs&.first

--- a/app/views/checklist_tests/_checklist_measure.html.erb
+++ b/app/views/checklist_tests/_checklist_measure.html.erb
@@ -93,7 +93,7 @@
                             <%= icon('fas fa-fw text-danger', 'times', :"aria-hidden" => true) %>
                             <% end %>
                             <% if criteria_field.object.negated_valueset %>
-                           <%= criteria_field.select :selected_negated_valueset, valuessets.collect{ |vs| ["#{lookup_valueset_name(vs)} - #{vs}", vs] }, class: 'hide-me' %>
+                           <%= criteria_field.select :selected_negated_valueset, valuessets.collect{ |vs| ["#{lookup_valueset_name(vs)} - #{valueset_oid_or_code(vs)}", vs] }, class: 'hide-me' %>
                             <% else %>
                               <%= criteria_field.text_field :code, hide_label: false, class: 'hide-me' %>
                             <% end %>

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,6 +6,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
+require 'phantomjs'
 SimpleCov.start 'rails'
 
 module SimpleCov
@@ -37,6 +38,10 @@ require 'capybara/poltergeist'
 require 'capybara/accessible'
 
 require 'axe-cucumber-steps'
+
+Capybara.register_driver :poltergeist do |app|
+  Capybara::Poltergeist::Driver.new(app, phantomjs: Phantomjs.path)
+end
 
 def default_drivers
   if ENV['IN_BROWSER']

--- a/test/helpers/checklist_tests_helper_test.rb
+++ b/test/helpers/checklist_tests_helper_test.rb
@@ -24,6 +24,18 @@ class ChecklistTestsHelperTest < ActiveSupport::TestCase
     assert_equal '', checklist_test_criteria_attribute(c1, 1)
   end
 
+  def test_valueset_oid_or_code
+    sb = FactoryBot.create(:static_bundle)
+    drc = sb.value_sets.detect { |value_set| value_set.oid[0, 3] == 'drc' }
+    drc_code = drc.concepts.first.code
+    # If the valueset is a direct reference code, the the method returns the code value
+    assert_equal valueset_oid_or_code(drc.oid), drc_code
+
+    # If the valueset is a valueset, the the method returns the oid
+    vs = sb.value_sets.detect { |value_set| value_set.oid[0, 3] != 'drc' }
+    assert_equal valueset_oid_or_code(vs.oid), vs.oid
+  end
+
   def test_available_attributes
     c1 = {}
     c1['dataElementAttributes'] = [{ 'attribute_name' => 'Test' }, { 'attribute_name' => 'id' }]


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code