### PR TITLE
QRDA files may have a null flavor value for gender

### DIFF
--- a/lib/cypress/qrda_post_processor.rb
+++ b/lib/cypress/qrda_post_processor.rb
@@ -176,7 +176,10 @@ module Cypress
     end
 
     def self.add_snomed_gender(patient)
-      gender_in_qrda = patient.qdmPatient.get_data_elements('patient_characteristic', 'gender').first.dataElementCodes.first[:code]
+      gender_elements = patient.qdmPatient.get_data_elements('patient_characteristic', 'gender')
+      return if gender_elements.empty?
+
+      gender_in_qrda = gender_elements.first.dataElementCodes.first[:code]
       return unless %w[M F].include?(gender_in_qrda)
 
       snomed_gender = gender_in_qrda == 'F' ? '248152002' : '248153007'


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code