### PR TITLE
Make file upload boxes clickable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ gem 'devise_invitable'
 gem 'rolify'
 
 # Use Puma as the app server
-gem 'puma', '~> 6.6'
+gem 'puma', '~> 7.2.1'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -463,7 +463,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (6.6.1)
+    puma (7.2.1)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -743,7 +743,7 @@ DEPENDENCIES
   propshaft
   pry
   pry-nav
-  puma (~> 6.6)
+  puma (~> 7.2.1)
   rails (~> 8.0.0, >= 8.0.2.1)
   rails-controller-testing
   rails-perftest

--- a/app/views/products/_product_form.html.erb
+++ b/app/views/products/_product_form.html.erb
@@ -52,8 +52,9 @@
 
                   <div class="input-group">
                     <input type="text"
-                           class="form-control"
+                           class="form-control pointer-on-hover"
                            data-file-upload-target="filename"
+                           data-action="click->file-upload#pick keydown.enter->file-upload#pick keydown.space->file-upload#pick"
                            placeholder="No file selected"
                            readonly>
 

--- a/app/views/test_executions/_execution_upload.html.erb
+++ b/app/views/test_executions/_execution_upload.html.erb
@@ -36,8 +36,9 @@
 
     <div class="input-group">
       <input type="text"
-             class="form-control"
+             class="form-control pointer-on-hover"
              data-file-upload-target="filename"
+             data-action="click->file-upload#pick keydown.enter->file-upload#pick keydown.space->file-upload#pick"
              placeholder="No file selected"
              readonly>
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

These changes were added to make the file upload boxes themselves clickable again, not just the "Select Files" button.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code