### PR TITLE
Tin in qrda

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -274,14 +274,29 @@ jobs:
       run: |
         RUBYOPT="-W0"
         bin/rails test test/unit/lib/*.rb;
+    - name: Upload code coverage to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        directory: coverage
+        name: codecov-unit-2-lib
     - name: Run Rake test units lib cypress
       run: |
         RUBYOPT="-W0"
         bin/rails test test/unit/lib/cypress/*.rb;
+    - name: Upload code coverage to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        directory: coverage
+        name: codecov-unit-2-lib-cypress
     - name: Run Rake test units lib validators
       run: |
         RUBYOPT="-W0"
         bin/rails test test/unit/lib/validators/*.rb;
+    - name: Upload code coverage to codecov.io
+      uses: codecov/codecov-action@v3
+      with:
+        directory: coverage
+        name: codecov-unit-2-validators
     - name: Run Rake test models
       run: |
         RUBYOPT="-W0"
@@ -290,7 +305,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         directory: coverage
-        name: codecov-unit-2
+        name: codecov-unit-2-models
 
   controllers-jobs-helpers-test:
     strategy:

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'mustache'
 ## gem 'os'
 
 gem 'cqm-models', '~> 4.2.0'
-gem 'cqm-parsers', git: 'https://github.com/projecttacoma/cqm-parsers', branch: 'master'
-gem 'cqm-reports', git: 'https://github.com/projecttacoma/cqm-reports', branch: 'master'
+gem 'cqm-parsers', '~> 4.1.1.2'
+gem 'cqm-reports', '~> 4.1.5'
 gem 'cqm-validators', '~> 4.0.6'
 
 # # Use faker to generate addresses

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,43 +1,4 @@
 GIT
-  remote: https://github.com/projecttacoma/cqm-parsers
-  revision: 5b7faee19af2c3eb5bb1f98ed9388a1919277af2
-  branch: master
-  specs:
-    cqm-parsers (4.1.1.1)
-      activesupport (> 5.0)
-      builder (~> 3.1)
-      cqm-models (> 3.0.0)
-      erubis (~> 2.7.0)
-      highline (~> 1.7.0)
-      log4r (~> 1.1.10)
-      memoist (~> 0.9.1)
-      mongoid (> 6.0.5, < 10.0.0)
-      mongoid-tree (~> 2.3.0)
-      mustache
-      nokogiri (>= 1.16.2)
-      rubyzip (~> 1.3)
-      typhoeus
-      uuid (~> 2.3.7)
-      zip-zip (~> 0.3)
-
-GIT
-  remote: https://github.com/projecttacoma/cqm-reports
-  revision: 876e8488e835a853c14b510768926f709947127f
-  branch: master
-  specs:
-    cqm-reports (4.1.4)
-      cqm-models (~> 4.0)
-      cqm-validators (~> 4.0)
-      erubis (~> 2.7)
-      log4r (~> 1.1)
-      memoist (~> 0.9)
-      mongoid-tree (> 2.0)
-      mustache
-      nokogiri (>= 1.16.2)
-      uuid (~> 2.3)
-      zip-zip (~> 0.3)
-
-GIT
   remote: https://github.com/turbolinks/turbolinks-classic
   revision: 80216ce9d89920bf073709405e3fce6d0a3ccd9a
   branch: master
@@ -204,6 +165,33 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     cqm-models (4.2.0)
+    cqm-parsers (4.1.1.2)
+      activesupport (> 5.0)
+      builder (~> 3.1)
+      cqm-models (> 3.0.0)
+      erubis (~> 2.7.0)
+      highline (~> 1.7.0)
+      log4r (~> 1.1.10)
+      memoist (~> 0.9.1)
+      mongoid (> 6.0.5, < 10.0.0)
+      mongoid-tree (~> 2.3.0)
+      mustache
+      nokogiri (>= 1.16.2)
+      rubyzip (~> 1.3)
+      typhoeus
+      uuid (~> 2.3.7)
+      zip-zip (~> 0.3)
+    cqm-reports (4.1.5)
+      cqm-models (~> 4.0)
+      cqm-validators (~> 4.0)
+      erubis (~> 2.7)
+      log4r (~> 1.1)
+      memoist (~> 0.9)
+      mongoid-tree (> 2.0)
+      mustache
+      nokogiri (>= 1.16.2)
+      uuid (~> 2.3)
+      zip-zip (~> 0.3)
     cqm-validators (4.0.6)
       nokogiri (>= 1.16.2)
     crack (1.0.0)
@@ -728,8 +716,8 @@ DEPENDENCIES
   carrierwave-mongoid
   codecov
   cqm-models (~> 4.2.0)
-  cqm-parsers!
-  cqm-reports!
+  cqm-parsers (~> 4.1.1.2)
+  cqm-reports (~> 4.1.5)
   cqm-validators (~> 4.0.6)
   csv (~> 3.3, >= 3.3.5)
   cucumber-rails

--- a/app/controllers/vendors_controller.rb
+++ b/app/controllers/vendors_controller.rb
@@ -99,6 +99,7 @@ class VendorsController < ApplicationController
     # save preferences to vendor preferred_code_systems
     @vendor.preferred_code_systems = JSON.parse(params['vendor_preferences'])
     @vendor.preferred_ccn = params['preferred_ccn'] unless params['preferred_ccn'] == ''
+    @vendor.preferred_tin = params['preferred_tin'] unless params['preferred_tin'] == ''
     @vendor.save
     redirect_to vendor_path(@vendor)
   end

--- a/app/models/c1_task.rb
+++ b/app/models/c1_task.rb
@@ -12,6 +12,7 @@ class C1Task < Task
   def validators
     @validators = if product_test.c1_test
                     [::Validators::CalculatingSmokingGunValidator.new(product_test.measures, product_test.patients, product_test.id),
+                     ::Validators::TinValidator.new,
                      ::Validators::QrdaCat1Validator.new(product_test.bundle, false, product_test.c3_test, true, product_test.measures)]
                   else
                     # A C1 task is created whenever C3 is selected.  If C1 isn't also selected, this task doesn't perform any validations

--- a/app/models/measure_test.rb
+++ b/app/models/measure_test.rb
@@ -30,7 +30,8 @@ class MeasureTest < ProductTest
     return unless provider.nil?
 
     self.provider = Provider.generate_provider(measure_type: measures.first.reporting_program_type,
-                                               preferred_ccn: product.vendor.preferred_ccn)
+                                               preferred_ccn: product.vendor.preferred_ccn,
+                                               preferred_tin: product.vendor.preferred_tin)
   end
 
   # passing only if both c1 and c3_cat1 tasks pass

--- a/app/models/vendor.rb
+++ b/app/models/vendor.rb
@@ -21,6 +21,7 @@ class Vendor
   field :zip, type: String
   field :preferred_code_systems, type: Hash, default: {}
   field :preferred_ccn, type: String
+  field :preferred_tin, type: String
   field :favorite_user_ids, type: Array, default: []
   field :vendor_patient_analysis, type: Hash, default: {}
 

--- a/app/views/vendors/preferences.html.erb
+++ b/app/views/vendors/preferences.html.erb
@@ -27,6 +27,7 @@
     <div class="card-body">
       <%= f.text_field :preferred_ccn, help: 'Health IT may be tailored for certain facility types (e.g., Critical Access Hospitals 
 ).  In these scenarios it is appropriate to use a preferred CMS Certification Number appropriate for the facility.', label: 'Preferred CMS Certification Number', autocomplete: 'off', value: @vendor.preferred_ccn %>
+      <%= f.text_field :preferred_tin, help: 'Health IT may be tailored for certain provider.  It is appropriate to use a preferred TIN for the provider.', label: 'Preferred TIN', autocomplete: 'off', value: @vendor.preferred_tin %>
     </div>
     <div class="card-footer">
       <%= f.submit "Save", :class => "btn btn-primary", :id => "preferences_submit_button" %>

--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -646,6 +646,12 @@ ipp_relevant:
   - hqmf_id : 'AE5FE43D-8A38-4309-B098-231246CF5373'
     statements : [ 'Qualified Scan']
 
+# CMS2, CMS122, CMS165
+aco_measures_hqmf_set_ids:
+  [ 'F2986519-5A4E-4149-A8F2-AF0A1DC7F6BC',
+    'ABDC37CC-BAC6-4156-9B91-D1BE2C8B7268',
+    '9A031E24-3D9B-11E1-8634-00237D5BF174']
+
 # These measures do not 
 telehealth_ineligible_measures:
   # CMS22v9, CMS69v9, CMS142v9, CMS143v9, CMS771v2

--- a/lib/ext/cqm/provider.rb
+++ b/lib/ext/cqm/provider.rb
@@ -34,9 +34,10 @@ module CQM
       prov.specialty = default_specialty(options[:measure_type])
       prov.save!
       ccn = options[:preferred_ccn] || prov.ccn = rand(1..66).to_s.rjust(2, '0') + rand(1..9899).to_s.rjust(4, '0')
+      tin = options[:preferred_tin] || rand.to_s[2..10]
       # TODO: This seems wrong
       prov.ids.build(namingSystem: '2.16.840.1.113883.4.6', value: Cypress::NpiGenerator.generate)
-      prov.ids.build(namingSystem: '2.16.840.1.113883.4.2', value: rand.to_s[2..10])
+      prov.ids.build(namingSystem: '2.16.840.1.113883.4.2', value: tin)
       prov.ids.build(namingSystem: '2.16.840.1.113883.4.336', value: ccn)
       prov.save!
       prov

--- a/lib/validators/tin_validator.rb
+++ b/lib/validators/tin_validator.rb
@@ -19,11 +19,11 @@ module Validators
         unless reported_tin == expected_tin
           msg = "Reported TIN #{reported_tin} does not match Expected TIN #{expected_tin}.  " \
                 'You can configure expected TIN using Vendor Preferences.'
-          add_error(msg, file_name: options[:file_name])
+          add_warning(msg, file_name: options[:file_name])
         end
       else
-        msg = 'TIN needs to be reported for these measures to support ACO reporting.'
-        add_error(msg, file_name: options[:file_name])
+        msg = 'TIN should be reported for these measures to support ACO reporting.'
+        add_warning(msg, file_name: options[:file_name])
       end
     end
   end

--- a/lib/validators/tin_validator.rb
+++ b/lib/validators/tin_validator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Validators
+  class TinValidator < QrdaFileValidator
+    include Validators::Validator
+
+    def validate(file, options = {})
+      aco_measure_ids = Measure.where(hqmf_set_id: { '$in': APP_CONSTANTS['aco_measures_hqmf_set_ids'] }).distinct(:hqmf_id)
+      return unless aco_measure_ids.include?(options.task.product_test.measure_ids.first)
+
+      @document = get_document(file)
+      expected_tin = options.task.product_test.provider.tin
+
+      # Otherwise, look for the certification ID
+      tin_node = @document.at_xpath('//cda:documentationOf/cda:serviceEvent/cda:performer/cda:assignedEntity/' \
+                                    "cda:representedOrganization/cda:id[@root='2.16.840.1.113883.4.2']")
+      if tin_node
+        reported_tin = tin_node['extension']
+        unless reported_tin == expected_tin
+          msg = "Reported TIN #{reported_tin} does not match Expected TIN #{expected_tin}.  " \
+                'You can configure expected TIN using Vendor Preferences.'
+          add_error(msg, file_name: options[:file_name])
+        end
+      else
+        msg = 'TIN needs to be reported for these measures to support ACO reporting.'
+        add_error(msg, file_name: options[:file_name])
+      end
+    end
+  end
+end

--- a/lib/validators/tin_validator.rb
+++ b/lib/validators/tin_validator.rb
@@ -22,7 +22,7 @@ module Validators
           add_warning(msg, file_name: options[:file_name])
         end
       else
-        msg = 'TIN should be reported for these measures to support ACO reporting.'
+        msg = 'TIN should be reported for this measure to support ACO reporting.'
         add_warning(msg, file_name: options[:file_name])
       end
     end

--- a/lib/validators/tin_validator.rb
+++ b/lib/validators/tin_validator.rb
@@ -22,7 +22,7 @@ module Validators
           add_warning(msg, file_name: options[:file_name])
         end
       else
-        msg = 'TIN should be reported for this measure to support ACO reporting.'
+        msg = "The Provider's TIN should be reported for this measure to support ACO reporting."
         add_warning(msg, file_name: options[:file_name])
       end
     end

--- a/test/fixtures/qrda/cat_I/sample_patient_no_tin.xml
+++ b/test/fixtures/qrda/cat_I/sample_patient_no_tin.xml
@@ -146,8 +146,6 @@
           <!-- This is the provider NPI -->
           <id extension="111111111" root="2.16.840.1.113883.4.6"/>
           <representedOrganization>
-            <!-- This is the organization TIN -->
-            <id extension="1520670765" root="2.16.840.1.113883.4.2"/>
             <!-- This is the organization CCN -->
             <id extension="54321" root="2.16.840.1.113883.4.336"/>
           </representedOrganization>

--- a/test/models/product_test_test.rb
+++ b/test/models/product_test_test.rb
@@ -97,6 +97,30 @@ class ProductTestTest < ActiveJob::TestCase
     assert_not_equal test1.provider.ccn, test2.provider.ccn
   end
 
+  def test_preferred_tin
+    # setup product
+    measure_ids = ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+    @product.update(c1_test: true, c2_test: true, c3_test: true, c4_test: true, randomize_patients: true,
+                    duplicate_patients: true, allow_duplicate_names: true, measure_ids:)
+    vendor2 = FactoryBot.create(:vendor)
+    vendor2.preferred_tin = '123456789'
+    product2 = vendor2.products.create(name: 'test_product', c2_test: true, randomize_patients: true,
+                                       bundle_id: @bundle.id, measure_ids:)
+
+    test1 = {}
+    test2 = {}
+    perform_enqueued_jobs do
+      # create tests with same seed
+      seed = Random.new_seed
+      test1 = @product.product_tests.create({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
+                                              bundle_id: @bundle.id, rand_seed: seed }, MeasureTest)
+      test2 = product2.product_tests.create({ name: 'mtest', measure_ids: ['BE65090C-EB1F-11E7-8C3F-9A214CF093AE'],
+                                              bundle_id: @bundle.id, rand_seed: seed }, MeasureTest)
+    end
+    assert_equal '123456789', test2.provider.tin
+    assert_not_equal test1.provider.tin, test2.provider.tin
+  end
+
   # # # # # # # # # # # # # # # # # # # #
   #   H E L P E R   F U N C T I O N S   #
   # # # # # # # # # # # # # # # # # # # #

--- a/test/unit/lib/validators/tin_validator_test.rb
+++ b/test/unit/lib/validators/tin_validator_test.rb
@@ -33,7 +33,7 @@ class TinValidatorTest < ActiveSupport::TestCase
     @validator.validate(document, @options)
 
     assert_equal 1, @validator.errors.count, "Expected 1 error, got #{@validator.errors}"
-    assert @validator.errors.map(&:message).include?('TIN should be reported for this measure to support ACO reporting.')
+    assert @validator.errors.map(&:message).include?("The Provider's TIN should be reported for this measure to support ACO reporting.")
   end
 
   def test_no_warnings_when_not_aco_measure

--- a/test/unit/lib/validators/tin_validator_test.rb
+++ b/test/unit/lib/validators/tin_validator_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+class TinValidatorTest < ActiveSupport::TestCase
+  include ::Validators
+
+  def setup
+    @validator = Validators::TinValidator.new
+    @options = { task: FactoryBot.create(:task) }
+    APP_CONSTANTS['aco_measures_hqmf_set_ids'] = ['7B2A9277-43DA-4D99-9BEE-6AC271A07747']
+  end
+
+  def test_document_with_correct_tin
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
+    document = get_document(file)
+    @validator.validate(document, @options)
+
+    assert_equal 0, @validator.errors.count, "Expected 0 error, got #{@validator.errors}"
+  end
+
+  def test_document_with_incorrect_tin
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_single_code.xml')).read
+    document = get_document(file)
+    @validator.validate(document, @options)
+
+    assert_equal 1, @validator.errors.count, "Expected 1 error, got #{@validator.errors}"
+    assert @validator.errors.map(&:message).include?('Reported TIN 1234567 does not match Expected TIN 1520670765.  You can configure expected TIN using Vendor Preferences.')
+  end
+
+  def test_document_with_no_tin
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_no_tin.xml')).read
+    document = get_document(file)
+    @validator.validate(document, @options)
+
+    assert_equal 1, @validator.errors.count, "Expected 1 error, got #{@validator.errors}"
+    assert @validator.errors.map(&:message).include?('TIN should be reported for these measures to support ACO reporting.')
+  end
+
+  def test_no_warnings_when_not_aco_measure
+    APP_CONSTANTS['aco_measures_hqmf_set_ids'] = ['6B2A9277-43DA-4D99-9BEE-6AC271A07747']
+    file = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'sample_patient_good.xml')).read
+    document = get_document(file)
+    @validator.validate(document, @options)
+
+    assert_equal 0, @validator.errors.count, "Expected 0 error, got #{@validator.errors}"
+  end
+end

--- a/test/unit/lib/validators/tin_validator_test.rb
+++ b/test/unit/lib/validators/tin_validator_test.rb
@@ -33,7 +33,7 @@ class TinValidatorTest < ActiveSupport::TestCase
     @validator.validate(document, @options)
 
     assert_equal 1, @validator.errors.count, "Expected 1 error, got #{@validator.errors}"
-    assert @validator.errors.map(&:message).include?('TIN should be reported for these measures to support ACO reporting.')
+    assert @validator.errors.map(&:message).include?('TIN should be reported for this measure to support ACO reporting.')
   end
 
   def test_no_warnings_when_not_aco_measure


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code