### PR TITLE
render human readable dates in patient reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'mustache'
 
 gem 'cqm-models', '~> 4.2.0'
 gem 'cqm-parsers', '~> 4.1.1.1'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'fix/human-friendly-datetimes'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'master'
 gem 'cqm-validators', '~> 4.0.6'
 
 # # Use faker to generate addresses

--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ gem 'mustache'
 
 gem 'cqm-models', '~> 4.2.0'
 gem 'cqm-parsers', '~> 4.1.1.1'
-gem 'cqm-reports', '~> 4.1.4'
+gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'fix/human-friendly-datetimes'
 gem 'cqm-validators', '~> 4.0.6'
 
 # # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,21 @@
 GIT
+  remote: https://github.com/projecttacoma/cqm-reports
+  revision: c7782fa11fafc88e491ccd4a9a7625bba4131e0c
+  branch: fix/human-friendly-datetimes
+  specs:
+    cqm-reports (4.1.4)
+      cqm-models (~> 4.0)
+      cqm-validators (~> 4.0)
+      erubis (~> 2.7)
+      log4r (~> 1.1)
+      memoist (~> 0.9)
+      mongoid-tree (> 2.0)
+      mustache
+      nokogiri (>= 1.16.2)
+      uuid (~> 2.3)
+      zip-zip (~> 0.3)
+
+GIT
   remote: https://github.com/turbolinks/turbolinks-classic
   revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
   branch: master
@@ -183,17 +200,6 @@ GEM
       rubyzip (~> 1.3)
       typhoeus
       uuid (~> 2.3.7)
-      zip-zip (~> 0.3)
-    cqm-reports (4.1.4)
-      cqm-models (~> 4.0)
-      cqm-validators (~> 4.0)
-      erubis (~> 2.7)
-      log4r (~> 1.1)
-      memoist (~> 0.9)
-      mongoid-tree (> 2.0)
-      mustache
-      nokogiri (>= 1.16.2)
-      uuid (~> 2.3)
       zip-zip (~> 0.3)
     cqm-validators (4.0.6)
       nokogiri (>= 1.16.2)
@@ -735,7 +741,7 @@ DEPENDENCIES
   codecov
   cqm-models (~> 4.2.0)
   cqm-parsers (~> 4.1.1.1)
-  cqm-reports (~> 4.1.4)
+  cqm-reports!
   cqm-validators (~> 4.0.6)
   cucumber-rails
   dartsass-sprockets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/projecttacoma/cqm-reports
-  revision: c7782fa11fafc88e491ccd4a9a7625bba4131e0c
-  branch: fix/human-friendly-datetimes
+  revision: 876e8488e835a853c14b510768926f709947127f
+  branch: master
   specs:
     cqm-reports (4.1.4)
       cqm-models (~> 4.0)

--- a/test/unit/html_test.rb
+++ b/test/unit/html_test.rb
@@ -33,7 +33,7 @@ class HTMLTest < ActiveSupport::TestCase
 
       if dt[ta[2]].respond_to?(:strftime)
         # timey object
-        formatted_date = dt[ta[2]].strftime('%FT%T')
+        formatted_date = dt[ta[2]].in_time_zone.strftime('%B %e, %Y %l:%M%P')
         assert html.include?(formatted_date), "html should include date/time value #{formatted_date}"
       elsif dt[ta[2]].is_a?(Array)
         # components, relatedTo (irrelevant), facilityLocations, diagnoses (all code or nested code)
@@ -52,7 +52,7 @@ class HTMLTest < ActiveSupport::TestCase
         assert html.include?(dt[ta[2]].to_s), "html should include text value #{dt[ta[2]]}"
       elsif dt[ta[2]].respond_to?(:low)
         # interval (may or may not include high)
-        formatted_date = dt[ta[2]].low.strftime('%FT%T')
+        formatted_date = dt[ta[2]].low.in_time_zone.strftime('%B %e, %Y %l:%M%P')
         assert html.include?(formatted_date), "html should include low value #{formatted_date}"
       elsif dt[ta[2]].respond_to?(:code)
         verify_code_in_html(dt[ta[2]], html)


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code