### PR TITLE
Speed up admin page when loading users

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -7,7 +7,7 @@ class AdminController < ApplicationController
   def show
     @bundles = Bundle.order_by('deprecated asc').all
     # dont allow them to muck with their own account
-    @users = User.excludes(id: current_user.id).order_by(email: 1)
+    @users = User.excludes(id: current_user.id).includes(roles: :resource).order_by(email: 1)
     @system_usage_stats = Vmstat.snapshot
     locals_admin_show = Settings.locals_admin_show(application_mode_settings)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -48,6 +48,7 @@ class User
 
   has_many :test_executions, dependent: :nullify
 
+  index(email: 1)
   index(invitation_token: 1)
   index(invitation_by_id: 1)
 

--- a/app/views/admin/_user_list.html.erb
+++ b/app/views/admin/_user_list.html.erb
@@ -10,9 +10,9 @@
     </tr>
   </thead>
   <tbody>
-    <% User.order_by(email:  1).each do |user|
-    role = user.roles.where({resource_id: nil}).first
-    assignments = user.roles.where({resource_id: {"$ne"=> nil}})
+    <% @users.each do |user|
+    role = user.roles.find { |user_role| user_role.resource_id.nil? }
+    assignments = user.roles.reject { |user_role| user_role.resource_id.nil? }
     %>
     <tr>
       <td><%= user.email %></td>


### PR DESCRIPTION
Pull requests into Cypress require the following. Submitter and reviewer should :white_check_mark: when done. For items that are not-applicable, note it's not-applicable ("N/A") and :white_check_mark:.

## Summary
This PR speeds up the admin page by eager-loading users’ roles and assigned resources, then reusing that prepared @users list in the view instead of querying MongoDB again for each user.

**Submitter:**
- [ ] This pull request describes why these changes were made.
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Code diff has been done and been reviewed
- [ ] Tests are included and test edge cases
- [ ] Tests have been run locally and pass

**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure where appropriate, and accomplishes the task’s purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code