### PR TITLE
Refresh task result status

### DIFF
--- a/app/controllers/test_executions_controller.rb
+++ b/app/controllers/test_executions_controller.rb
@@ -131,10 +131,11 @@ class TestExecutionsController < ApplicationController
   end
 
   def render_measure_tests_table_row_stream
+    task = Task.find(@task.id)
     render turbo_stream: turbo_stream.replace(
-      view_context.measure_tests_table_row_wrapper_id(@task),
+      view_context.measure_tests_table_row_wrapper_id(task),
       partial: 'products/measure_tests_table_row',
-      locals: { task: @task,
+      locals: { task: task,
                 has_eh_tests: @product.eh_tests?,
                 has_ep_tests: @product.ep_tests?,
                 html_id: test_execution_param(:html_id),

--- a/app/models/test_execution.rb
+++ b/app/models/test_execution.rb
@@ -23,11 +23,19 @@ class TestExecution
   belongs_to :task, touch: true
 
   before_save :verify_artifact
+  before_create :mark_task_latest_execution
   after_save :refresh_product_test_status
   after_destroy :refresh_product_test_status
 
   def verify_artifact
     artifact&.save
+  end
+
+  def mark_task_latest_execution
+    return unless task
+
+    task.latest_test_execution_id = id.to_s
+    task.set(latest_test_execution_id: id.to_s) if task.persisted?
   end
 
   def refresh_product_test_status

--- a/test/controllers/test_executions_controller_test.rb
+++ b/test/controllers/test_executions_controller_test.rb
@@ -155,6 +155,36 @@ class TestExecutionsControllerTest < ActionController::TestCase
     end
   end
 
+  test 'turbo create shows c2 and c3 results in progress after rerun' do
+    sign_in User.find(ADMIN)
+    @first_product.update!(c3_test: true)
+    c3_task = @first_test.tasks.create!({}, C3Cat3Task)
+    @first_c2_task.test_executions.create!(state: :passed, user: @vendor_user)
+    c3_task.test_executions.create!(state: :passed, user: @vendor_user)
+
+    post :create, params: turbo_create_params(@first_c2_task, xml_upload, include_c1: false)
+
+    assert_response :success
+    assert_equal 2, response.body.scan('In Progress').count
+  end
+
+  test 'turbo create shows c1 and c3 results in progress after rerun' do
+    sign_in User.find(ADMIN)
+    measure_ids = ['AE65090C-EB1F-11E7-8C3F-9A214CF093AE']
+    product = @vendor.products.create!(name: "my product #{rand}", c1_test: true, c3_test: true, bundle_id: @bundle_id,
+                                       measure_ids:)
+    test = product.product_tests.create!({ name: "my measure test #{rand}", measure_ids: }, MeasureTest)
+    c1_task = test.tasks.c1_task
+    c3_task = test.tasks.c3_cat1_task
+    c1_task.test_executions.create!(state: :passed, user: @vendor_user)
+    c3_task.test_executions.create!(state: :passed, user: @vendor_user)
+
+    post :create, params: turbo_create_params(c1_task, zip_upload, include_c1: true)
+
+    assert_response :success
+    assert_equal 2, response.body.scan('In Progress').count
+  end
+
   # need negative tests for user that does not have owner or vendor access
   test 'should be able to restrict access to create unauthorized users ' do
     C1Task.any_instance.stubs(:validators).returns([])
@@ -586,6 +616,19 @@ class TestExecutionsControllerTest < ActionController::TestCase
   def xml_upload
     xmlfile = Rails.root.join('test', 'fixtures', 'qrda', 'cat_III', 'ep_test_qrda_cat3_good.xml')
     Rack::Test::UploadedFile.new(xmlfile, 'application/xml')
+  end
+
+  def turbo_create_params(task, upload, include_c1:)
+    {
+      format: :turbo_stream,
+      task_id: task.id,
+      test_execution: {
+        results: upload,
+        html_id: include_c1 ? 'c1_c3_qrda_i' : 'c2_c3_qrda_iii',
+        include_c1: include_c1.to_s,
+        product_page_url: vendor_product_path(task.product_test.product.vendor, task.product_test.product)
+      }
+    }
   end
 
   def accepted_execution_show_attributes

--- a/test/models/c3_cat1_task_test.rb
+++ b/test/models/c3_cat1_task_test.rb
@@ -16,6 +16,16 @@ class C3Cat1TaskTest < ActiveSupport::TestCase
     assert(@task.validators.any? { |v| v.is_a?(MeasurePeriodValidator) })
   end
 
+  def test_new_execution_updates_cached_status_when_previous_execution_was_latest
+    @task.test_executions.create!(state: :passed, user: @user)
+    assert_equal 'passing', @test.reload.task_status('C3Cat1Task')
+
+    new_execution = @task.test_executions.create!(user: @user)
+
+    assert_equal new_execution.id.to_s, @task.reload.latest_test_execution_id
+    assert_equal 'pending', @test.reload.task_status('C3Cat1Task')
+  end
+
   def test_task_should_not_error_when_extra_record_included
     c1_task = @test.tasks.create!({}, C1Task)
     zip = File.new(Rails.root.join('test', 'fixtures', 'qrda', 'cat_I', 'ep_qrda_test_too_many_files.zip'))

--- a/test/models/c3_cat3_task_test.rb
+++ b/test/models/c3_cat3_task_test.rb
@@ -17,6 +17,16 @@ class C3Cat3TaskTest < ActiveSupport::TestCase
     assert(@task.validators.any? { |v| v.is_a?(MeasurePeriodValidator) })
   end
 
+  def test_new_execution_updates_cached_status_when_previous_execution_was_latest
+    @task.test_executions.create!(state: :passed, user: @user)
+    assert_equal 'passing', @test.reload.task_status('C3Cat3Task')
+
+    new_execution = @task.test_executions.create!(user: @user)
+
+    assert_equal new_execution.id.to_s, @task.reload.latest_test_execution_id
+    assert_equal 'pending', @test.reload.task_status('C3Cat3Task')
+  end
+
   def test_task_good_results_should_pass
     c2_task = @test.tasks.create({ expected_results: @test.expected_results }, C2Task)
     xml = Tempfile.new(['good_results_debug_file', '.xml'])


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

Updated test execution creation so newly created C1/C2 and sibling C3 executions immediately become the latest execution used for status caching. The product-page Turbo upload response now reloads the task before rendering, so both result columns show In Progress right after rerunning C1+C3 or C2+C3 tests.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code