### PR TITLE
always shift atleast 1 day when randomizing

### DIFF
--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -78,7 +78,7 @@ module Cypress
       random_patients.each do |patient|
         seconds_in_day = 86_400 # 60 secs per min * 60 min per hour * 24 hours
         plus_minus = prng.rand(2).zero? ? 1 : -1 # use this to make move dates forward or backwards
-        date_shift = prng.rand(10) * seconds_in_day * plus_minus
+        date_shift = prng.rand(1..10) * seconds_in_day * plus_minus
         patient.qdmPatient.shift_dates(date_shift)
         patients << patient
       end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code