### PR TITLE
improve load times

### DIFF
--- a/app/helpers/products_helper.rb
+++ b/app/helpers/products_helper.rb
@@ -118,9 +118,9 @@ module ProductsHelper
 
     case task
     when C1Task
-      return [task, task.product_test.tasks.c3_cat1_task] if task.product_test.c3_cat1_task?
+      return [task, task.product_test.tasks.c3_cat1_task].compact
     when C2Task
-      return [task, task.product_test.tasks.c3_cat3_task] if task.product_test.c3_cat3_task?
+      return [task, task.product_test.tasks.c3_cat3_task].compact
     end
     [task]
   end

--- a/lib/cypress/product_status_values.rb
+++ b/lib/cypress/product_status_values.rb
@@ -91,7 +91,7 @@ module Cypress
     end
 
     def product_test_statuses(tests, task_type)
-      tasks = tests.map { |test| test.tasks.where(_type: task_type) }
+      tasks = tests.map { |test| test.tasks.only(:status, :updated_at, :latest_test_execution_id).where(_type: task_type).to_a }
       tasks.empty? ? [0, 0, 0, 0, 0] : tasks_values(tasks)
     end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code