### PR TITLE
filter tests were always displaying last updated seconds ago

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -332,7 +332,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (8.0.0)
       railties (>= 3.2.16)
-    json (2.21.1)
+    json (2.21.2)
     kaminari-core (1.2.2)
     kaminari-mongoid (1.0.2)
       kaminari-core (~> 1.0)
@@ -354,7 +354,7 @@ GEM
       nokogiri (>= 1.12.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap
@@ -400,7 +400,7 @@ GEM
     multi_json (1.20.1)
     multi_test (1.1.0)
     mustache (1.1.2)
-    net-imap (0.6.4.1)
+    net-imap (0.6.6)
       date
       net-protocol
     net-pop (0.1.2)

--- a/app/views/application/_certification_status_table.html.erb
+++ b/app/views/application/_certification_status_table.html.erb
@@ -1,4 +1,4 @@
-  <% if product.product_tests.first&.tasks&.first&.current_cached_status.nil? %>
+  <% if product.product_tests.any? { |pt| !pt.tasks.empty? && pt.tasks.first.current_cached_status.nil? } %>
     <% product.product_tests.each(&:rebuild_most_recent_product_test_status!) %>
   <% end %>
   

--- a/app/views/products/_filtering_test_status_display_body.html.erb
+++ b/app/views/products/_filtering_test_status_display_body.html.erb
@@ -22,8 +22,7 @@
           <%= render 'filtering_test_link', :test => test, :task => test.cat3_task, :parent_reloading => true, :html_id => html_id, :product_page_url => request.path %>
         </td>
         <td class="no-wrap"><%= icon('far fa-fw', 'clock', :"aria-hidden" => true) %>
-          <% updated_at_time = [test.cat3_task.updated_at, test.cat1_task.updated_at].max %>
-          <%= local_time_ago(updated_at_time) %></td>
+          <%= local_time_ago(test.updated_at) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/products/_filtering_test_status_display_body.html.erb
+++ b/app/views/products/_filtering_test_status_display_body.html.erb
@@ -22,7 +22,8 @@
           <%= render 'filtering_test_link', :test => test, :task => test.cat3_task, :parent_reloading => true, :html_id => html_id, :product_page_url => request.path %>
         </td>
         <td class="no-wrap"><%= icon('far fa-fw', 'clock', :"aria-hidden" => true) %>
-          <%= local_time_ago(test.updated_at) %></td>
+          <% updated_at_time = [test.cat3_task.updated_at, test.cat1_task.updated_at].max %>
+          <%= local_time_ago(updated_at_time) %></td>
       </tr>
     <% end %>
   </tbody>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code