### PR TITLE
change way jquery2-core is loaded

### DIFF
--- a/vendor/javascript/jquery2_global.js
+++ b/vendor/javascript/jquery2_global.js
@@ -1,6 +1,7 @@
-import $ from "jquery2-core";
+import "jquery2-core";
 
-// Make the imported instance the global one used by plugins
+const $ = window.jQuery || window.$;
+
 window.$ = $;
 window.jQuery = $;
 


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code