### PR TITLE
reset IDs in config file after the test completes

### DIFF
--- a/test/models/cms_program_task_test.rb
+++ b/test/models/cms_program_task_test.rb
@@ -175,6 +175,7 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
 
   def test_eh_task_with_future_date_warning
     setup_eh
+    original_measure_ids = APP_CONSTANTS['measures_without_future_data']
     pt = @product.product_tests.cms_program_tests.where(cms_program: 'HQR_PI').first
     APP_CONSTANTS['measures_without_future_data'] = pt.measure_ids
     task = pt.tasks.first
@@ -185,6 +186,8 @@ class CMSProgramTaskTest < ActiveSupport::TestCase
       msg = 'QDM::EncounterPerformed that occurs after the Performance Period on 09/28/2027 was not used in calculation for CMS32v7.'
       assert te.execution_errors.where(message: msg).size.positive?
     end
+    # Reset IDs when done
+    APP_CONSTANTS['measures_without_future_data'] = original_measure_ids
   end
 
   def test_eh_task_with_multiple_entered_values


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code