### PR TITLE
fix ignore_roles toggle

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -45,7 +45,8 @@ class AdminController < ApplicationController
 
   def mode_custom(settings)
     Settings.current.update(auto_approve: settings['auto_approve'] == 'enable',
-                            ignore_roles: settings['ignore_roles'] == 'enable',
+                            # Interpret 'disable' option as ignoring roles (i.e., not enforcing them)
+                            ignore_roles: settings['ignore_roles'] == 'disable',
                             default_role: settings['default_role'] == 'None' ? '' : settings['default_role'].underscore.to_sym,
                             enable_debug_features: settings['debug_features'] == 'enable')
   end

--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -45,8 +45,7 @@ class AdminController < ApplicationController
 
   def mode_custom(settings)
     Settings.current.update(auto_approve: settings['auto_approve'] == 'enable',
-                            # Interpret 'disable' option as ignoring roles (i.e., not enforcing them)
-                            ignore_roles: settings['ignore_roles'] == 'disable',
+                            ignore_roles: settings['ignore_roles'] == 'enable',
                             default_role: settings['default_role'] == 'None' ? '' : settings['default_role'].underscore.to_sym,
                             enable_debug_features: settings['debug_features'] == 'enable')
   end

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -50,9 +50,9 @@
                 <%= custom_form.radio_button :auto_approve, "enable", label: "Enable", inline: true, checked: mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
                 <%= custom_form.radio_button :auto_approve, "disable", label: "Disable", inline: true, checked: !mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
               <% end %>
-              <%= custom_form.form_group :ignore_roles, label: { text: "Enforce Roles", id: "ignore-roles" } do %>
-                <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: !mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
-                <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
+              <%= custom_form.form_group :ignore_roles, label: { text: "Ignore Roles", id: "ignore-roles" } do %>
+                <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
+                <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: !mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
               <% end %>
               <%= custom_form.form_group :debug_features, label: { text: "Debug Features", id: "debug-features" } do %>
                 <%= custom_form.radio_button :debug_features, "enable", label: "Enable", inline: true, checked: mode_settings.debug_features, 'aria-labelledby' => "debug-features" %>


### PR DESCRIPTION
There was a bug in the UI, due to "Enforce Rules" being the toggle in the UI, and "ignore_rules" being the value in the data model. To replicate the bug, Edit Application Settings, selecting custom mode for application, make radio button selections and click "Edit Settings" at the bottom of the form. Click Edit Application Settings again, and notice that Enforce Rules has changed. By making the toggle name to match the data model, and then updating the radio buttons to be correctly selected based on the data model, the value is no longer flipped on settings update.

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code