### PR TITLE
normalize gender_code before picking nickname

### DIFF
--- a/lib/cypress/name_randomizer.rb
+++ b/lib/cypress/name_randomizer.rb
@@ -28,7 +28,8 @@ module Cypress
         updated_name
       when 2 # nickname
         updated_name.each_index do |idx|
-          nicknames = NAMES_RANDOM['nicknames'][patient.gender][updated_name[idx]]
+          gender_code = %w[M 248153007].include?(patient.gender) ? 'M' : 'F'
+          nicknames = NAMES_RANDOM['nicknames'][gender_code][updated_name[idx]]
           updated_name[idx] = nickname(nicknames, updated_name[idx], random:)
         end
         updated_name


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code