### PR TITLE
disable turbo for action modal submits

### DIFF
--- a/app/views/application/_action_button.html.erb
+++ b/app/views/application/_action_button.html.erb
@@ -26,6 +26,6 @@
 <% modal_title ||= 'Remove Permanently' %>
 <% modal_message ||= '' %>
 
-<%= form_tag(action_path, method: button_action, class: 'inline-block') do %>
+<%= form_tag(action_path, method: button_action, class: 'inline-block', data: { turbo: false }) do %>
   <%= button_tag button_text, type: 'button', class: button_classes, data: { 'bs-toggle': 'modal', 'bs-target': '#action_modal', object_type: object_type, object_name: object_name, object_action: object_action, title: modal_title, message: modal_message } %>
 <% end %>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code