### PR TITLE
Certification Types radio buttons disappeared if add products failed

### DIFF
--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -22,7 +22,7 @@
               <legend class="control-label">Certification Types</legend>
               <div id="certifications_errors_container"></div>
 
-              <% if product.product_tests.blank? %>
+              <% if product.product_tests.none?(&:persisted?) %>
                 <%= f.form_group help: "Select the certification type Cypress should use to certify this product" do %>
                   <% APP_CONSTANTS['certifications'].each do |c, certification| %>
                     <% if c == 'C1' || c == 'C2' || c == 'C3' || c == 'C4'%>

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -2,7 +2,7 @@
   <div class="card card-default">
     <div class="card-header"><h1 class='card-title lead'><%= submit_text %><%= product.name ? ": "+ product.name : "" %></h1></div>
 
-    <%= bootstrap_form_for [product.vendor, product], html: { multipart: true, "data-parsley-validate": '','data-parsley-excluded': "input.disabled" }, data: { turbo: false } do |f| %>
+    <%= bootstrap_form_for [product.vendor, product], html: { multipart: true, data: { turbo: false }, "data-parsley-validate": true, "data-parsley-excluded": "[disabled], input[type=hidden]" } do |f| %>
       <div class="card-body">
         <div class="row">
           <div class="col-md-6">


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code