### PR TITLE
Gender code should be a string

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -330,11 +330,11 @@ version_config:
             codeSystem     : 2.16.840.1.113883.6.238
             codeSystemName : CDC Race
         genders:
-          - code           : 248152002
+          - code           : '248152002'
             name           : Female
             codeSystem     : 2.16.840.1.113883.6.96
             codeSystemName : SNOMEDCT
-          - code           : 248153007
+          - code           : '248153007'
             name           : Male
             codeSystem     : 2.16.840.1.113883.6.96
             codeSystemName : SNOMEDCT


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code