### PR TITLE
MADiE measures have a different filename structure

### DIFF
--- a/lib/cypress/cql_bundle_importer.rb
+++ b/lib/cypress/cql_bundle_importer.rb
@@ -144,7 +144,7 @@ module Cypress
         FileUtils.rm_f(temp_file_path)
         measure_package_zipped.extract(temp_file_path)
         measure_package = File.new temp_file_path
-        cms_id = measure_package_zipped.name[%r{measures/(.*?)v}m, 1]
+        cms_id = measure_package_zipped.name.gsub('-', '')[%r{measures/(.*?)v}m, 1]
         measure_details = { 'episode_of_care' => measure_info[cms_id].episode_of_care }
         loader = Measures::CqlLoader.new(measure_package, measure_details)
         # will return an array of CQMMeasures, most of the time there will only be a single measure


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code