### PR TITLE
bump docker image versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./docker/nginx:/docker/nginx:ro
       - ./docker/nginx/nginx-init.sh:/docker-entrypoint.d/nginx-init.sh:ro
   cypress:
-    image: mitrehealthdocker/cypress:cypress_v7
+    image: mitrehealthdocker/cypress:latest
     platform: linux/amd64
     # Uncomment build section below to build a new image from source
     # build:
@@ -42,7 +42,7 @@ services:
     command: --config=/etc/mongo/docker_mongod.conf
     restart: unless-stopped
   cqm-execution-service:
-    image: mitrehealthdocker/cqm-execution-service:cypress_v7
+    image: mitrehealthdocker/cqm-execution-service:latest
     platform: linux/amd64
     restart: unless-stopped
 volumes:


### PR DESCRIPTION
In addition to publishing the images with their specific release version "7.4.1", i also updated the "latest" tag to point to that. In the future, we won't have to update the docker compose file when we update new release versions to dockerhub, since I'll keep the "latest" tag in sync with the latest version.



Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code