### PR TITLE
update homepage css styling

### DIFF
--- a/app/assets/stylesheets/cypress/_sessions.scss
+++ b/app/assets/stylesheets/cypress/_sessions.scss
@@ -1,14 +1,15 @@
 .splash-panel {
   background: image-url('cypress_bg_cropped.png');
-  background-size: auto 310px;
-  background-repeat: repeat-x;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: center bottom;
 }
 
 .splash-title-container {
   display: inline-block;
-  margin-left: 50px;
-  margin-top: 35px;
-  width: 45%;
+  margin-left: 30px;
+  margin-top: 0px;
+  width: 100%;
   color: $secondary;
   text-align: left;
 
@@ -21,7 +22,7 @@
 
   h2 {
     font-size: 20px;
-    margin-top: 20px;
+    margin-top: 3px;
     margin-bottom: 5px;
     font-weight: 700;
   }
@@ -35,7 +36,9 @@
 .sign-in-panel {
   text-align: left;
   width: 300px;
-  margin-bottom: 0;
+  margin-top: 20px;
+  margin-right: 10px;
+  margin-bottom: 15px;
 }
 
 .sign-in-panel-wide {
@@ -65,16 +68,17 @@
 
 .sign-in-panel-container-moved {
 
-  .sign-in-panel-footer {
-    a {
-      color: $primary;
-    }
-  }
+  // .sign-in-panel-footer {
+  //   a {
+  //     color: $primary;
+  //   }
+  // }
 }
 
 .sign-in-panel-footer {
   margin-left: 0;
   text-align: left;
+  margin-bottom: 15px;
 
   a {
     color: $white;


### PR DESCRIPTION
Updated the css styling on the homepage. Looks good on all screen sizes.

<img width="3018" height="1570" alt="image" src="https://github.com/user-attachments/assets/5bee3e9a-3066-49dc-869f-0879a8b02947" />


Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code