### PR TITLE
fix/form-ui-tweaks

### DIFF
--- a/app/assets/stylesheets/cypress/_forms.scss
+++ b/app/assets/stylesheets/cypress/_forms.scss
@@ -17,6 +17,23 @@
   }
 }
 
+.form-check {
+  margin-bottom: 10px !important;
+}
+
+.form-check .form-check-input {
+  border-color: #9d9d9d !important;
+}
+
+.control-label {
+  margin-bottom: 6px !important;
+}
+
+.form-check .form-check-label {
+  margin: 0px !important;
+  padding: 0px !important;
+}
+
 // need to overwrite .input-group-addon colors when buttons are involved
 @each $state in primary, success, danger, warning, info, default {
   .input-group-addon.btn-#{$state} {


### PR DESCRIPTION
Careful attention made not to break other forms in Cypress. Checked throughout the application and all forms I saw looked good.

<img width="1512" height="555" alt="Screenshot 2025-10-02 at 11 05 34 AM" src="https://github.com/user-attachments/assets/6c7e1215-3b55-4631-84ca-965e6f9dd1c3" />






Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code