### PR TITLE
Shift end dates

### DIFF
--- a/config/cypress.yml
+++ b/config/cypress.yml
@@ -652,6 +652,10 @@ aco_measures_hqmf_set_ids:
     'ABDC37CC-BAC6-4156-9B91-D1BE2C8B7268',
     '9A031E24-3D9B-11E1-8634-00237D5BF174']
 
+# CMS1017
+shift_encounter_ends_measure_ids:
+  [ 'E7B2323F-934A-4E2F-ABB1-3391011DC5B0']
+
 # These measures do not 
 telehealth_ineligible_measures:
   # CMS22v9, CMS69v9, CMS142v9, CMS143v9, CMS771v2

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -84,6 +84,7 @@ module Cypress
       end
     end
 
+    # rubocop:disable Metrics/MethodLength
     # if provider argument is nil, this function will assign a new provider based on the @option['providers'] and @option['generate_provider'] options
     def clone_and_save_patient(patient, prng, provider = nil, allow_dups: false)
       # This operates on the assumption that we are always cloning a patient for a product test.
@@ -106,6 +107,7 @@ module Cypress
       DemographicsRandomizer.update_demographic_codes(cloned_patient)
       randomize_entry_ids(cloned_patient) unless options['disable_randomization']
 
+      # Some measures report the length of stay.  There is an edge case around day light savings when the length can change due to timezone.
       shift_measure_ids = Measure.where(hqmf_set_id: { '$in': APP_CONSTANTS['shift_encounter_ends_measure_ids'] }).distinct(:hqmf_id)
       shift_encounter_ends(cloned_patient) if options['randomize_demographics'] && shift_measure_ids.include?(@test.measure_ids.first)
       # if the test is a multi measure test, restrict to a single code
@@ -114,6 +116,7 @@ module Cypress
       cloned_patient.save!
       cloned_patient
     end
+    # rubocop:enable Metrics/MethodLength
 
     def unnumerify(patient)
       [%w[0 ZERO], %w[1 ONE], %w[2 TWO], %w[3 THREE], %w[4 FOUR], %w[5 FIVE], %w[6 SIX], %w[7 SEVEN], %w[8 EIGHT], %w[9 NINE]].each do |replacement|
@@ -124,11 +127,15 @@ module Cypress
 
     def shift_encounter_ends(cloned_patient)
       cloned_patient.qdmPatient.get_data_elements('encounter', 'performed').each do |encounter|
-        encounter_length = (encounter.relevantPeriod.high - encounter.relevantPeriod.low) / (60 * 60)
+        encounter_length = (encounter.relevantPeriod.high.to_f - encounter.relevantPeriod.low.to_f) / (60 * 60)
         encounter_mod = encounter_length.modulo(24)
+        # Skip if encounter is less than 1 day or if the encounter end hour of day is not within an hour of the start hour of day
         next if (encounter_length < 23) || (encounter_mod < 23 && encounter_mod > 1)
 
-        shifted_rp = QDM::Interval.new(encounter.relevantPeriod.low, encounter.relevantPeriod.high + (60 * 60 * 22))
+        # Shift towards the middle of the day.  26 hours will shift a morning time 2 hours later. 22 will shift an afternoon time earlier.
+        hour_shift = encounter.relevantPeriod.high.hour < 12 ? 26 : 22
+
+        shifted_rp = QDM::Interval.new(encounter.relevantPeriod.low, encounter.relevantPeriod.high.to_time + (60 * 60 * hour_shift))
         encounter.relevantPeriod = shifted_rp
       end
     end

--- a/lib/cypress/population_clone_job.rb
+++ b/lib/cypress/population_clone_job.rb
@@ -105,6 +105,9 @@ module Cypress
       DemographicsRandomizer.randomize_race(cloned_patient, Random.new(0)) if cloned_patient.race == '2131-1'
       DemographicsRandomizer.update_demographic_codes(cloned_patient)
       randomize_entry_ids(cloned_patient) unless options['disable_randomization']
+
+      shift_measure_ids = Measure.where(hqmf_set_id: { '$in': APP_CONSTANTS['shift_encounter_ends_measure_ids'] }).distinct(:hqmf_id)
+      shift_encounter_ends(cloned_patient) if options['randomize_demographics'] && shift_measure_ids.include?(@test.measure_ids.first)
       # if the test is a multi measure test, restrict to a single code
       restrict_entry_codes(cloned_patient) if @test.is_a? MultiMeasureTest
       provider ? assign_existing_provider(cloned_patient, provider) : assign_provider(cloned_patient)
@@ -116,6 +119,17 @@ module Cypress
       [%w[0 ZERO], %w[1 ONE], %w[2 TWO], %w[3 THREE], %w[4 FOUR], %w[5 FIVE], %w[6 SIX], %w[7 SEVEN], %w[8 EIGHT], %w[9 NINE]].each do |replacement|
         patient.givenNames.map { |n| n.gsub!(replacement[0], replacement[1]) }
         patient.familyName.gsub!(replacement[0], replacement[1])
+      end
+    end
+
+    def shift_encounter_ends(cloned_patient)
+      cloned_patient.qdmPatient.get_data_elements('encounter', 'performed').each do |encounter|
+        encounter_length = (encounter.relevantPeriod.high - encounter.relevantPeriod.low) / (60 * 60)
+        encounter_mod = encounter_length.modulo(24)
+        next if (encounter_length < 23) || (encounter_mod < 23 && encounter_mod > 1)
+
+        shifted_rp = QDM::Interval.new(encounter.relevantPeriod.low, encounter.relevantPeriod.high + (60 * 60 * 22))
+        encounter.relevantPeriod = shifted_rp
       end
     end
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code