### PR TITLE
update to look for newer eCQMs on eCQI. The 2022 have been removed

### DIFF
--- a/test/helpers/test_executions_helper_test.rb
+++ b/test/helpers/test_executions_helper_test.rb
@@ -205,11 +205,11 @@ class TestExecutionHelper < ActiveSupport::TestCase
   end
 
   def test_ecqi_link
-    # test with a measure from the 2023 reporting period
-    bundle2022 = Bundle.create(version: '2022.5.0')
-    measure2022 = Measure.create(reporting_program_type: 'ep', cms_id: 'CMS161v11', bundle_id: bundle2022.id)
-    ecqi_url2022 = ecqi_link(measure2022.cms_id)
-    ecqi_request2022 = RestClient::Request.execute(method: :get, url: ecqi_url2022)
-    assert_equal 200, ecqi_request2022.code
+    # test with a measure from the 2025 reporting period
+    bundle2024 = Bundle.create(version: '2024.5.0')
+    measure2024 = Measure.create(reporting_program_type: 'ep', cms_id: 'CMS128v13', bundle_id: bundle2024.id)
+    ecqi_url2024 = ecqi_link(measure2024.cms_id)
+    ecqi_request2024 = RestClient::Request.execute(method: :get, url: ecqi_url2024)
+    assert_equal 200, ecqi_request2024.code
   end
 end


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code