### PR TITLE
bump jbuilder version to address ActiveSupport::ProxyObject deprecation warnings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ gem 'local_time', '~> 2.0.0'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
 gem 'turbolinks', git: 'https://github.com/turbolinks/turbolinks-classic', branch: 'master'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.11.0'
+gem 'jbuilder', '~> 2.14', '>= 2.14.1'
 # A set of responders modules to dry up your Rails 4.2+ app.
 gem 'responders'
 # Roar is a framework for parsing and rendering REST documents

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,9 +334,9 @@ GEM
       reline (>= 0.4.2)
     jasny-bootstrap-rails (3.1.3)
       railties (>= 3.0)
-    jbuilder (2.11.5)
-      actionview (>= 5.0.0)
-      activesupport (>= 5.0.0)
+    jbuilder (2.14.1)
+      actionview (>= 7.0.0)
+      activesupport (>= 7.0.0)
     jquery-datatables-rails (3.4.0)
       actionpack (>= 3.1)
       jquery-rails
@@ -753,7 +753,7 @@ DEPENDENCIES
   faker (> 1.5.0)
   font-awesome-sass (~> 5.0.13)
   jasny-bootstrap-rails
-  jbuilder (~> 2.11.0)
+  jbuilder (~> 2.14, >= 2.14.1)
   jquery-datatables-rails
   jquery-rails
   jquery-ui-rails (~> 8.0.0)


### PR DESCRIPTION
Addresses deprecation warnings on app startup seen in screenshot below.

<img width="2934" height="1760" alt="image" src="https://github.com/user-attachments/assets/d07f2de5-341f-4a92-9350-5f3707f0baa1" />





Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code