### PR TITLE
check for the existance of regenerate-secrets

### DIFF
--- a/contrib/upgrade_cypress_70.sh
+++ b/contrib/upgrade_cypress_70.sh
@@ -37,6 +37,31 @@ then
 else
   printf "${RED}---> Cypress not found, continuing...${NC}\n"
 fi
+
+# Ensure regenerate-secrets.service exists, then enable and run it
+SERVICE_FILE="/etc/systemd/system/regenerate-secrets.service"
+if [[ ! -f "$SERVICE_FILE" ]]; then
+    printf "${GREEN}---> Creating regenerate-secrets.service...${NC}\n"
+    cat > "$SERVICE_FILE" <<'EOF'
+[Unit]
+Description=Regenerate cypress secret keys
+Before=cypress.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c "/usr/bin/cypress config:set SECRET_KEY_BASE=$(/usr/bin/cypress run rails secret)"
+ExecStartPost=/bin/systemctl disable regenerate-secrets.service
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+  printf "${GREEN}---> Enabling and running regenerate-secrets.service...${NC}\n"
+  systemctl daemon-reload
+  systemctl enable --now regenerate-secrets.service
+  systemctl start regenerate-secrets
+fi
+
 #if description import flag true
 if [ "$desc" ]
 then


### PR DESCRIPTION

https://oncprojectracking.healthit.gov/support/browse/CYPRESS-2821

Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code