### PR TITLE
allow for deeper nesting to accommodate measures like CMS133v14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (8.0.0)
       railties (>= 3.2.16)
-    json (2.19.4)
+    json (2.21.1)
     kaminari-core (1.2.2)
     kaminari-mongoid (1.0.2)
       kaminari-core (~> 1.0)

--- a/lib/cypress/cqm_execution_calc.rb
+++ b/lib/cypress/cqm_execution_calc.rb
@@ -29,7 +29,7 @@ module Cypress
       post_data = { patients: @patients, measure:, valueSets: measure.value_sets, options: @options }
       # cqm-execution-service expects a field called value_set_oids which is really just our
       # oids field. There is a value_set_oids on the measure for this explicit purpose.
-      post_data = post_data.to_json(methods: %i[_type])
+      post_data = JSON.generate(post_data.as_json(methods: %i[_type]), max_nesting: 200)
       begin
         response = RestClient::Request.execute(method: :post, url: @connection_string, timeout: 120,
                                                payload: post_data, headers: { content_type: 'application/json' })


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code