### PR TITLE
fix ignore_roles toggle (#1964)

### DIFF
--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -50,9 +50,9 @@
                 <%= custom_form.radio_button :auto_approve, "enable", label: "Enable", inline: true, checked: mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
                 <%= custom_form.radio_button :auto_approve, "disable", label: "Disable", inline: true, checked: !mode_settings.auto_approve, 'aria-labelledby' => "auto-approve" %>
               <% end %>
-              <%= custom_form.form_group :ignore_roles, label: { text: "Enforce Roles", id: "ignore-roles" } do %>
-                <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: !mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
-                <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
+              <%= custom_form.form_group :ignore_roles, label: { text: "Ignore Roles", id: "ignore-roles" } do %>
+                <%= custom_form.radio_button :ignore_roles, "enable", label: "Enable", inline: true, checked: mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
+                <%= custom_form.radio_button :ignore_roles, "disable", label: "Disable", inline: true, checked: !mode_settings.ignore_roles, 'aria-labelledby' => "ignore-roles" %>
               <% end %>
               <%= custom_form.form_group :debug_features, label: { text: "Debug Features", id: "debug-features" } do %>
                 <%= custom_form.radio_button :debug_features, "enable", label: "Enable", inline: true, checked: mode_settings.debug_features, 'aria-labelledby' => "debug-features" %>


### PR DESCRIPTION
* fix

* update

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code