### PR TITLE
Update dependencies for Docker images after update to 3.3.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     build-essential libpq-dev git \
-    nodejs npm tzdata
+    nodejs npm tzdata \
+    libyaml-dev pkg-config
 
 # App directory & non-root user
 ENV APP_HOME=/app
@@ -40,7 +41,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
     libcurl4 \
     # updates necessary to address cves
     openssl libssl3 libc6 libc-bin \ 
-    tzdata
+    tzdata procps
     # nodejs
 
 # Copy the built app & cached gems from the builder
@@ -74,7 +75,8 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     curl \
     build-essential libpq-dev git \
-    nodejs npm tzdata
+    nodejs npm tzdata \
+    libyaml-dev pkg-config procps
 
 # Copy only Gemfiles to install dependencies early
 WORKDIR /app


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code